### PR TITLE
Fix: Force bitcoinfuzz recompilation for each test using .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,5 @@ include/bitcoinfuzz/basemodule.o: include/bitcoinfuzz/basemodule.cpp include/bit
 
 clean:
 	rm -rf *.o module.a bitcoinfuzz include/bitcoinfuzz/*.o $(MODULES)
+
+.PHONY: all bitcoinfuzz

--- a/modules/nlightning/src/NLightning.CppBridge.csproj
+++ b/modules/nlightning/src/NLightning.CppBridge.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLightning.Bolt11" Version="0.2.0" />
+    <PackageReference Include="NLightning.Bolt11" Version="0.2.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR ensures bitcoinfuzz is always recompiled for each test by marking it as a .PHONY target in the Makefile.

Closes: #128