### PR TITLE
Listing dependencies on readme file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 all: bitcoinfuzz
 
+CXX := clang++
 CXXFLAGS += -fsanitize=address,fuzzer -Wall -Wextra -std=c++20 -I include -I .
 MODULES := $(wildcard modules/*/module.a)
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,45 @@ Note this project is a WIP and might be not stable.
 
 # Installation
 
+## Dependencies
+
+### llvm toolset (clang and libfuzzer)
+
+* To support the flags used in some modules `-fsanitize=address,fuzzer -std=c++20` the minimum clang version required is 10.0
+
+* For macOS the llvm tools are installed by default, just check that you have the minimum required version 10.0
+
+    * If not installed or lesser than 10.0 just run:
+
+        ```
+        brew install llvm
+        ```
+
+
+* For ubuntu/debian it can be installed using the package manager:
+    ```
+    sudo apt install clang lld llvm-dev
+    ```
+
+* To install it from source check [clang_get_started](https://clang.llvm.org/get_started.html). You must build it with this cmake option: `-DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt"`
+
+
+### boost
+
+To build the bitcoin core module the boost library is required. Minimum version 
+
+The module uses only libboost-filesystem and libboost-system modules. For ubuntu you can install with:
+
+```
+sudo apt install libboost-filesystem-dev libboost-system-dev
+```
+
+Or install the complete boost library with 
+```
+sudo apt install libboost-all-dev
+```
+
+
 ## Bitcoin modules:
 
 ### rust-bitcoin

--- a/modules/bitcoin/Makefile
+++ b/modules/bitcoin/Makefile
@@ -1,5 +1,6 @@
 all: module.a
 
+CXX := clang++
 CXXFLAGS += -Wall -Wextra -std=c++20 \
             -fsanitize=fuzzer,address \
             -I . \

--- a/modules/rustbitcoin/Makefile
+++ b/modules/rustbitcoin/Makefile
@@ -1,5 +1,6 @@
 all: module.a
 
+CXX := clang++
 CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer -std=c++20 -I ../../include
 # MacOS: ./rust_bitcoin_lib/target/aarch64-apple-darwin/release/librust_bitcoin_lib.a
 RUST_LIB_PATH := ./rust_bitcoin_lib/target/release/librust_bitcoin_lib.a

--- a/modules/rustminiscript/Makefile
+++ b/modules/rustminiscript/Makefile
@@ -1,5 +1,6 @@
 all: module.a
 
+CXX := clang++
 CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer -std=c++20 -I ../../include
 # MacOS: ./rust_miniscript_lib/target/aarch64-apple-darwin/release/librust_bitcoin_lib.a
 RUST_MINISCRIPT_LIB_PATH := ./rust_miniscript_lib/target/release/librust_miniscript_lib.a


### PR DESCRIPTION
* Listed the dependencies and installations steps for non-macOS systems. 
* Added clang as default compiler in some modules