### PR TITLE
Add PSBT deserialization support in btcd wrapper

### DIFF
--- a/btcd_lib/go.mod
+++ b/btcd_lib/go.mod
@@ -3,9 +3,10 @@ module main
 go 1.21.6
 
 require (
-	github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd // indirect
+	github.com/btcsuite/btcd v0.23.5-0.20231219003633-4c2ce6daed8f // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.1.3 // indirect
 	github.com/btcsuite/btcd/btcutil v1.1.5 // indirect
+	github.com/btcsuite/btcd/btcutil/psbt v1.1.9 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect

--- a/btcd_lib/go.sum
+++ b/btcd_lib/go.sum
@@ -14,6 +14,8 @@ github.com/btcsuite/btcd/btcutil v1.0.0/go.mod h1:Uoxwv0pqYWhD//tfTiipkxNfdhG9Ur
 github.com/btcsuite/btcd/btcutil v1.1.0/go.mod h1:5OapHB7A2hBBWLm48mmw4MOHNJCcUBTwmWH/0Jn8VHE=
 github.com/btcsuite/btcd/btcutil v1.1.5 h1:+wER79R5670vs/ZusMTF1yTcRYE5GUsFbdjdisflzM8=
 github.com/btcsuite/btcd/btcutil v1.1.5/go.mod h1:PSZZ4UitpLBWzxGd5VGOrLnmOjtPP/a6HaFo12zMs00=
+github.com/btcsuite/btcd/btcutil/psbt v1.1.9 h1:UmfOIiWMZcVMOLaN+lxbbLSuoINGS1WmK1TZNI0b4yk=
+github.com/btcsuite/btcd/btcutil/psbt v1.1.9/go.mod h1:ehBEvU91lxSlXtA+zZz3iFYx7Yq9eqnKx4/kSrnsvMY=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 h1:59Kx4K6lzOW5w6nFlA0v5+lk/6sjybR934QNHSJZPTQ=

--- a/btcd_lib/wrapper.go
+++ b/btcd_lib/wrapper.go
@@ -2,11 +2,13 @@ package main
 
 import "C"
 import (
+	"bytes"
 	"unsafe"
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/bech32"
+	"github.com/btcsuite/btcd/btcutil/psbt"
 )
 
 //export go_btcd_des_block
@@ -48,6 +50,17 @@ func go_btcd_bech32(cinput *C.uchar, len C.int) *C.char {
 	}
 
 	return C.CString("")
+}
+
+//export go_btcd_psbt
+func go_btcd_psbt(cinput *C.uchar, len C.int) *C.char {
+	data := C.GoBytes(unsafe.Pointer(cinput), len)
+
+	if _, err := psbt.NewFromRawBytes(bytes.NewReader(data), false); err == nil {
+		return C.CString("1")
+	}
+
+	return C.CString("0")
 }
 
 func main() {

--- a/targets/psbt.cpp
+++ b/targets/psbt.cpp
@@ -9,6 +9,7 @@
 #include "bitcoin/src/node/psbt.h"
 
 extern "C" char* rust_bitcoin_psbt(uint8_t *data, size_t len);
+extern "C" char* go_btcd_psbt(uint8_t *data, size_t len);
 
 bool PSBTCore(Span<const uint8_t> buffer)
 {
@@ -26,8 +27,14 @@ void Psbt(FuzzedDataProvider& provider)
     std::vector<uint8_t> buffer{provider.ConsumeRemainingBytes<uint8_t>()};
     bool core{PSBTCore(buffer)};
     std::string rust_bitcoin{rust_bitcoin_psbt(buffer.data(), buffer.size())};
+    //std::string btcd {go_btcd_psbt(buffer.data(), buffer.size())};
+
     if (rust_bitcoin == "invalid xonly public key" || 
         rust_bitcoin == "bitcoin consensus encoding error") return;
     if (core) assert(rust_bitcoin == "1");
     else assert(rust_bitcoin == "0");
+
+    // BTCD PSBT code is currently unstable - and will crash really fast
+    // if (core) assert(btcd == "1");
+    // else assert(btcd == "0");
 }


### PR DESCRIPTION
Relevant code in `psbt.cpp` is commented out as BTCD's PSBT code is unstable and still a WIP(?).