### PR TITLE
Add `block_deserialization` to `BTCD`, verifying the block and witness

### DIFF
--- a/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
+++ b/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
@@ -87,6 +87,7 @@ extern "C" {
 
 extern int BTCDEvalScript(ByteArray scriptData, uint32_t flags);
 extern char* BTCDScriptAsm(ByteArray scriptData);
+extern char* BTCDDesBlock(ByteArray scriptData);
 
 #ifdef __cplusplus
 }

--- a/modules/btcd/btcd_wrapper/libscript.h
+++ b/modules/btcd/btcd_wrapper/libscript.h
@@ -87,6 +87,7 @@ extern "C" {
 
 extern int BTCDEvalScript(ByteArray scriptData, uint32_t flags);
 extern char* BTCDScriptAsm(ByteArray scriptData);
+extern char* BTCDDesBlock(ByteArray scriptData);
 
 #ifdef __cplusplus
 }

--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -12,8 +12,11 @@ typedef struct {
 import "C"
 import (
 	"log"
+	"math/big"
 	"unsafe"
 
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 )
@@ -56,6 +59,30 @@ func BTCDScriptAsm(scriptData C.ByteArray) *C.char {
 		return C.CString("")
 	}
 	return C.CString(disasm)
+}
+
+//export BTCDDesBlock
+func BTCDDesBlock(scriptData C.ByteArray) *C.char {
+	buffer := C.GoBytes(unsafe.Pointer(scriptData.data), scriptData.length)
+
+	block, err := btcutil.NewBlockFromBytes(buffer)
+	if err != nil {
+		return C.CString("0")
+	}
+
+	// Easiest possible PoW
+	powLimit := new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)
+	err = blockchain.CheckBlockSanity(block, powLimit, blockchain.NewMedianTime())
+	if err != nil {
+		return C.CString("0")
+	}
+
+	err = blockchain.ValidateWitnessCommitment(block)
+	if err != nil {
+		return C.CString("0")
+	}
+
+	return C.CString("true")
 }
 
 func main() {}

--- a/modules/btcd/module.cpp
+++ b/modules/btcd/module.cpp
@@ -31,5 +31,16 @@ namespace bitcoinfuzz
             return res;
         }
 
+        std::optional<std::vector<bool>> Btcd::deserialize_block(std::span<const uint8_t> buffer) const
+        {
+            ByteArray script_data{
+                .data = reinterpret_cast<char *>(const_cast<uint8_t *>(buffer.data())),
+                .length = static_cast<int>(buffer.size())};
+
+            std::string result{BTCDDesBlock(script_data)};
+            std::vector<bool> final_result{"true" == result};
+            return final_result;
+        }
+
     } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/btcd/module.h
+++ b/modules/btcd/module.h
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <bitcoinfuzz/basemodule.h>
 
-
 namespace bitcoinfuzz
 {
     namespace module
@@ -16,6 +15,7 @@ namespace bitcoinfuzz
             Btcd(void);
             std::optional<bool> script_eval(const std::vector<uint8_t>& input_data, unsigned int flags, size_t version) const override;
             std::optional<std::string> script_asm(std::span<const uint8_t> buffer) const override;
+            std::optional<std::vector<bool>> deserialize_block(std::span<const uint8_t> buffer) const override;
             ~Btcd() noexcept override = default;
         };
 


### PR DESCRIPTION
This PR adds support for `block_deserialization` to `btcd`, aligning it with Bitcoin Core and rust-bitcoin. In addition to block deserialization, this target also verifies the Merkle root and the witness commitment.

Close #78  