### PR TITLE
add missing CXX variable in Makefiles

### DIFF
--- a/modules/ldk/Makefile
+++ b/modules/ldk/Makefile
@@ -1,5 +1,6 @@
 all: module.a
 
+CXX = clang++
 CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer -std=c++20 -I ../../include
 LDK_LIB_PATH := ./ldk_lib/target/release/libldk_lib.a
 

--- a/modules/mako/Makefile
+++ b/modules/mako/Makefile
@@ -1,5 +1,6 @@
 all: module.a
 
+CXX = clang++
 CXXFLAGS += -Wall -Wextra -std=c++20 -I ../../include
 # MAKO_LIB_PATH:= /Users/user/projects/mako/build/libmako.a
 


### PR DESCRIPTION
While trying to build the project my default C++ compiler was set to g++. Due to missing CXX flags in the following files, I faced some issues. This PR adds the missing CXX flags in the files. 