### PR TITLE
enhance Invoice Deserialization to Return Detailed Information

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -107,12 +107,14 @@ namespace bitcoinfuzz
     {
         FuzzedDataProvider provider(buffer.data(), buffer.size());
         std::string invoice{provider.ConsumeRemainingBytesAsString()};
-        std::optional<bool> last_response{std::nullopt};
+        std::optional<std::string> last_response{std::nullopt};
         for (auto &module : modules)
         {
-            std::optional<bool> res{module.second->deserialize_invoice(invoice)};
+            std::optional<std::string> res{module.second->deserialize_invoice(invoice)};
             if (!res.has_value()) continue;
-            if (last_response.has_value()) assert(*res == *last_response);
+            if (last_response.has_value()) {
+                assert(*res == *last_response);
+            }
 
             last_response = res.value();
         }

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -38,7 +38,7 @@ namespace bitcoinfuzz
         return std::nullopt;
     }
 
-    std::optional<bool> BaseModule::deserialize_invoice(std::string str) const
+    std::optional<std::string> BaseModule::deserialize_invoice(std::string str) const
     {
         return std::nullopt;
     }

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -23,7 +23,7 @@ namespace bitcoinfuzz
         virtual std::optional<bool> descriptor_parse(std::string str) const;
         virtual std::optional<bool> miniscript_parse(std::string str) const;
         virtual std::optional<std::string> script_asm(std::span<const uint8_t> buffer) const;
-        virtual std::optional<bool> deserialize_invoice(std::string str) const;
+        virtual std::optional<std::string> deserialize_invoice(std::string str) const;
         virtual std::optional<std::string> address_parse(std::string str) const;
         
         virtual ~BaseModule() noexcept;

--- a/modules/ldk/ldk_lib/ldk_lib.h
+++ b/modules/ldk/ldk_lib/ldk_lib.h
@@ -1,3 +1,5 @@
 #include <cstdint>
 
-extern "C" bool ldk_des_invoice(const char* input);
+extern "C" char* ldk_des_invoice(const char* input);
+
+extern "C" void ldk_free_string(const char* ptr);

--- a/modules/ldk/ldk_lib/src/lib.rs
+++ b/modules/ldk/ldk_lib/src/lib.rs
@@ -1,32 +1,104 @@
-use lightning_invoice::Currency;
+use lightning_invoice::{
+    Bolt11InvoiceDescriptionRef, Bolt11SemanticError, Currency, ParseOrSemanticError,
+};
+use std::ffi::CString;
+use std::os::raw::c_char;
 use std::{ffi::CStr, str::FromStr};
 
+unsafe fn str_to_c_string(input: &str) -> *mut c_char {
+    CString::new(input).unwrap().into_raw()
+}
+
 #[no_mangle]
-pub unsafe extern "C" fn ldk_des_invoice(input: *const std::os::raw::c_char) -> bool {
+pub unsafe extern "C" fn ldk_des_invoice(input: *const std::os::raw::c_char) -> *mut c_char {
     if input.is_null() {
-        return false;
+        return str_to_c_string("");
     }
 
     // Convert C string to Rust string
     let c_str = match CStr::from_ptr(input).to_str() {
         Ok(s) => s,
-        Err(_) => return false,
+        Err(_) => return str_to_c_string(""),
     };
 
-    match lightning_invoice::SignedRawBolt11Invoice::from_str(c_str) {
+    match lightning_invoice::Bolt11Invoice::from_str(c_str) {
         Ok(invoice) => {
-            // If the destination pubkey was provided as a tagged field, use that
-            // to verify the signature, otherwise recover it from the signature
-            let is_signature_valid = if let Some(_) = invoice.payee_pub_key() {
-                invoice.check_signature()
-            } else {
-                invoice.recover_payee_pub_key().is_ok()
-            };
-            let is_currency_bitcoin = invoice.currency() == Currency::Bitcoin;
-            let has_payment_hash = invoice.payment_hash().is_some();
+            if invoice.currency() != Currency::Bitcoin {
+                return str_to_c_string("");
+            }
+            let mut result = String::new();
 
-            has_payment_hash && is_currency_bitcoin && is_signature_valid
+            result.push_str("HASH=");
+            result.push_str(&invoice.payment_hash().to_string());
+
+            result.push_str(";AMOUNT=");
+            if let Some(amount) = invoice.amount_milli_satoshis() {
+                result.push_str(&amount.to_string());
+            }
+
+            result.push_str(";DESCRIPTION=");
+            if let Bolt11InvoiceDescriptionRef::Direct(direct_description) = invoice.description() {
+                result.push_str(&direct_description.to_string());
+            }
+
+            let invoice_payee_pub_key = match invoice.payee_pub_key() {
+                Some(payee) => payee.clone(),
+                None => invoice.recover_payee_pub_key(),
+            };
+
+            result.push_str(";RECIPIENT=");
+            result.push_str(&invoice_payee_pub_key.to_string());
+
+            result.push_str(";EXPIRY=");
+            result.push_str(&invoice.expiry_time().as_secs().to_string());
+
+            result.push_str(";TIMESTAMP=");
+            result.push_str(
+                &invoice
+                    .clone()
+                    .into_signed_raw()
+                    .raw_invoice()
+                    .data
+                    .timestamp
+                    .as_unix_timestamp()
+                    .to_string(),
+            );
+
+            result.push_str(";ROUTING_HINTS=");
+            result.push_str(&invoice.private_routes().len().to_string());
+
+            result.push_str(";MIN_CLTV=");
+            result.push_str(&invoice.min_final_cltv_expiry_delta().to_string());
+
+            str_to_c_string(&result)
         }
-        Err(_) => false,
+        // Handle invoices without payment secrets by returning null
+        // This is needed because some Lightning implementations don't require payment secrets,
+        // and we need to maintain compatibility with these implementations
+        Err(ParseOrSemanticError::SemanticError(Bolt11SemanticError::NoPaymentSecret)) => {
+            std::ptr::null_mut()
+        }
+        // Handle invoices with multiple payment hashes by returning null
+        // This is needed because some Lightning implementations don't require payment to have only one hash,
+        // and we need to maintain compatibility with these implementations
+        Err(ParseOrSemanticError::SemanticError(Bolt11SemanticError::MultiplePaymentHashes)) => {
+            std::ptr::null_mut()
+        }
+        // Handle invoices with multiple descriptions hashes by returning null
+        // This is needed because some Lightning implementations don't require to have only one description,
+        // and we need to maintain compatibility with these implementations
+        Err(ParseOrSemanticError::SemanticError(Bolt11SemanticError::MultipleDescriptions)) => {
+            std::ptr::null_mut()
+        }
+        Err(_) => str_to_c_string(""),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ldk_free_string(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        unsafe {
+            let _ = CString::from_raw(ptr);
+        }
     }
 }

--- a/modules/ldk/module.cpp
+++ b/modules/ldk/module.cpp
@@ -1,8 +1,7 @@
 #include <span>
 
 #include "module.h"
-
-extern "C" bool ldk_des_invoice(const char* input);
+#include "ldk_lib/ldk_lib.h"
 
 namespace bitcoinfuzz
 {
@@ -10,10 +9,15 @@ namespace bitcoinfuzz
     {
         Ldk::Ldk(void) : BaseModule("Ldk") {}
 
-        std::optional<bool> Ldk::deserialize_invoice(std::string str) const
+        std::optional<std::string> Ldk::deserialize_invoice(std::string str) const
         {
-            bool result = ldk_des_invoice(str.c_str());
-            return result;
+            auto result = ldk_des_invoice(str.c_str());
+            if (result == nullptr) {
+                return std::nullopt;
+            }
+            std::string result_str(result);
+            ldk_free_string(result);
+            return result_str;
         }
 
     }

--- a/modules/ldk/module.h
+++ b/modules/ldk/module.h
@@ -13,7 +13,7 @@ namespace bitcoinfuzz
         {
         public:
             Ldk(void);
-            std::optional<bool> deserialize_invoice(std::string str) const override;
+            std::optional<std::string> deserialize_invoice(std::string str) const override;
             ~Ldk() noexcept override = default;
         };
 

--- a/modules/lnd/lnd_wrapper/liblnd_wrapper.h
+++ b/modules/lnd/lnd_wrapper/liblnd_wrapper.h
@@ -80,7 +80,7 @@ typedef struct { void *data; GoInt len; GoInt cap; } GoSlice;
 extern "C" {
 #endif
 
-extern int LndDeserializeInvoice(char* cInvoiceStr);
+extern char* LndDeserializeInvoice(char* cInvoiceStr);
 
 #ifdef __cplusplus
 }

--- a/modules/lnd/lnd_wrapper/libscript.h
+++ b/modules/lnd/lnd_wrapper/libscript.h
@@ -96,7 +96,7 @@ extern "C"
 {
 #endif
 
-  extern int LndDeserializeInvoice(const char *input);
+  extern char* LndDeserializeInvoice(const char *input);
 
 #ifdef __cplusplus
 }

--- a/modules/lnd/lnd_wrapper/wrapper.go
+++ b/modules/lnd/lnd_wrapper/wrapper.go
@@ -7,16 +7,18 @@ package main
 import "C"
 
 import (
+	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/lightningnetwork/lnd/zpay32"
 )
 
 //export LndDeserializeInvoice
-func LndDeserializeInvoice(cInvoiceStr *C.char) C.int {
+func LndDeserializeInvoice(cInvoiceStr *C.char) *C.char {
 	if cInvoiceStr == nil {
-		return 0
+		return C.CString("")
 	}
 
 	runtime.GC()
@@ -26,14 +28,49 @@ func LndDeserializeInvoice(cInvoiceStr *C.char) C.int {
 
 	network := &chaincfg.MainNetParams
 
-	_, err := zpay32.Decode(invoiceStr, network)
+	invoice, err := zpay32.Decode(invoiceStr, network)
 	if err != nil {
-		return 0
+		return C.CString("")
 	}
 
-	runtime.GC()
+	var sb strings.Builder
 
-	return 1
+	sb.WriteString("HASH=")
+	if invoice.PaymentHash != nil {
+		sb.WriteString(fmt.Sprintf("%x", *invoice.PaymentHash))
+	}
+
+	sb.WriteString(";AMOUNT=")
+	if invoice.MilliSat != nil {
+		sb.WriteString(fmt.Sprintf("%d", *invoice.MilliSat))
+	}
+
+	sb.WriteString(";DESCRIPTION=")
+	if invoice.Description != nil {
+		sb.WriteString(*invoice.Description)
+	}
+
+	sb.WriteString(";RECIPIENT=")
+	if invoice.Destination != nil {
+		sb.WriteString(fmt.Sprintf("%x", invoice.Destination.SerializeCompressed()))
+	}
+
+	sb.WriteString(";EXPIRY=")
+	if invoice.Expiry() > 0 {
+		sb.WriteString(fmt.Sprintf("%d", int64(invoice.Expiry().Seconds())))
+	}
+
+	sb.WriteString(";TIMESTAMP=")
+	sb.WriteString(fmt.Sprintf("%d", invoice.Timestamp.Unix()))
+
+	sb.WriteString(fmt.Sprintf(";ROUTING_HINTS=%d", len(invoice.RouteHints)))
+
+	sb.WriteString(";MIN_CLTV=")
+	if invoice.MinFinalCLTVExpiry() > 0 {
+		sb.WriteString(fmt.Sprintf("%d", invoice.MinFinalCLTVExpiry()))
+	}
+
+	return C.CString(sb.String())
 }
 
 func main() {}

--- a/modules/lnd/module.cpp
+++ b/modules/lnd/module.cpp
@@ -9,11 +9,12 @@ namespace bitcoinfuzz
     {
         Lnd::Lnd(void) : BaseModule("Lnd") {}
 
-        std::optional<bool> Lnd::deserialize_invoice(std::string str) const
+        std::optional<std::string> Lnd::deserialize_invoice(std::string str) const
         {
-            bool result = LndDeserializeInvoice(str.c_str());
-            return result;
+            auto result = LndDeserializeInvoice(str.c_str());
+            std::string result_str(result);
+            free(result);
+            return result_str;
         }
-
     }
 }

--- a/modules/lnd/module.h
+++ b/modules/lnd/module.h
@@ -13,7 +13,7 @@ namespace bitcoinfuzz
         {
         public:
             Lnd(void);
-            std::optional<bool> deserialize_invoice(std::string str) const override;
+            std::optional<std::string> deserialize_invoice(std::string str) const override;
             ~Lnd() noexcept override = default;
         };
 

--- a/modules/nlightning/module.cpp
+++ b/modules/nlightning/module.cpp
@@ -32,7 +32,9 @@ namespace bitcoinfuzz
 {
     namespace module
     {
+        FreeStringFunc NLightning::freeString = nullptr;
         DecodeInvoiceFunc NLightning::decodeInvoice = nullptr;
+        CleanupResources NLightning::cleanupResources = nullptr;
 
         NLightning::NLightning(void) : BaseModule("NLightning")
         {
@@ -69,11 +71,43 @@ namespace bitcoinfuzz
                 CLOSE_LIBRARY(libHandle);
                 return;
             }
+
+            if (freeString == nullptr)
+                freeString = (FreeStringFunc)GET_PROC_ADDRESS(libHandle, "FreeString");
+
+            if (!freeString)
+            {
+                std::cerr << "Failed to find FreeString symbol" << std::endl;
+                CLOSE_LIBRARY(libHandle);
+                return;
+            }
+
+            if (cleanupResources == nullptr)
+                cleanupResources = (CleanupResources)GET_PROC_ADDRESS(libHandle, "CleanupResources");
+
+            if (!cleanupResources)
+            {
+                std::cerr << "Failed to find CleanupResources symbol" << std::endl;
+                CLOSE_LIBRARY(libHandle);
+                return;
+            }
         }
 
-        std::optional<bool> NLightning::deserialize_invoice(std::string str) const
+        std::optional<std::string> NLightning::deserialize_invoice(std::string str) const
         {
-            return decodeInvoice(str.c_str());
+            char* result = decodeInvoice(str.c_str());
+            
+            if (result == nullptr) {
+                cleanupResources();
+                return std::nullopt;
+            }
+            
+            std::string resultStr(result);
+            freeString(result);
+            cleanupResources();
+           
+            
+            return resultStr;
         }
     }
 }

--- a/modules/nlightning/module.h
+++ b/modules/nlightning/module.h
@@ -9,18 +9,21 @@ namespace bitcoinfuzz
 {
     namespace module
     {
-        typedef bool (*DecodeInvoiceFunc)(const char* input);
+        typedef char* (*DecodeInvoiceFunc)(const char* input);
+        typedef void (*FreeStringFunc)(char* ptr);
+        typedef void (*CleanupResources)();
 
         class NLightning : public BaseModule
         {
         public:
             NLightning(void);
-            std::optional<bool> deserialize_invoice(std::string str) const override;
+            std::optional<std::string> deserialize_invoice(std::string str) const override;
             ~NLightning() noexcept override = default;
 
         private:
             static DecodeInvoiceFunc decodeInvoice;
+            static FreeStringFunc freeString;
+            static CleanupResources cleanupResources;
         };
-
     }
 }

--- a/modules/nlightning/src/Bolts/BOLT11/InvoiceBridge.cs
+++ b/modules/nlightning/src/Bolts/BOLT11/InvoiceBridge.cs
@@ -2,26 +2,80 @@ using System.Runtime.InteropServices;
 
 namespace NLightning.CppBridge.Bolts.BOLT11;
 
+using System.Text;
 using NLightning.Bolts.BOLT11;
 public static class InvoiceBridge
 {
     [UnmanagedCallersOnly(EntryPoint = "DecodeInvoice")]
-    public static bool DecodeInvoice(IntPtr invoiceStringPtr)
+    public static IntPtr DecodeInvoice(IntPtr invoiceStringPtr)
     {
         try
         {
             string? invoiceString = Marshal.PtrToStringUTF8(invoiceStringPtr);
             if (string.IsNullOrEmpty(invoiceString))
             {
-                return false;
+                return CreateEmptyStringPtr();
             }
 
-            _ = Invoice.Decode(invoiceString);
-            return true;
+            Invoice invoice = Invoice.Decode(invoiceString);
+
+            StringBuilder resultBuilder = new();
+
+            resultBuilder.Append("HASH=").Append(invoice.PaymentHash);
+            resultBuilder.Append(";AMOUNT=").Append(invoice.AmountMilliSats);
+            resultBuilder.Append(";DESCRIPTION=").Append(invoice.Description);
+            resultBuilder.Append(";RECIPIENT=").Append(invoice.PayeePubKey);
+            resultBuilder.Append(";EXPIRY=").Append((int)(invoice.ExpiryDate - DateTimeOffset.FromUnixTimeSeconds(invoice.Timestamp)).TotalSeconds);
+            resultBuilder.Append(";TIMESTAMP=").Append(invoice.Timestamp);
+            resultBuilder.Append(";ROUTING_HINTS=").Append(invoice.RoutingInfos?.Count ?? 0);
+            resultBuilder.Append(";MIN_CLTV=").Append(invoice.MinFinalCltvExpiry);
+
+            string result = resultBuilder.ToString();
+
+            // Manually allocate unmanaged memory for the UTF-8 string
+            byte[] resultBytes = Encoding.UTF8.GetBytes(result);
+            IntPtr resultPtr = Marshal.AllocHGlobal(resultBytes.Length + 1); // +1 for null terminator
+
+            // Copy the UTF-8 bytes to unmanaged memory
+            Marshal.Copy(resultBytes, 0, resultPtr, resultBytes.Length);
+
+            // Null-terminate the string
+            Marshal.WriteByte(resultPtr + resultBytes.Length, 0);
+
+            return resultPtr;
         }
         catch
         {
-            return false;
+            return CreateEmptyStringPtr();
         }
+    }
+
+    private static IntPtr CreateEmptyStringPtr()
+    {
+        // Allocate memory for just a null terminator (empty string)
+        IntPtr emptyStringPtr = Marshal.AllocHGlobal(1);
+        Marshal.WriteByte(emptyStringPtr, 0);
+        return emptyStringPtr;
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "FreeString")]
+    public static void FreeString(IntPtr stringPtr)
+    {
+        if (stringPtr != IntPtr.Zero)
+        {
+            Marshal.FreeHGlobal(stringPtr);
+        }
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "CleanupResources")]
+    public static void CleanupResources()
+    {
+        // Force garbage collection to clean up any managed resources
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true, true);
+        GC.WaitForPendingFinalizers();
+
+        // Run a second collection to clean up finalizers
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true, true);
+        GC.WaitForPendingFinalizers();
     }
 }


### PR DESCRIPTION
This pr improves the deserialize_invoice functionality across all implementations:

- Change return type from bool to string to provide rich invoice content
- Implement consistent format for invoice data across all implementations: HASH=<payment_hash>;AMOUNT=<milli_sats>;DESCRIPTION=<desc>;RECIPIENT=<pubkey>; EXPIRY=<seconds>;TIMESTAMP=<unix_time>;ROUTING_HINTS=<count>;MIN_CLTV=<value>
- Ensure consistent memory management for returned strings in all modules

These changes enable consistent testing across different Lightning implementations, allowing for detailed comparison of parsed invoice fields rather than just success/failure validation.

Closes #112