### PR TITLE
add embit descriptor parsing support and fix embit miniscript_parse

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Test - descriptor_parse
         timeout-minutes: 5
         run: |
-          export CXXFLAGS="-DBITCOIN_CORE -DRUST_MINISCRIPT"
+          export CXXFLAGS="-DBITCOIN_CORE -DRUST_MINISCRIPT -DEMBIT"
           make
           FUZZ=descriptor_parse ./bitcoinfuzz -runs=100
 

--- a/modules/embit/embit_lib/embit_lib.cpp
+++ b/modules/embit/embit_lib/embit_lib.cpp
@@ -3,10 +3,9 @@
 #include <iostream>
 #include <cstring>
 
-extern "C" bool embit_miniscript_miniscript_parse(const char* input) {
+static bool call_python_parser(const char* input, const char* function_name) {
     if (!Py_IsInitialized()) {
         Py_Initialize();
-        
         PyRun_SimpleString("import sys; sys.path.append('.')");
     }
     
@@ -15,20 +14,20 @@ extern "C" bool embit_miniscript_miniscript_parse(const char* input) {
     
     bool success = false;
     PyObject* main_module = NULL;
-    PyObject* miniscript_parse_func = NULL;
+    PyObject* parse_func = NULL;
     PyObject* args = NULL;
     PyObject* result = NULL;
     PyObject* input_str = NULL;
     
-    // Import the main Python module containing miniscript_parse
+    // Import the main Python module containing the parser function
     main_module = PyImport_ImportModule("main");
     if (!main_module) {
         goto cleanup;
     }
     
-    // Get the miniscript_parse function from the module
-    miniscript_parse_func = PyObject_GetAttrString(main_module, "miniscript_parse");
-    if (!miniscript_parse_func || !PyCallable_Check(miniscript_parse_func)) {
+    // Get the parser function from the module
+    parse_func = PyObject_GetAttrString(main_module, function_name);
+    if (!parse_func || !PyCallable_Check(parse_func)) {
         goto cleanup;
     }
     
@@ -45,14 +44,13 @@ extern "C" bool embit_miniscript_miniscript_parse(const char* input) {
     }
     
     // Add the input string to the tuple
-    // PyTuple_SetItem steals a reference, so we don't need to decref input_str after
     if (PyTuple_SetItem(args, 0, input_str) < 0) {
         goto cleanup;
     }
     input_str = NULL;  // Ownership transferred to args
     
     // Call the Python function
-    result = PyObject_CallObject(miniscript_parse_func, args);
+    result = PyObject_CallObject(parse_func, args);
     if (!result) {
         goto cleanup;
     }
@@ -65,11 +63,19 @@ extern "C" bool embit_miniscript_miniscript_parse(const char* input) {
 cleanup:
     Py_XDECREF(result);
     Py_XDECREF(args);
-    Py_XDECREF(miniscript_parse_func);
+    Py_XDECREF(parse_func);
     Py_XDECREF(main_module);
     Py_XDECREF(input_str);
     
     PyGILState_Release(gstate);
     
     return success;
+}
+
+extern "C" bool embit_miniscript_miniscript_parse(const char* input) {
+    return call_python_parser(input, "miniscript_parse");
+}
+
+extern "C" bool embit_descriptor_parse(const char* input) {
+    return call_python_parser(input, "descriptor_parse");
 }

--- a/modules/embit/embit_lib/embit_lib.h
+++ b/modules/embit/embit_lib/embit_lib.h
@@ -1,3 +1,5 @@
 #include <cstdint>
 
 extern "C" bool embit_miniscript_miniscript_parse(const char* input);
+
+extern "C" bool embit_miniscript_descriptor_parse(const char* input);

--- a/modules/embit/embit_lib/embit_lib.py
+++ b/modules/embit/embit_lib/embit_lib.py
@@ -1,15 +1,14 @@
-
 from io import BytesIO
 from embit.descriptor.miniscript import Miniscript
 
 def miniscript_parse(input):
     try:
-        ms = Miniscript.read_from(BytesIO(input.encode()), taproot=False)
+        ms = Miniscript.from_string(input, taproot=False)
         ms.verify()
         return True
     except Exception as _:
         try:
-            ms = Miniscript.read_from(BytesIO(input.encode()), taproot=True)
+            ms = Miniscript.from_string(input, taproot=True)
             ms.verify()
             return True
         except Exception as _:

--- a/modules/embit/embit_lib/embit_lib.py
+++ b/modules/embit/embit_lib/embit_lib.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 from embit.descriptor.miniscript import Miniscript
+from embit.descriptor import Descriptor
 
 def miniscript_parse(input):
     try:
@@ -13,3 +14,10 @@ def miniscript_parse(input):
             return True
         except Exception as _:
             return False
+        
+def descriptor_parse(input):
+    try:
+        desc = Descriptor.from_string(input)
+        return True
+    except Exception as _:
+        return False


### PR DESCRIPTION
This PR updates embit by modifying `miniscript_parse` to use the higher-level `from_string` function and adding support for `descriptor_parse`.

- Refactor Python interface code by extracting common parsing logic into call_python_parser function 
- Add new descriptor_parse function to Python layer using embit's Descriptor.from_string() 
- Add corresponding C++ binding function embit_descriptor_parse 
- Update miniscript parsing to use Miniscript.from_string() instead of read_from(BytesIO()) 
- Export the new descriptor parse function in the header file Add embit on miniscript_parse workflow