### PR TITLE
Refactor Embit module naming and implement descriptor_parse

### DIFF
--- a/modules/embit/embit_lib/embit_lib.cpp
+++ b/modules/embit/embit_lib/embit_lib.cpp
@@ -72,7 +72,7 @@ cleanup:
     return success;
 }
 
-extern "C" bool embit_miniscript_miniscript_parse(const char* input) {
+extern "C" bool embit_miniscript_parse(const char* input) {
     return call_python_parser(input, "miniscript_parse");
 }
 

--- a/modules/embit/embit_lib/embit_lib.h
+++ b/modules/embit/embit_lib/embit_lib.h
@@ -1,5 +1,5 @@
 #include <cstdint>
 
-extern "C" bool embit_miniscript_miniscript_parse(const char* input);
+extern "C" bool embit_miniscript_parse(const char* input);
 
-extern "C" bool embit_miniscript_descriptor_parse(const char* input);
+extern "C" bool embit_descriptor_parse(const char* input);

--- a/modules/embit/embit_lib/embit_lib.py
+++ b/modules/embit/embit_lib/embit_lib.py
@@ -1,4 +1,3 @@
-from io import BytesIO
 from embit.descriptor.miniscript import Miniscript
 from embit.descriptor import Descriptor
 

--- a/modules/embit/module.cpp
+++ b/modules/embit/module.cpp
@@ -1,8 +1,7 @@
 #include <span>
 
 #include "module.h"
-
-extern "C" bool embit_miniscript_miniscript_parse(const char* input);
+#include "embit_lib/embit_lib.h"
 
 namespace bitcoinfuzz
 {
@@ -12,9 +11,12 @@ namespace bitcoinfuzz
 
         std::optional<bool> Embit::miniscript_parse(std::string str) const
         {
-            bool result = embit_miniscript_miniscript_parse(str.c_str());
-            return result;
+            return embit_miniscript_parse(str.c_str());
         }
 
+        std::optional<bool> Embit::descriptor_parse(std::string str) const
+        {
+            return embit_descriptor_parse(str.c_str());
+        }
     }
 }

--- a/modules/embit/module.h
+++ b/modules/embit/module.h
@@ -14,6 +14,7 @@ namespace bitcoinfuzz
         public:
             Embit(void);
             std::optional<bool> miniscript_parse(std::string str) const override;
+            std::optional<bool> descriptor_parse(std::string str) const override;
             ~Embit() noexcept override = default;
         };
 


### PR DESCRIPTION
This pr streamlines the Embit module by cleaning up function names and implementing the missing descriptor_parse functionality. Changes include:

- Rename embit_miniscript_miniscript_parse to embit_miniscript_parse to eliminate redundant naming
- Rename embit_miniscript_descriptor_parse to embit_descriptor_parse for consistency
- Add implementation for descriptor_parse method in the Embit class
- Add proper header includes in module.cpp and remove unused imports
- Fix the Embit descriptor_parse function call to target the correct implementation

These changes complete the Embit interface implementation and improve overall code organization.

I forgot to add the descriptor function into the embit module.cpp... Now this is fixed!