### PR TITLE
Add testing for all fuzz targets

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -91,11 +91,48 @@ jobs:
         run: |
           cd modules/nlightning && make
 
-      - name: Build - bitcoinfuzz
+      - name: Test - script
         timeout-minutes: 5
         run: |
           export CXXFLAGS="-DBITCOIN_CORE -DRUST_BITCOIN"
           make
+          FUZZ=script ./bitcoinfuzz -runs=100
 
-      - name: Test
-        run: FUZZ=script ./bitcoinfuzz -runs=100
+      - name: Test - deserialize_block
+        timeout-minutes: 5
+        run: |
+          export CXXFLAGS="-DBITCOIN_CORE -DRUST_BITCOIN -DBTCD"
+          make
+          FUZZ=deserialize_block ./bitcoinfuzz -runs=100
+
+      - name: Test - script_eval
+        timeout-minutes: 5
+        run: |
+          export CXXFLAGS="-DBITCOIN_CORE -DBTCD"
+          make
+          FUZZ=script_eval ./bitcoinfuzz -runs=100
+
+      - name: Test - descriptor_parse
+        timeout-minutes: 5
+        run: |
+          export CXXFLAGS="-DBITCOIN_CORE -DRUST_MINISCRIPT"
+          make
+          FUZZ=descriptor_parse ./bitcoinfuzz -runs=100
+
+      - name: Test - miniscript_parse
+        run: |
+          export CXXFLAGS="-DBITCOIN_CORE -DRUST_MINISCRIPT"
+          make
+          FUZZ=miniscript_parse ./bitcoinfuzz -runs=100
+
+      - name: Test - script_asm
+        run: |
+          export CXXFLAGS="-DBITCOIN_CORE -DBTCD"
+          make
+          FUZZ=script_asm ./bitcoinfuzz -runs=100
+
+      - name: Test - deserialize_invoice
+        run: |
+          export CXXFLAGS="-DLDK -DLND -DNLIGHTNING"
+          make
+          FUZZ=deserialize_invoice ./bitcoinfuzz -runs=100

--- a/driver.cpp
+++ b/driver.cpp
@@ -123,7 +123,7 @@ namespace bitcoinfuzz
         std::span<const uint8_t> buffer{data, size};
         if (target == "script") {
             this->ScriptTarget(buffer);
-        } else if (target == "block_deserialization") {
+        } else if (target == "deserialize_block") {
             this->BlockDeserializationTarget(buffer);
         } else if (target == "script_eval") {
             this->ScriptEvalTarget(buffer);
@@ -133,7 +133,7 @@ namespace bitcoinfuzz
 	        this->MiniscriptParseTarget(buffer);
         } else if (target == "script_asm") {
             this->ScriptAsmTarget(buffer);
-	    } else if (target == "invoice_deserialization") {
+	    } else if (target == "deserialize_invoice") {
             this->InvoiceDeserializationTarget(buffer);
         }else {
             std::cout << "Target not defined!" << std::endl;


### PR DESCRIPTION
## Summary
This PR improves our CI process by testing all available fuzz targets and standardizes our target naming convention.

## Changes
- Rename fuzzing targets in driver.cpp for consistency:
  - `block_deserialization` → `deserialize_block`
  - `invoice_deserialization` → `deserialize_invoice`
- Expand GitHub Actions workflow to test all fuzz targets with their appropriate compiler flags:
  - script (existing)
  - deserialize_block
  - script_eval
  - descriptor_parse
  - miniscript_parse
  - script_asm
  - deserialize_invoice

## Testing
All tests pass in the GitHub Actions workflow with 100 runs per target.

## Related Issues
Related to #93 and #90

This PR contributes to the discussion in issues #93 and #90 about building bitcoinfuzz with all modules. I believe building bitcoinfuzz with only the necessary modules for each specific target is a reasonable approach, as users typically run one target at a time and don't need all modules compiled together.

This targeted compilation approach allows us to test all fuzz targets in CI while avoiding module compatibility issues.