### PR TITLE
Add instructions for artifacts files produced by libfuzzer to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 bitcoinfuzz
 */target/
+crash-*
+leak-*
+timeout-*


### PR DESCRIPTION
Add entries for artifacts which maybe produced by libfuzzer to gitignore, namely, `crash-<sha1>` , `leak-<sha1>` and `timeout-<sha1>`. 

I have tested it and artifacts produced in the root directory or in any other subdirectory are ignored.

Test commands:
`LD_LIBRARY_PATH=$LD_LIBRARY_PATH:rust_bitcoin_lib/target/release ./bitcoinfuzz`
`LD_LIBRARY_PATH=$LD_LIBRARY_PATH:rust_bitcoin_lib/target/release ./bitcoinfuzz -artifact-prefix=interesting/`
