### PR TITLE
[feature enhancement] added address parsing fuzzing target 

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -136,3 +136,9 @@ jobs:
           export CXXFLAGS="-DLDK -DLND -DNLIGHTNING"
           make
           FUZZ=deserialize_invoice ./bitcoinfuzz -runs=100
+      
+      - name: Test - address_parse
+        run: |
+          export CXXFLAGS="-DBITCOIN_CORE -DRUST_BITCOIN"
+          make
+          FUZZ=address_parse ./bitcoinfuzz -runs=100

--- a/driver.cpp
+++ b/driver.cpp
@@ -118,6 +118,36 @@ namespace bitcoinfuzz
         }
     }
 
+    void Driver::AddressParseTarget(std::span<const uint8_t> buffer) const
+    {
+        FuzzedDataProvider provider(buffer.data(), buffer.size());
+        std::string address{provider.ConsumeRemainingBytesAsString()};
+
+        std::optional<std::string> last_response{std::nullopt};
+        std::string last_module_name;
+
+        for(auto module: modules)
+        {
+            std::optional<std::string> res{module.second->address_parse(address)};
+            if(!res.has_value()) continue;
+
+            if(last_response.has_value()) 
+            {
+                if(*res != *last_response)
+                {
+                    std::cout << "Input address: " << address << "\n";
+                    std::cout << "MISMATCH DETECTED between " << last_module_name << " and " << module.first << "!" << "\n";
+                    std::cout << "  " << last_module_name << ": " << *last_response << "\n";
+                    std::cout << "  " << module.first << ": " << *res << "\n";
+                }
+
+                assert(*res == *last_response);
+            }
+            last_response = *res;
+            last_module_name = module.first;
+        }
+    }
+
     void Driver::Run(const uint8_t *data, const size_t size, const std::string &target) const
     {
         std::span<const uint8_t> buffer{data, size};
@@ -135,7 +165,9 @@ namespace bitcoinfuzz
             this->ScriptAsmTarget(buffer);
 	    } else if (target == "deserialize_invoice") {
             this->InvoiceDeserializationTarget(buffer);
-        }else {
+        } else if (target == "address_parse") {
+            this->AddressParseTarget(buffer);
+        } else {
             std::cout << "Target not defined!" << std::endl;
             assert(false);
         }

--- a/driver.h
+++ b/driver.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <map>
 #include <vector>
+#include <span>
 #include <utility>
 
 #include <bitcoinfuzz/basemodule.h>
@@ -26,5 +27,6 @@ namespace bitcoinfuzz
         void ScriptAsmTarget(std::span<const uint8_t> buffer) const;
         void InvoiceDeserializationTarget(std::span<const uint8_t> buffer) const;
         void Run(const uint8_t *data, const size_t size, const std::string& target) const;
+        void AddressParseTarget(std::span<const uint8_t> buffer) const;
     };
 }

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -42,4 +42,9 @@ namespace bitcoinfuzz
     {
         return std::nullopt;
     }
+
+    std::optional<std::string> BaseModule::address_parse(std::string str) const
+    {
+        return std::nullopt;
+    }
 }

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -24,7 +24,8 @@ namespace bitcoinfuzz
         virtual std::optional<bool> miniscript_parse(std::string str) const;
         virtual std::optional<std::string> script_asm(std::span<const uint8_t> buffer) const;
         virtual std::optional<bool> deserialize_invoice(std::string str) const;
-
+        virtual std::optional<std::string> address_parse(std::string str) const;
+        
         virtual ~BaseModule() noexcept;
     };
 }

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -13,6 +13,7 @@
 #include "util/chaintype.h"
 #include "validation.h"
 #include "core_io.h"
+#include "key_io.h"
 
 namespace {
 class FuzzedSignatureChecker : public BaseSignatureChecker
@@ -295,6 +296,41 @@ std::optional<std::string> Bitcoin::script_asm(std::span<const uint8_t> buffer) 
     auto asm_str = ScriptToAsmStr(script);
     if (asm_str.find("[error]") != std::string::npos) return std::nullopt;
     return asm_str;
+}
+
+std::optional<std::string> Bitcoin::address_parse(std::string str) const
+{
+    static bool initialized = false;
+    if (!initialized) 
+    {
+        SelectParams(ChainType::MAIN);
+        initialized = true;
+    }
+    try {
+        CTxDestination dest = DecodeDestination(str);
+        if (IsValidDestination(dest)) {
+            std::string result;
+
+            if (std::holds_alternative<PKHash>(dest)) {
+                result = "PKH:";
+            } else if (std::holds_alternative<ScriptHash>(dest)) {
+                result = "SH:";
+            } else if (std::holds_alternative<WitnessV0KeyHash>(dest)) {
+                result = "WPKH:";
+            } else if (std::holds_alternative<WitnessV0ScriptHash>(dest)) {
+                result = "WSH:";
+            } else if (std::holds_alternative<WitnessV1Taproot>(dest)) {
+                result = "TR:";
+            } else {
+                result = "UNK:";
+            }
+
+            return result + EncodeDestination(dest);
+        }
+        return "INVALID";
+    } catch (const std::exception&) {
+        return "INVALID";
+    }
 }
 
 } // namespace module

--- a/modules/bitcoin/module.h
+++ b/modules/bitcoin/module.h
@@ -20,6 +20,7 @@ namespace bitcoinfuzz
             std::optional<bool> descriptor_parse(std::string str) const override;
             std::optional<bool> miniscript_parse(std::string str) const override;
             std::optional<std::string> script_asm(std::span<const uint8_t> buffer) const override;
+            std::optional<std::string> address_parse(std::string str) const override;
             ~Bitcoin() noexcept override = default;
         };
 

--- a/modules/rustbitcoin/module.cpp
+++ b/modules/rustbitcoin/module.cpp
@@ -28,5 +28,15 @@ namespace bitcoinfuzz
             std::vector<bool> final_result{"true" == result};
             return final_result;
         }
+
+        std::optional<std::string> Rustbitcoin::address_parse(std::string str) const
+        {
+            auto result_ptr = rust_bitcoin_address_parse(str.c_str());
+            if (result_ptr == nullptr) return std::nullopt;
+
+            std::string result(result_ptr);
+            free_c_string(result_ptr);
+            return result;
+        }
     }
 }

--- a/modules/rustbitcoin/module.h
+++ b/modules/rustbitcoin/module.h
@@ -1,5 +1,6 @@
 #include <optional>
 #include <span>
+#include <string>
 #include <vector>
 #include <cstddef>
 #include <cstdint>
@@ -15,6 +16,7 @@ namespace bitcoinfuzz
             Rustbitcoin(void);
             std::optional<std::string> script_parse(std::span<const uint8_t> buffer) const override;
             std::optional<std::vector<bool>> deserialize_block(std::span<const uint8_t> buffer) const override;
+            std::optional<std::string> address_parse(std::string str) const override;
             ~Rustbitcoin() noexcept override = default;
         };
 

--- a/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
+++ b/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
@@ -3,4 +3,5 @@
 extern "C" char* rust_bitcoin_script(const uint8_t *data, size_t len);
 extern "C" char* rust_bitcoin_des_block(const uint8_t *data, size_t len);
 extern "C" char* rust_bitcoin_script_asm(const char* input);
+extern "C" char* rust_bitcoin_address_parse(const char* address);
 extern "C" void free_c_string(char* ptr);

--- a/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
+++ b/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
@@ -1,10 +1,10 @@
-use std::collections::HashMap;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::slice;
-use std::str::Utf8Error;
+use std::str::{Utf8Error, FromStr};
 
+use bitcoin::address::Address;
 use bitcoin::consensus::{deserialize_partial, encode};
 use bitcoin::Block;
 
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn free_c_string(ptr: *mut c_char) {
 pub unsafe extern "C" fn rust_bitcoin_des_block(
     data: *const u8,
     len: usize,
-    out_len: *mut usize,
+    _out_len: *mut usize,
 ) -> *mut c_char {
     let data_slice = std::slice::from_raw_parts(data, len);
     let res = deserialize_partial::<Block>(data_slice);
@@ -67,6 +67,41 @@ pub unsafe extern "C" fn rust_bitcoin_script(data: *const u8, len: usize) -> *mu
             final_res.push_str(if s.0.is_push_only() { "1" } else { "0" });
             str_to_c_string(&final_res)
         }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_bitcoin_address_parse(address: *const c_char) -> *mut c_char {
+    if address.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    let address_str = match c_str_to_str(address) {
+        Ok(s) => s,
+        Err(_) => return str_to_c_string("INVALID"),
+    };
+
+    match Address::from_str(address_str) {
+        Ok(addr_unchecked) => {
+            match addr_unchecked.require_network(bitcoin::Network::Bitcoin) {
+                Ok(addr) => {
+                    let prefix = match addr.address_type() {
+                        Some(bitcoin::address::AddressType::P2pkh) => "PKH:",
+                        Some(bitcoin::address::AddressType::P2sh) => "SH:",
+                        Some(bitcoin::address::AddressType::P2wpkh) => "WPKH:",
+                        Some(bitcoin::address::AddressType::P2wsh) => "WSH:",
+                        Some(bitcoin::address::AddressType::P2tr) => "TR:",
+                        Some(_) => "UNK:",
+                        None => "UNK:",
+                    };
+
+                    let result = format!("{}{:}", prefix, addr);
+                    str_to_c_string(&result)
+                },
+                Err(_) => str_to_c_string("INVALID"),
+            }
+        },
+        Err(_) => str_to_c_string("INVALID"),
     }
 }
 


### PR DESCRIPTION
## Feature Added
Adds a new fuzzing target that compares how different Bitcoin implementations handle address parsing, with special attention to newer formats like Taproot addresses.

## Changes Made
- Added `address_parse` method to base module
- Implemented address parsing for `Bitcoin Core` and `rust-bitcoin` modules only
- Added the `AddressParseTarget` method to the driver class
- Updated the Driver::Run method to include the new target

## Implementation Details
- The target compares how different implementations categorize and normalize Bitcoin addresses
- Address types tested include:
    - legacy addresse (p2pkh)
    - p2sh
    -  segwit (p2wpkh, p2wsh)
    - taproot (p2tr)
   
## Issues related to it
- It works perfectly fine if doing: `ASAN_OPTIONS=detect_container_overflow=0 FUZZ=address_parse ./bitcoinfuzz` or `FUZZ=address_parse ./bitcoinfuzz -runs=100`
- When running with the dictionary file (`FUZZ=address_parse ./bitcoinfuzz -dict=address.dict -max_total_time=1800 corpus/address_parse`), the fuzzer encounters container overflow error [Not able to figure out why?]
- While running the fuzzer using this `FUZZ=address_parse ./bitcoinfuzz -max_total_time=1800 corpus/address_parse ` it runs for the time it encounters container overflow error
```
~/Desktop/ws/bitcoinfuzz addr_parsing* 30m 1s
❯ FUZZ=address_parse ./bitcoinfuzz -max_total_time=1800 corpus/address_parse
bitcoinfuzz(84263,0x1f1924240) malloc: nano zone abandoned due to inability to reserve vm space.
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 696920424
INFO: Loaded 1 modules   (59462 inline 8-bit counters): 59462 [0x104eb4000, 0x104ec2846),
INFO: Loaded 1 PC tables (59462 PCs): 59462 [0x104ec2848,0x104faaca8),
INFO:      570 files found in corpus/address_parse
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: seed corpus: files: 570 min: 1b max: 346b total: 26341b rss: 56Mb
#571    INITED cov: 1505 ft: 3451 corp: 355/18Kb exec/s: 0 rss: 64Mb
#1187   REDUCE cov: 1505 ft: 3451 corp: 355/18Kb lim: 354 exec/s: 0 rss: 66Mb L: 4/346 MS: 1 EraseBytes-
#26915  REDUCE cov: 1505 ft: 3451 corp: 355/18Kb lim: 604 exec/s: 26915 rss: 131Mb L: 26/346 MS: 3 ChangeByte-InsertByte-EraseBytes-
#28266  REDUCE cov: 1505 ft: 3451 corp: 355/18Kb lim: 613 exec/s: 28266 rss: 134Mb L: 40/346 MS: 1 EraseBytes-
#43799  REDUCE cov: 1505 ft: 3451 corp: 355/18Kb lim: 766 exec/s: 43799 rss: 168Mb L: 39/346 MS: 3 CopyPart-ChangeByte-EraseBytes-
#46887  REDUCE cov: 1505 ft: 3451 corp: 355/18Kb lim: 793 exec/s: 23443 rss: 175Mb L: 20/346 MS: 3 ChangeBit-ChangeASCIIInt-EraseBytes-
=================================================================
==84263==ERROR: AddressSanitizer: container-overflow on address 0x6080002832e8 at pc 0x000105ddf2d4 bp 0x00016bb02610 sp 0x00016bb01dc0
READ of size 96 at 0x6080002832e8 thread T0
    #0 0x000105ddf2d0 in __asan_memcpy+0x3d4 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x4f2d0)
    #1 0x00010430d7f0 in void std::__1::__uninitialized_allocator_relocate[abi:ne190103]<std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>, std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>(std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>&, std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>*, std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>*, std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>*)+0x4c (bitcoinfuzz:arm64+0x1000117f0)
    #2 0x00010430cb64 in std::__1::vector<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>, std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>>::__swap_out_circular_buffer(std::__1::__split_buffer<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>, std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>&>&)+0x198 (bitcoinfuzz:arm64+0x100010b64)
    #3 0x000104674130 in std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>* std::__1::vector<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>, std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>>::__push_back_slow_path<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>> const&>(std::__1::vector<unsigned char, std::__1::allocator<unsigned char>> const&)+0x200 (bitcoinfuzz:arm64+0x100378130)
    #4 0x0001049f76f8 in fuzzer::ReadDirToVectorOfUnits(char const*, std::__1::vector<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>, std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>>*, long*, unsigned long, bool, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>*) FuzzerIO.cpp:116
    #5 0x0001049fa4f4 in fuzzer::Fuzzer::RereadOutputCorpus(unsigned long) FuzzerLoop.cpp:420
    #6 0x0001049fcbbc in fuzzer::Fuzzer::Loop(std::__1::vector<fuzzer::SizedFile, std::__1::allocator<fuzzer::SizedFile>>&) FuzzerLoop.cpp:883
    #7 0x0001049ec8e0 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) FuzzerDriver.cpp:915
    #8 0x000104a17354 in main FuzzerMain.cpp:20
    #9 0x000187cc4270  (<unknown module>)

0x608000283300 is located 0 bytes after 96-byte region [0x6080002832a0,0x608000283300)
allocated by thread T0 here:
    #0 0x000105df12c4 in _Znwm+0x6c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x612c4)
    #1 0x0001042ff830 in void* std::__1::__libcpp_operator_new[abi:ne190103]<unsigned long>(unsigned long)+0x24 (bitcoinfuzz:arm64+0x100003830)
    #2 0x0001042ff730 in std::__1::__libcpp_allocate[abi:ne190103](unsigned long, unsigned long)+0x7c (bitcoinfuzz:arm64+0x100003730)
    #3 0x00010430d5c4 in std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>::allocate[abi:ne190103](unsigned long)+0x98 (bitcoinfuzz:arm64+0x1000115c4)
    #4 0x00010430d35c in std::__1::__allocation_result<std::__1::allocator_traits<std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>>::pointer> std::__1::__allocate_at_least[abi:ne190103]<std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>>(std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>&, unsigned long)+0x2c (bitcoinfuzz:arm64+0x10001135c)
    #5 0x00010430d0dc in std::__1::__split_buffer<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>, std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>&)+0x208 (bitcoinfuzz:arm64+0x1000110dc)
    #6 0x00010430c9b8 in std::__1::__split_buffer<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>, std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>&>::__split_buffer(unsigned long, unsigned long, std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>&)+0x40 (bitcoinfuzz:arm64+0x1000109b8)
    #7 0x0001046740dc in std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>* std::__1::vector<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>, std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>>::__push_back_slow_path<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>> const&>(std::__1::vector<unsigned char, std::__1::allocator<unsigned char>> const&)+0x1ac (bitcoinfuzz:arm64+0x1003780dc)
    #8 0x0001049f76f8 in fuzzer::ReadDirToVectorOfUnits(char const*, std::__1::vector<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>, std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>>*, long*, unsigned long, bool, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>*) FuzzerIO.cpp:116
    #9 0x0001049fa4f4 in fuzzer::Fuzzer::RereadOutputCorpus(unsigned long) FuzzerLoop.cpp:420
    #10 0x0001049fcbbc in fuzzer::Fuzzer::Loop(std::__1::vector<fuzzer::SizedFile, std::__1::allocator<fuzzer::SizedFile>>&) FuzzerLoop.cpp:883
    #11 0x0001049ec8e0 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) FuzzerDriver.cpp:915
    #12 0x000104a17354 in main FuzzerMain.cpp:20
    #13 0x000187cc4270  (<unknown module>)

HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_container_overflow=0.
If you suspect a false positive see also: https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow.
SUMMARY: AddressSanitizer: container-overflow (bitcoinfuzz:arm64+0x1000117f0) in void std::__1::__uninitialized_allocator_relocate[abi:ne190103]<std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>, std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>(std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>>&, std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>*, std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>*, std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>*)+0x4c
Shadow bytes around the buggy address:
  0x608000283000: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
  0x608000283080: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fa
  0x608000283100: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fa
  0x608000283180: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
  0x608000283200: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
=>0x608000283280: fa fa fa fa 00 00 00 00 00 00 00 00 00[fc]fc fc
  0x608000283300: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x608000283380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x608000283400: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x608000283480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x608000283500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==84263==ABORTING
MS: 5 CrossOver-ChangeBit-ChangeBinInt-CopyPart-InsertByte-; base unit: aa9575438d1e586966227da0c0251a9a7bcc3850


artifact_prefix='./'; Test unit written to ./crash-da39a3ee5e6b4b0d3255bfef95601890afd80709
Base64:
zsh: abort      FUZZ=address_parse ./bitcoinfuzz -max_total_time=1800 corpus/address_parse

```