### PR TITLE
Add c-lightning module for differential fuzzing

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,19 +26,20 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "stable"
-      
+
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
-      
+          dotnet-version: "8.0.x"
+
       - name: Setup Python and install embit
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - run: |
           python -m pip install --upgrade pip
           pip install -r modules/embit/embit_lib/requirements.txt
+          pip install mako
 
       - name: Install LLVM and Clang - Ubuntu
         if: matrix.os == 'ubuntu-24.04'
@@ -62,11 +63,11 @@ jobs:
         if: matrix.os == 'ubuntu-24.04'
         run: |
           sudo apt install libboost-all-dev
-      
+
       - name: Install Boost and build dependencies - macOS
         if: matrix.os == 'macos-13'
         run: |
-          brew install boost autoconf automake libtool pkg-config
+          brew install boost autoconf gnu-sed automake libtool gettext pkg-config protobuf libsodium
 
       - name: Setup common environment - Ubuntu
         if: matrix.os == 'ubuntu-24.04'
@@ -116,17 +117,17 @@ jobs:
         timeout-minutes: 5
         run: |
           cd modules/btcd && make
-      
+
       - name: Build - embit
         timeout-minutes: 5
         run: |
           cd modules/embit && make
-      
+
       - name: Build - lnd
         timeout-minutes: 5
         run: |
           cd modules/lnd && make
-          
+
       - name: Build - ldk
         timeout-minutes: 5
         run: |
@@ -137,6 +138,11 @@ jobs:
         timeout-minutes: 5
         run: |
           cd modules/nlightning && make
+
+      - name: Build - clightning
+        timeout-minutes: 5
+        run: |
+          cd modules/clightning && make
 
       - name: Test - script
         timeout-minutes: 5
@@ -180,10 +186,10 @@ jobs:
 
       - name: Test - deserialize_invoice
         run: |
-          export CXXFLAGS="-DLDK -DLND -DCUSTOM_MUTATOR_BOLT11"
+          export CXXFLAGS="-DLDK -DLND -DCLIGHTNING -DCUSTOM_MUTATOR_BOLT11"
           make
           ASAN_OPTIONS=detect_leaks=0 FUZZ=deserialize_invoice ./bitcoinfuzz -runs=100
-      
+
       - name: Test - address_parse
         run: |
           export CXXFLAGS="-DBITCOIN_CORE -DRUST_BITCOIN"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -184,11 +184,6 @@ jobs:
           make
           FUZZ=script_asm ./bitcoinfuzz -runs=0
 
-      - name: Test - deserialize_invoice
-        run: |
-          export CXXFLAGS="-DLDK -DLND -DCLIGHTNING -DCUSTOM_MUTATOR_BOLT11"
-          make
-          ASAN_OPTIONS=detect_leaks=0 FUZZ=deserialize_invoice ./bitcoinfuzz -runs=100
 
       - name: Test - address_parse
         run: |
@@ -201,3 +196,10 @@ jobs:
           export CXXFLAGS="-DEMBIT -DRUST_BITCOIN -DBTCD"
           make
           ASAN_OPTIONS=detect_leaks=0 FUZZ=psbt_parse ./bitcoinfuzz -runs=100
+
+      - name: Test - deserialize_invoice
+        run: |
+          export CXXFLAGS="-DLDK -DLND -DCLIGHTNING -DCUSTOM_MUTATOR_BOLT11"
+          (cd ./modules/bitcoin && make clean)
+          make
+          ASAN_OPTIONS=detect_leaks=0 FUZZ=deserialize_invoice ./bitcoinfuzz -runs=100

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "external/lightning"]
+	path = external/lightning
+	url = https://github.com/ElementsProject/lightning.git
+	ignore = all

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,10 @@ ifeq ($(UNAME_S), Darwin)
 LDFLAGS = -framework CoreFoundation -Wl,-ld_classic
 endif
 
+SODIUM_LDLIBS = $(shell pkg-config --silence-errors --libs libsodium 2>/dev/null)
+
 bitcoinfuzz: main.cpp driver.o include/bitcoinfuzz/basemodule.o
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp $(MODULES) driver.o include/bitcoinfuzz/basemodule.o -o bitcoinfuzz $(PYTHON_LDFLAGS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp $(MODULES) driver.o include/bitcoinfuzz/basemodule.o -o bitcoinfuzz $(PYTHON_LDFLAGS) $(SODIUM_LDLIBS)
 
 driver.o: driver.cpp driver.h
 	$(CXX) $(CXXFLAGS) -c driver.cpp -o driver.o

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Note this project is a WIP and might be not stable.
 
 ### boost
 
-To build the bitcoin core module the boost library is required. Minimum version 
+To build the bitcoin core module the boost library is required. Minimum version
 
 The module uses only libboost-filesystem and libboost-system modules. For ubuntu you can install with:
 
@@ -38,7 +38,7 @@ The module uses only libboost-filesystem and libboost-system modules. For ubuntu
 sudo apt install libboost-filesystem-dev libboost-system-dev
 ```
 
-Or install the complete boost library with 
+Or install the complete boost library with
 ```
 sudo apt install libboost-all-dev
 ```
@@ -119,6 +119,16 @@ export CXXFLAGS="$CXXFLAGS -DLND"
 cd modules/nlightning
 make
 export CXXFLAGS="$CXXFLAGS -DNLIGHTNING"
+```
+
+### C-lightning
+
+```bash
+pip install mako
+git submodule update --init --recursive external/lightning
+cd modules/clightning
+make
+export CXXFLAGS="$CXXFLAGS -DCLIGHTNING"
 ```
 
 Once the modules are compiled, you can compile bitcoinfuzz and execute it:

--- a/driver.cpp
+++ b/driver.cpp
@@ -108,12 +108,25 @@ namespace bitcoinfuzz
         FuzzedDataProvider provider(buffer.data(), buffer.size());
         std::string invoice{provider.ConsumeRemainingBytesAsString()};
         std::optional<std::string> last_response{std::nullopt};
+        std::string last_module_name;
+
         for (auto &module : modules)
         {
             std::optional<std::string> res{module.second->deserialize_invoice(invoice)};
             if (!res.has_value()) continue;
-            if (last_response.has_value()) assert(*res == *last_response);
+            if (last_response.has_value()) {
+                if (*res != *last_response) {
+                    std::cout << "Invoice deserialization failed for " << invoice << std::endl;
+                    std::cout << "Module: " << module.first << std::endl;
+                    std::cout << "Result: " << *res << std::endl;
+                    std::cout << "Module: " << last_module_name << std::endl;
+                    std::cout << "Result: " << *last_response << std::endl;
+                }
+                assert(*res == *last_response);
+            }
+
             last_response = res.value();
+            last_module_name = module.first;
         }
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -36,9 +36,14 @@
 #include <modules/embit/module.h>
 #endif
 
+#ifdef CLIGHTNING
+#include <modules/clightning/module.h>
+#endif
+
 #ifdef CUSTOM_MUTATOR_BOLT11
 #include <modules/bolt11mutator/bech32.h>
 #endif
+
 
 std::shared_ptr<bitcoinfuzz::Driver> driver = nullptr;
 
@@ -343,6 +348,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 #endif
 #ifdef EMBIT
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::Embit>());
+#endif
+#ifdef CLIGHTNING
+  driver->LoadModule(std::make_shared<bitcoinfuzz::module::CLightning>());
 #endif
 
   driver->Run(Data, Size, target);

--- a/modules/clightning/Makefile
+++ b/modules/clightning/Makefile
@@ -1,0 +1,51 @@
+CXX = clang++
+CXXFLAGS += -Wall -Wextra -std=c++20 -fPIC
+
+INCLUDE_DIRS += -I.
+INCLUDE_DIRS += -I../../include
+INCLUDE_DIRS += -I../../external/lightning
+INCLUDE_DIRS += -I../../external/lightning/ccan
+INCLUDE_DIRS += -I../../external/lightning/external/libwally-core/src/secp256k1/include
+
+CXXFLAGS += $(INCLUDE_DIRS)
+
+ROOT_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
+LIGHTNING_DIR := $(ROOT_DIR)/external/lightning
+CLIGHTNING_MAKEFILE := ./Makefile-clightning
+LIBCLIGHTNING_WRAPPER := ./libcln.a
+
+all: module.a
+
+$(LIGHTNING_DIR)/config.vars:
+	@echo "Running ./configure in $(LIGHTNING_DIR)..."
+	@if [ "$(shell uname)" = "Darwin" ]; then \
+		cd $(LIGHTNING_DIR) && ./configure --disable-compat --disable-valgrind CC=cc; \
+	else \
+		cd $(LIGHTNING_DIR) && ./configure --enable-address-sanitizer --disable-compat --enable-fuzzing --disable-valgrind --enable-ub-sanitizer CC=clang; \
+	fi
+
+
+libcln.a: $(LIGHTNING_DIR)/config.vars
+	@echo "Appending Makefile-clightning to $(LIGHTNING_DIR)/Makefile if not already present..."
+	@marker="$$(head -n 2 $(CLIGHTNING_MAKEFILE) | tail -n 1)"; \
+	if ! grep -Fxq "$$marker" $(LIGHTNING_DIR)/Makefile; then \
+		echo "Marker not found, appending..."; \
+		awk '{ print }' $(CLIGHTNING_MAKEFILE) >> $(LIGHTNING_DIR)/Makefile; \
+	else \
+		echo "Makefile already includes clightning makefile content."; \
+	fi
+
+	@echo "Building lightning in $(LIGHTNING_DIR)..."
+	cd $(LIGHTNING_DIR) && make libcln.a
+
+	@echo "Copying static library in $(LIGHTNING_DIR)..."
+	cp $(LIGHTNING_DIR)/libcln.a $(LIBCLIGHTNING_WRAPPER)
+
+module.a: libcln.a module.o
+	bash ../../merge.sh module.a libcln.a module.o
+
+module.o: module.cpp module.h
+	$(CXX) $(CXXFLAGS) -fPIC -c module.cpp -o module.o
+
+clean:
+	rm -f *.o *.a

--- a/modules/clightning/Makefile-clightning
+++ b/modules/clightning/Makefile-clightning
@@ -1,0 +1,23 @@
+
+libcln.a: libccan.a $(BITCOIN_OBJS) $(COMMON_OBJS) $(WIRE_OBJS) $(EXTERNAL_LIBS) $(CCAN_OBJS)
+	@$(call VERBOSE, "ar $@", $(AR) r $@ $(BITCOIN_OBJS) $(COMMON_OBJS) $(WIRE_OBJS) $(CCAN_OBJS))
+	@echo "Extracting external libraries..."
+	@for lib in ${EXTERNAL_LIBS}; do \
+    echo "Processing $$lib"; \
+    if [ -f "$$lib" ]; then \
+        tmpdir=$$(mktemp -d); \
+        echo "Created temp dir: $$tmpdir"; \
+        fullpath="$$(pwd)/$$lib"; \
+        echo "Full path: $$fullpath"; \
+        (cd $$tmpdir && $(AR) x "$$fullpath" && echo "Extraction completed successfully"); \
+        if [ -n "$$(ls -A $$tmpdir)" ]; then \
+            echo "Found object files: $$(ls $$tmpdir)"; \
+            $(AR) r $@ $$tmpdir/*.o; \
+        else \
+            echo "Warning: No object files found in $$lib"; \
+        fi; \
+        rm -rf $$tmpdir; \
+    else \
+        echo "Warning: Library $$lib not found"; \
+    fi; \
+done

--- a/modules/clightning/module.cpp
+++ b/modules/clightning/module.cpp
@@ -1,0 +1,94 @@
+#define template c_template  // avoid C++ keyword conflict just during includes
+
+extern "C" {
+    #include "common/bolt11.h"
+    #include "bitcoin/pubkey.h"
+    #include "common/node_id.h"
+    #include "common/utils.h"
+    #include <bitcoin/chainparams.h>
+    #include <ccan/tal/tal.h>
+}
+
+#undef template
+
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <cstring>
+#include <vector>
+#include <memory>
+#include <iostream>
+#include <iostream>
+#include <span>
+#include "module.h"
+
+struct TalFree {
+    void operator()(void* ptr) const { tal_free(ptr); }
+};
+
+std::string hex_encode(const unsigned char* data, size_t len) {
+    std::ostringstream oss;
+    oss << std::hex << std::setfill('0');
+    for (size_t i = 0; i < len; ++i) {
+        oss << std::setw(2) << static_cast<int>(data[i]);
+    }
+    return oss.str();
+}
+
+std::string clightning_des_invoice(const std::string& input) {
+    char* fail = nullptr;
+    const struct chainparams* params = chainparams_for_network("bitcoin");
+
+    std::unique_ptr<bolt11, TalFree> invoice(
+        bolt11_decode(nullptr, input.c_str(), nullptr, nullptr, params, &fail)
+    );
+
+    if (!invoice) {
+        tal_free(fail);
+        return "";
+    }
+
+    std::ostringstream result;
+    result << "HASH=" << hex_encode(invoice->payment_hash.u.u8, 32) << ";";
+
+    result << "AMOUNT=";
+    if (invoice->msat) {
+        result << invoice->msat->millisatoshis;
+    } else {
+        result << "0";
+    }
+    result << ";";
+
+    result << "DESCRIPTION=";
+    if (invoice->description) {
+        result << invoice->description;
+    }
+    result << ";";
+
+    struct pubkey key;
+    assert(pubkey_from_node_id(&key, &invoice->receiver_id));
+
+    uint8_t compressed[33];
+    pubkey_to_der(compressed, &key);
+    result << "RECIPIENT=" << hex_encode(compressed, 33) << ";";
+
+    result << "EXPIRY=" << invoice->expiry << ";";
+    result << "TIMESTAMP=" << invoice->timestamp << ";";
+    result << "ROUTING_HINTS=" << tal_count(invoice->routes) << ";";
+    result << "MIN_CLTV=" << invoice->min_final_cltv_expiry;
+
+    return result.str();
+}
+
+namespace bitcoinfuzz
+{
+    namespace module
+    {
+        CLightning::CLightning(void) : BaseModule("CLightning") {}
+
+        std::optional<std::string> CLightning::deserialize_invoice(std::string str) const
+        {
+            return clightning_des_invoice(str.c_str());
+        }
+    }
+}

--- a/modules/clightning/module.h
+++ b/modules/clightning/module.h
@@ -1,0 +1,21 @@
+#include <optional>
+#include <span>
+#include <vector>
+#include <cstddef>
+#include <cstdint>
+#include <bitcoinfuzz/basemodule.h>
+
+namespace bitcoinfuzz
+{
+    namespace module
+    {
+        class CLightning : public BaseModule
+        {
+        public:
+            CLightning(void);
+            std::optional<std::string> deserialize_invoice(std::string str) const override;
+            ~CLightning() noexcept override = default;
+        };
+
+    }
+}

--- a/modules/lnd/lnd_wrapper/wrapper.go
+++ b/modules/lnd/lnd_wrapper/wrapper.go
@@ -43,6 +43,8 @@ func LndDeserializeInvoice(cInvoiceStr *C.char) *C.char {
 	sb.WriteString(";AMOUNT=")
 	if invoice.MilliSat != nil {
 		sb.WriteString(fmt.Sprintf("%d", *invoice.MilliSat))
+	} else {
+		sb.WriteString("0")
 	}
 
 	sb.WriteString(";DESCRIPTION=")
@@ -56,9 +58,7 @@ func LndDeserializeInvoice(cInvoiceStr *C.char) *C.char {
 	}
 
 	sb.WriteString(";EXPIRY=")
-	if invoice.Expiry() > 0 {
-		sb.WriteString(fmt.Sprintf("%d", int64(invoice.Expiry().Seconds())))
-	}
+	sb.WriteString(fmt.Sprintf("%d", int64(invoice.Expiry().Seconds())))
 
 	sb.WriteString(";TIMESTAMP=")
 	sb.WriteString(fmt.Sprintf("%d", invoice.Timestamp.Unix()))
@@ -66,9 +66,7 @@ func LndDeserializeInvoice(cInvoiceStr *C.char) *C.char {
 	sb.WriteString(fmt.Sprintf(";ROUTING_HINTS=%d", len(invoice.RouteHints)))
 
 	sb.WriteString(";MIN_CLTV=")
-	if invoice.MinFinalCLTVExpiry() > 0 {
-		sb.WriteString(fmt.Sprintf("%d", invoice.MinFinalCLTVExpiry()))
-	}
+	sb.WriteString(fmt.Sprintf("%d", invoice.MinFinalCLTVExpiry()))
 
 	return C.CString(sb.String())
 }


### PR DESCRIPTION
This commit introduces a c-lightning module to the bitcoinfuzz project, enabling differential fuzzing of lightning invoices.

Key changes:

Module Integration:
  - Add `modules/clightning` directory with module implementation and wrapper
  - Compile c-lightning as a library and link it to the clightning module.cpp file

Build System:
  - Update GitHub workflow to include c-lightning module in fuzzing
  - Modify Makefile to handle c-lightning dependencies

Differential Fuzzing:
  - Enhance driver to compare invoice deserialization across implementations
  - Enable detection of discrepancies between c-lightning and other modules

Dependencies:
  - Add c-lightning as a submodule in `external/lightning`
  - Configure necessary build dependencies
  
Closes #96