### PR TITLE
Remove payment secret workaround

### DIFF
--- a/modules/ldk/ldk_lib/src/lib.rs
+++ b/modules/ldk/ldk_lib/src/lib.rs
@@ -72,12 +72,6 @@ pub unsafe extern "C" fn ldk_des_invoice(input: *const std::os::raw::c_char) -> 
 
             str_to_c_string(&result)
         }
-        // Handle invoices without payment secrets by returning null
-        // This is needed because some Lightning implementations don't require payment secrets,
-        // and we need to maintain compatibility with these implementations
-        Err(ParseOrSemanticError::SemanticError(Bolt11SemanticError::NoPaymentSecret)) => {
-            std::ptr::null_mut()
-        }
         // Handle invoices with multiple payment hashes by returning null
         // This is needed because some Lightning implementations don't require payment to have only one hash,
         // and we need to maintain compatibility with these implementations


### PR DESCRIPTION
Now that the payment secret is needed by both the writer and the reader, we should remove the ldk workaround

Closes #138