### PR TITLE
build: fix some minor problems with the building system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ HEADERS :=  $(wildcard $(shell find bitcoin -type f -name '*.h')) compiler.h tar
 SOURCES :=  $(wildcard $(shell find bitcoin -type f -name '*.cpp')) compiler.cpp targets/miniscript_policy.cpp targets/miniscript_string.cpp targets/block_des.cpp
 
 bitcoinfuzz: $(HEADERS) $(SOURCES) fuzzer.cpp
-	g++ -O3 -g0 -Wall -fsanitize=address,fuzzer -DHAVE_GMTIME_R=1 -std=c++20 -march=native -L rust_bitcoin_lib/target/release  -lrust_bitcoin_lib -lpthread -ldl -flto -Ibitcoin $(SOURCES) fuzzer.cpp -o bitcoinfuzz
+	clang++ -O3 -g0 -Wall -fsanitize=address,fuzzer -DHAVE_GMTIME_R=1 -std=c++20 -march=native -L rust_bitcoin_lib/target/release  -lrust_bitcoin_lib -lpthread -ldl -flto -Ibitcoin $(SOURCES) fuzzer.cpp -o bitcoinfuzz

--- a/rust_bitcoin_lib/Cargo.toml
+++ b/rust_bitcoin_lib/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [lib]
 name = "rust_bitcoin_lib"
-crate-type = ["staticlib"]
+crate-type = ["cdylib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This PR addresses a few problems I had while compiling this project on Linux.

There's still an issue I have while running with, e.g.

```bash
FUZZ=block_des LD_LIBRARY_PATH=$PWD/rust_bitcoin_lib/target/release/ valgrind ./bitcoinfuzz
```

`asan` will abort the process with a weird error:

```
Shadow memory range interleaves with an existing memory mapping. ASan cannot proceed correctly. ABORTING.
ASan shadow was supposed to be located in the [0x00007fff7000-0x10007fff7fff] range.
This might be related to ELF_ET_DYN_BASE change in Linux 4.12.
See https://github.com/google/sanitizers/issues/856 for possible workarounds.
```

It seems like a Linux-only issue, so I'm not removing `asan` from the `makefile`. However, for people using Linux, removing `address` from `-fsanitize` seems the only immediate fix. I'm investigating to see if I can fix that too.

Edit: This last one is likely due to my kernel configuration, and not a problem with this code (Bitcoin core gives the same error). 