### PR TITLE
Bump timeout minutes for CI workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -49,7 +49,7 @@ jobs:
           fi
 
       - name: Build
-        timeout-minutes: 20
+        timeout-minutes: 40
         run: |
           if [ "$RUNNER_OS" == "macOS" ]; then
                 export PATH=/usr/local/bin:$PATH


### PR DESCRIPTION
Recently MacOS CI builds have been failing due to reaching the timeout threshold. This bumps the timeout to fix this problem.