### PR TITLE
Add memory management for C-style strings in btcd wrapper

### DIFF
--- a/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
+++ b/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
@@ -88,6 +88,7 @@ extern "C" {
 extern int BTCDEvalScript(ByteArray scriptData, uint32_t flags);
 extern char* BTCDScriptAsm(ByteArray scriptData);
 extern char* BTCDDesBlock(ByteArray scriptData);
+extern void BTCDFreeString(char* ptr);
 
 #ifdef __cplusplus
 }

--- a/modules/btcd/btcd_wrapper/libscript.h
+++ b/modules/btcd/btcd_wrapper/libscript.h
@@ -88,6 +88,7 @@ extern "C" {
 extern int BTCDEvalScript(ByteArray scriptData, uint32_t flags);
 extern char* BTCDScriptAsm(ByteArray scriptData);
 extern char* BTCDDesBlock(ByteArray scriptData);
+extern void BTCDFreeString(char* ptr);
 
 #ifdef __cplusplus
 }

--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -85,4 +85,9 @@ func BTCDDesBlock(scriptData C.ByteArray) *C.char {
 	return C.CString("true")
 }
 
+//export BTCDFreeString
+func BTCDFreeString(ptr *C.char) {
+	C.free(unsafe.Pointer(ptr))
+}
+
 func main() {}

--- a/modules/btcd/module.cpp
+++ b/modules/btcd/module.cpp
@@ -37,7 +37,9 @@ namespace bitcoinfuzz
                 .data = reinterpret_cast<char *>(const_cast<uint8_t *>(buffer.data())),
                 .length = static_cast<int>(buffer.size())};
 
-            std::string result{BTCDDesBlock(script_data)};
+            auto pointer{BTCDDesBlock(script_data)};
+            std::string result(pointer);
+            BTCDFreeString(pointer);
             std::vector<bool> final_result{"true" == result};
             return final_result;
         }

--- a/modules/rustbitcoin/module.cpp
+++ b/modules/rustbitcoin/module.cpp
@@ -19,7 +19,9 @@ namespace bitcoinfuzz
 
         std::optional<std::vector<bool>> Rustbitcoin::deserialize_block(std::span<const uint8_t> buffer) const
         {
-            std::string result{rust_bitcoin_des_block(buffer.data(), buffer.size())};
+            auto pointer{rust_bitcoin_des_block(buffer.data(), buffer.size())};
+            std::string result(pointer);
+            free_c_string(pointer);
             if (result == "unsupported segwit version") {
                 return std::nullopt;
             }


### PR DESCRIPTION
- Add BTCDFreeString function in libbtcd_wrapper.h and libscript.h
- Implement BTCDFreeString in wrapper.go to free allocated C strings
- Update module.cpp to properly free dynamically allocated strings
  - In btcd module, use BTCDFreeString to free returned pointer
  - In rust-bitcoin module, use free_c_string to free returned pointer
- Ensures proper memory cleanup for dynamically allocated strings


Should fix this memory leak https://github.com/brunoerg/bitcoinfuzz/actions/runs/13900938502/job/38892257110#step:17:15