### PR TITLE
add Embit module for Miniscript parsing

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,6 +31,14 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
+      
+      - name: Setup Python and install embit
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: |
+          python -m pip install --upgrade pip
+          pip install -r modules/embit/embit_lib/requirements.txt
 
       - name: Install LLVM and Clang
         run: |
@@ -74,6 +82,11 @@ jobs:
         timeout-minutes: 5
         run: |
           cd modules/btcd && make
+      
+      - name: Build - embit
+        timeout-minutes: 5
+        run: |
+          cd modules/embit && make
       
       - name: Build - lnd
         timeout-minutes: 5
@@ -121,7 +134,7 @@ jobs:
 
       - name: Test - miniscript_parse
         run: |
-          export CXXFLAGS="-DBITCOIN_CORE -DRUST_MINISCRIPT"
+          export CXXFLAGS="-DBITCOIN_CORE -DRUST_MINISCRIPT -DEMBIT"
           make
           FUZZ=miniscript_parse ./bitcoinfuzz -runs=100
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ bin/
 obj/
 *.dylib
 *.so
+__pycache__
+main.py
+corpus/

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,15 @@ CXXFLAGS += -fsanitize=address,fuzzer -Wall -Wextra -std=c++20 -I include -I .
 MODULES := $(wildcard modules/*/module.a)
 UNAME_S := $(shell uname -s)
 
-ifeq ($(UNAME_S),Darwin)
+# Get Python linking flags if the embit module is being used (DEMBIT is defined)
+PYTHON_LDFLAGS = $(shell if echo "$(CXXFLAGS)" | grep -q "\-DEMBIT"; then python3-config --ldflags --embed; fi)
+
+ifeq ($(UNAME_S), Darwin)
 LDFLAGS = -framework CoreFoundation -Wl,-ld_classic
 endif
 
 bitcoinfuzz: main.cpp driver.o include/bitcoinfuzz/basemodule.o
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp $(MODULES) driver.o include/bitcoinfuzz/basemodule.o -o bitcoinfuzz
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp $(MODULES) driver.o include/bitcoinfuzz/basemodule.o -o bitcoinfuzz $(PYTHON_LDFLAGS)
 
 driver.o: driver.cpp driver.h
 	$(CXX) $(CXXFLAGS) -c driver.cpp -o driver.o

--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ make
 export CXXFLAGS="$CXXFLAGS -DBTCD"
 ```
 
+### embit
+
+To run the fuzzer with `embit` module, you need to install the `embit` library.
+
+To install the `embit` library, you can use the following command:
+```bash
+cd modules/embit
+pip install -r embit_lib/requirements.txt
+```
+
+```bash
+cd modules/embit
+make
+export CXXFLAGS="$CXXFLAGS -DEMBIT"
+```
+
 ### Bitcoin Core
 
 ```bash

--- a/main.cpp
+++ b/main.cpp
@@ -34,6 +34,10 @@
 #include <modules/nlightning/module.h>
 #endif
 
+#ifdef EMBIT
+#include <modules/embit/module.h>
+#endif
+
 std::shared_ptr<bitcoinfuzz::Driver> driver = nullptr;
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
@@ -63,6 +67,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 #endif
 #ifdef NLIGHTNING
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::NLightning>());
+#endif
+#ifdef EMBIT
+  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Embit>());
 #endif
 
   driver->Run(Data, Size, target);

--- a/modules/embit/Makefile
+++ b/modules/embit/Makefile
@@ -1,0 +1,23 @@
+all: module.a
+
+CXX=clang
+CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer -std=c++20 -I ../../include
+PYTHON_CFLAGS := $(shell python3-config --includes)
+
+# Build the static library for the module
+module.a: module.o embit_lib/embit_lib.o
+	$(AR) rcs $@ $^
+	ranlib $@
+	cp embit_lib/embit_lib.py ../../main.py
+
+# Compile the module
+module.o: module.cpp module.h
+	$(CXX) $(CXXFLAGS) -I . -fPIC -c $< -o $@
+
+# Compile the Python lib
+embit_lib/embit_lib.o: embit_lib/embit_lib.cpp
+	$(CXX) $(CXXFLAGS) $(PYTHON_CFLAGS) -fPIC -c $< -o $@
+
+# Clean up
+clean:
+	rm -rf *.o *.a ./embit_lib/embit_lib.o

--- a/modules/embit/embit_lib/embit_lib.cpp
+++ b/modules/embit/embit_lib/embit_lib.cpp
@@ -1,0 +1,75 @@
+#include <Python.h>
+#include <string>
+#include <iostream>
+#include <cstring>
+
+extern "C" bool embit_miniscript_miniscript_parse(const char* input) {
+    if (!Py_IsInitialized()) {
+        Py_Initialize();
+        
+        PyRun_SimpleString("import sys; sys.path.append('.')");
+    }
+    
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+    
+    bool success = false;
+    PyObject* main_module = NULL;
+    PyObject* miniscript_parse_func = NULL;
+    PyObject* args = NULL;
+    PyObject* result = NULL;
+    PyObject* input_str = NULL;
+    
+    // Import the main Python module containing miniscript_parse
+    main_module = PyImport_ImportModule("main");
+    if (!main_module) {
+        goto cleanup;
+    }
+    
+    // Get the miniscript_parse function from the module
+    miniscript_parse_func = PyObject_GetAttrString(main_module, "miniscript_parse");
+    if (!miniscript_parse_func || !PyCallable_Check(miniscript_parse_func)) {
+        goto cleanup;
+    }
+    
+    // Create a Python string from the input
+    input_str = PyUnicode_FromString(input);
+    if (!input_str) {
+        goto cleanup;
+    }
+    
+    // Create arguments for the function call
+    args = PyTuple_New(1);
+    if (!args) {
+        goto cleanup;
+    }
+    
+    // Add the input string to the tuple
+    // PyTuple_SetItem steals a reference, so we don't need to decref input_str after
+    if (PyTuple_SetItem(args, 0, input_str) < 0) {
+        goto cleanup;
+    }
+    input_str = NULL;  // Ownership transferred to args
+    
+    // Call the Python function
+    result = PyObject_CallObject(miniscript_parse_func, args);
+    if (!result) {
+        goto cleanup;
+    }
+    
+    // Convert Python boolean result to C++ bool
+    if (PyBool_Check(result)) {
+        success = (result == Py_True);
+    }
+    
+cleanup:
+    Py_XDECREF(result);
+    Py_XDECREF(args);
+    Py_XDECREF(miniscript_parse_func);
+    Py_XDECREF(main_module);
+    Py_XDECREF(input_str);
+    
+    PyGILState_Release(gstate);
+    
+    return success;
+}

--- a/modules/embit/embit_lib/embit_lib.h
+++ b/modules/embit/embit_lib/embit_lib.h
@@ -1,0 +1,3 @@
+#include <cstdint>
+
+extern "C" bool embit_miniscript_miniscript_parse(const char* input);

--- a/modules/embit/embit_lib/embit_lib.py
+++ b/modules/embit/embit_lib/embit_lib.py
@@ -1,0 +1,16 @@
+
+from io import BytesIO
+from embit.descriptor.miniscript import Miniscript
+
+def miniscript_parse(input):
+    try:
+        ms = Miniscript.read_from(BytesIO(input.encode()), taproot=False)
+        ms.verify()
+        return True
+    except Exception as _:
+        try:
+            ms = Miniscript.read_from(BytesIO(input.encode()), taproot=True)
+            ms.verify()
+            return True
+        except Exception as _:
+            return False

--- a/modules/embit/embit_lib/requirements.txt
+++ b/modules/embit/embit_lib/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/diybitcoinhardware/embit.git@master

--- a/modules/embit/module.cpp
+++ b/modules/embit/module.cpp
@@ -1,0 +1,20 @@
+#include <span>
+
+#include "module.h"
+
+extern "C" bool embit_miniscript_miniscript_parse(const char* input);
+
+namespace bitcoinfuzz
+{
+    namespace module
+    {
+        Embit::Embit(void) : BaseModule("Embit") {}
+
+        std::optional<bool> Embit::miniscript_parse(std::string str) const
+        {
+            bool result = embit_miniscript_miniscript_parse(str.c_str());
+            return result;
+        }
+
+    }
+}

--- a/modules/embit/module.h
+++ b/modules/embit/module.h
@@ -1,0 +1,21 @@
+#include <optional>
+#include <span>
+#include <vector>
+#include <cstddef>
+#include <cstdint>
+#include <bitcoinfuzz/basemodule.h>
+
+namespace bitcoinfuzz
+{
+    namespace module
+    {
+        class Embit : public BaseModule
+        {
+        public:
+            Embit(void);
+            std::optional<bool> miniscript_parse(std::string str) const override;
+            ~Embit() noexcept override = default;
+        };
+
+    }
+}


### PR DESCRIPTION
Add support for Embit, a Python-based Bitcoin library, as a new module to BitcoinFuzz:

- Create Embit module structure with Makefile and necessary files
- Implement Python bindings to call Embit's Miniscript parser
- Add integration with main driver and update build system for Python integration
- Update .gitignore to exclude Python cache files and main.py
- Update workflow to build and run Embit module

The module uses Python C API to bridge between C++ and the Embit Python library for parsing Miniscript expressions in both taproot and non-taproot contexts.

add embit on miniscript_parse