### PR TITLE
Fix macOS build issues by explicitly detecting OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ all: bitcoinfuzz
 CXX := clang++
 CXXFLAGS += -fsanitize=address,fuzzer -Wall -Wextra -std=c++20 -I include -I .
 MODULES := $(wildcard modules/*/module.a)
+UNAME_S := $(shell uname -s)
 
-ifeq ($(UNAME_S), Darwin)
+ifeq ($(UNAME_S),Darwin)
 LDFLAGS = -framework CoreFoundation -Wl,-ld_classic
 endif
 


### PR DESCRIPTION
The Makefile was previously relying on the UNAME_S environment variable to detect macOS systems, but this variable isn't automatically set in all environments. This caused linking errors on macOS when the Darwin-specific flags weren't applied.

**Changes:**

- Added explicit OS detection using shell uname -s command
- Set UNAME_S variable at the beginning of the Makefile

Should fix: #102