### PR TITLE
feat: Add Eclair module for invoice deserialization

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           go-version: "stable"
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v4
         with:
@@ -136,6 +142,11 @@ jobs:
         run: |
           cd modules/clightning && make
 
+      - name: Build - eclair
+        timeout-minutes: 5
+        run: |
+          cd modules/eclair && make
+
       - name: Cache build artifacts
         uses: actions/cache/save@v4
         with:
@@ -196,7 +207,7 @@ jobs:
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "deserialize_invoice_clean"
             target: "deserialize_invoice"
-            cxxflags: "-DLDK -DLND -DCLIGHTNING -DCUSTOM_MUTATOR_BOLT11"
+            cxxflags: "-DLDK -DLND -DCLIGHTNING -DECLAIR -DCUSTOM_MUTATOR_BOLT11"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
             pre_build: "(cd ./modules/bitcoin && make clean)"
           - corpus: "deserialize_offer"

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ bin/
 obj/
 *.dylib
 *.so
+*.jar
+*.zip
 __pycache__
 main.py
 corpus/

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,3 +3,9 @@
 	url = https://github.com/ElementsProject/lightning.git
 	ignore = all
 	branch = master
+	
+[submodule "external/eclair"]
+	path = external/eclair
+	url = https://github.com/ACINQ/eclair.git
+	ignore = all
+	branch = master

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,12 @@ RUN wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-p
     apt-get update && apt-get install -y dotnet-sdk-8.0 && \
     rm -rf /var/lib/apt/lists/*
 
+# Installs Java 21 (OpenJDK 21 from Adoptium)
+RUN wget https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_linux_hotspot_21.0.7_6.tar.gz && \
+    mkdir -p /opt/java && \
+    tar -xzf OpenJDK21U-jdk_x64_linux_hotspot_21.0.7_6.tar.gz -C /opt/java && \
+    rm OpenJDK21U-jdk_x64_linux_hotspot_21.0.7_6.tar.gz
+
 # Installs Python 3.11 and pip
 RUN apt-get update && apt-get install -y python3 python3-pip python3-venv && \
     rm -rf /var/lib/apt/lists/*
@@ -48,6 +54,8 @@ RUN apt-get update && apt-get install -y \
 ENV CC=/usr/bin/clang
 ENV CXX=/usr/bin/clang++
 ENV LDFLAGS="-lsodium"
+ENV JAVA_HOME="/opt/java/jdk-21.0.7+6"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Working directory
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,12 @@
 all: bitcoinfuzz
 
 CXX := clang++
-CXXFLAGS += -fsanitize=address,fuzzer -Wall -Wextra -std=c++20 -I include -I .
+BASE_CXXFLAGS := -fsanitize=address,fuzzer -Wall -Wextra -std=c++20 -I include -I .
 MODULES := $(wildcard modules/*/module.a)
 UNAME_S := $(shell uname -s)
 
-# Get Python linking flags if the embit module is being used (DEMBIT is defined)
-PYTHON_LDFLAGS = $(shell if echo "$(CXXFLAGS)" | grep -q "\-DEMBIT"; then python3-config --ldflags --embed; fi)
-
 ifeq ($(UNAME_S), Darwin)
-LDFLAGS = -framework CoreFoundation -Wl,-ld_classic
+	LDFLAGS = -framework CoreFoundation -Wl,-ld_classic
 endif
 
 ifneq ($(findstring -DNBITCOIN,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
@@ -23,6 +20,24 @@ endif
 
 SODIUM_LDLIBS = $(shell pkg-config --silence-errors --libs libsodium 2>/dev/null)
 
+# Check for EMBIT define and add Python-related flags
+ifneq ($(findstring -DEMBIT,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+  PYTHON_LDFLAGS := $(shell python3-config --ldflags --embed)
+endif
+
+# Check for ECLAIR define and add Java-related flags
+ifneq ($(findstring -DECLAIR,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+	ifeq ($(UNAME_S), Darwin)
+		JAVA_HOME ?= $(shell /usr/libexec/java_home)
+	else
+		JAVA_HOME ?= $(shell dirname $$(dirname $$(readlink -f $$(which javac))))
+	endif
+	
+  JAVA_CXXFLAGS := -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(shell uname -s | tr '[:upper:]' '[:lower:]') -L$(JAVA_HOME)/lib/server -ljvm -Wl,-rpath,$(JAVA_HOME)/lib/server
+endif
+
+CXXFLAGS := $(BASE_CXXFLAGS) $(JAVA_CXXFLAGS) $(CXXFLAGS) $(PYTHON_LDFLAGS)
+
 bitcoinfuzz: main.cpp driver.o include/bitcoinfuzz/basemodule.o
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp $(MODULES) driver.o include/bitcoinfuzz/basemodule.o $(NBITCOIN_DYLIB) -o bitcoinfuzz $(PYTHON_LDFLAGS) $(SODIUM_LDLIBS)
 
@@ -34,5 +49,6 @@ include/bitcoinfuzz/basemodule.o: include/bitcoinfuzz/basemodule.cpp include/bit
 
 clean:
 	rm -rf *.o module.a bitcoinfuzz include/bitcoinfuzz/*.o $(MODULES)
+	rm -rf modules/eclair/eclair.zip modules/eclair/lib modules/eclair/eclair_extracted
 
 .PHONY: all bitcoinfuzz

--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ If you prefer, you can still build the modules manually. Below are the steps for
     make
     export CXXFLAGS="$CXXFLAGS -DCLIGHTNING"
     ```
+### Eclair
+
+    ```bash
+    git submodule update --init --recursive external/eclair
+    cd modules/eclair
+    make
+    export CXXFLAGS="$CXXFLAGS -DECLAIR"
+    ```
 
 ## Final Build and Execution
 Once the modules are compiled, you can compile `bitcoinfuzz` an execute it:

--- a/auto_build.sh
+++ b/auto_build.sh
@@ -64,6 +64,10 @@ clightning() {
     execute_in_module "modules/clightning" "$1"
 }
 
+eclair() {
+    execute_in_module "modules/eclair" "$1"
+}
+
 custom_mutator_bolt11() {
     execute_in_module "modules/custommutator" "$1"
 }
@@ -77,7 +81,7 @@ custom_mutator_p2p_message() {
 }
 
 # Define the list of modules
-modules="bitcoin_core rust_bitcoin rust_miniscript btcd nbitcoin embit lnd ldk nlightning clightning custom_mutator_bolt11 custom_mutator_bolt12_offer custom_mutator_p2p_message"
+modules="bitcoin_core rust_bitcoin rust_miniscript btcd nbitcoin embit lnd ldk nlightning clightning eclair custom_mutator_bolt11 custom_mutator_bolt12_offer custom_mutator_p2p_message"
 
 # Full clean: runs `make clean` in all module directories
 full_clean() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       dockerfile: Dockerfile
     environment:
       <<: *common-env
-      CXXFLAGS: "-DLDK -DLND -DNLIGHTNING -DCLIGHTNING -DCUSTOM_MUTATOR_BOLT11"
+      CXXFLAGS: "-DLDK -DLND -DNLIGHTNING -DCLIGHTNING -DECLAIR -DCUSTOM_MUTATOR_BOLT11"
       FUZZ: deserialize_invoice
       ASAN_OPTIONS: detect_leaks=0
     volumes:

--- a/main.cpp
+++ b/main.cpp
@@ -32,6 +32,10 @@
 #include <modules/ldk/module.h>
 #endif
 
+#ifdef ECLAIR
+#include <modules/eclair/module.h>
+#endif
+
 #ifdef NLIGHTNING
 #include <modules/nlightning/module.h>
 #endif
@@ -464,6 +468,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 #endif
 #ifdef CLIGHTNING
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::CLightning>());
+#endif
+#ifdef ECLAIR
+  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Eclair>());
 #endif
 
   driver->Run(Data, Size, target);

--- a/modules/eclair/.gitignore
+++ b/modules/eclair/.gitignore
@@ -1,0 +1,2 @@
+eclair_extracted/
+*.class

--- a/modules/eclair/Bolt11InvoiceWrapper.java
+++ b/modules/eclair/Bolt11InvoiceWrapper.java
@@ -1,0 +1,120 @@
+import fr.acinq.eclair.payment.Bolt11Invoice;
+import scala.util.Try;
+import scala.util.Either;
+import scala.util.Success;
+import scala.util.Failure;
+import scala.Option;
+import scodec.bits.ByteVector;
+import scala.collection.immutable.List;
+import scala.collection.immutable.Seq;
+import fr.acinq.eclair.MilliSatoshi;
+import fr.acinq.bitcoin.scalacompat.ByteVector32;
+import fr.acinq.eclair.payment.Bolt11Invoice.ExtraHop;
+
+public class Bolt11InvoiceWrapper {
+  /**
+   * Decodes a BOLT11 invoice and returns all values in a formatted string.
+   * This method is designed to be called from other languages via JNI or direct
+   * Java calls.
+   * 
+   * @param invoiceString The BOLT11 invoice string to decode
+   * @return Formatted string with all invoice values, or empty string if parsing
+   *         fails
+   */
+  public static String decodeBolt11Invoice(String invoiceString) {
+    try {
+      Try<Bolt11Invoice> result = Bolt11Invoice.fromString(invoiceString);
+
+      if (!result.isSuccess()) {
+        Throwable ex = (Throwable) result.failed().get();
+        if (ex.getMessage().equals("requirement failed: there must be exactly one payment secret tag")) {
+          return "payment_secret_error";
+        }
+        return "";
+      }
+
+      Bolt11Invoice invoice = result.get();
+
+      StringBuilder sb = new StringBuilder();
+
+      sb.append("HASH=").append(invoice.paymentHash());
+      sb.append(";PAYMENT_SECRET=").append(invoice.paymentSecret());
+
+      sb.append(";AMOUNT=");
+      Option<MilliSatoshi> amountOpt = invoice.amount_opt();
+      if (amountOpt.isDefined()) {
+        sb.append(amountOpt.get());
+      } else {
+        sb.append("0");
+      }
+
+      Either<String, ByteVector32> descEither = invoice.description();
+      sb.append(";DESCRIPTION=");
+      if (descEither.isLeft()) {
+        sb.append(descEither.left().get());
+      }
+
+      sb.append(";METADATA=");
+      Option<ByteVector> metadataOpt = invoice.paymentMetadata();
+      if (metadataOpt.isDefined()) {
+        sb.append(metadataOpt.get().toHex());
+      }
+
+      sb.append(";RECIPIENT=").append(invoice.nodeId().toString());
+
+      sb.append(";DESCRIPTION_HASH=");
+      if (descEither.isRight()) {
+        sb.append(descEither.right().get());
+      }
+
+      sb.append(";EXPIRY=").append(invoice.relativeExpiry().toSeconds());
+      sb.append(";TIMESTAMP=").append(invoice.createdAt().toLong());
+
+      Option<String> fallbackAddr = invoice.fallbackAddress();
+      sb.append(";FALLBACK_ADDRESS=");
+      if (fallbackAddr.isDefined()) {
+        sb.append(fallbackAddr.get());
+      }
+
+      Seq<Seq<ExtraHop>> routingInfo = invoice.routingInfo();
+      scala.collection.Iterator<Seq<ExtraHop>> routeIterator = routingInfo.iterator();
+
+      while (routeIterator.hasNext()) {
+        Seq<ExtraHop> route = routeIterator.next();
+        sb.append(";PRIVATE_ROUTE=[");
+
+        scala.collection.Iterator<ExtraHop> hopIterator = route.iterator();
+        int hopIndex = 0;
+
+        while (hopIterator.hasNext()) {
+          ExtraHop hop = hopIterator.next();
+
+          if (hopIndex == 0) {
+            sb.append("(");
+          } else {
+            sb.append(",(");
+          }
+
+          sb.append("NODE_ID=").append(hop.nodeId().toString());
+          sb.append(",SHORT_CHANNEL_ID=").append(hop.shortChannelId().toString());
+          sb.append(",FEES=").append(hop.feeBase().toLong());
+          sb.append(",CLTV_EXPIRY_DELTA=").append(hop.cltvExpiryDelta().toInt());
+          sb.append(",PROPORTIONAL_MILLIONTHS=").append(hop.feeProportionalMillionths());
+          sb.append(")");
+
+          hopIndex++;
+        }
+
+        sb.append("]");
+      }
+
+      sb.append(";MIN_CLTV=").append(invoice.minFinalCltvExpiryDelta().toInt());
+      sb.append(";FEATURES=").append(invoice.features().toByteVector().toHex());
+
+      return sb.toString();
+
+    } catch (Exception e) {
+      return "";
+    }
+  }
+}

--- a/modules/eclair/Makefile
+++ b/modules/eclair/Makefile
@@ -1,0 +1,47 @@
+CXX = clang++
+CXXFLAGS += -Wall -Wextra -std=c++20 -fPIC  -I ../../include
+
+OS_NAME := $(shell uname | tr '[:upper:]' '[:lower:]')
+
+ifeq ($(OS_NAME),darwin)
+    JAVA_HOME ?= $(shell /usr/libexec/java_home)
+else
+    JAVA_HOME ?= $(shell dirname $$(dirname $$(readlink -f $$(which javac))))
+endif
+
+CXXFLAGS += -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(OS_NAME)
+
+ROOT_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
+ECLAIR_DIR := $(ROOT_DIR)/external/eclair
+
+all: module.a
+
+lib: eclair.zip
+	mkdir -p lib
+	mkdir -p eclair_extracted
+	unzip -o eclair.zip -d eclair_extracted
+	cp -r eclair_extracted/*/lib/* lib/
+
+eclair.zip:
+	@echo "Building eclair in $(ECLAIR_DIR)..."
+	cd $(ECLAIR_DIR) && ./mvnw package -pl eclair-node -am -Dmaven.test.skip=true -DskipTests
+
+	@ECLAIR_ZIP_BUILD=$$(find $(ECLAIR_DIR)/eclair-node/target -name "eclair-node*.zip" | head -n 1); \
+	echo "Copying $$ECLAIR_ZIP_BUILD to eclair.zip..."; \
+	cp $$ECLAIR_ZIP_BUILD eclair.zip
+
+lib/Bolt11InvoiceWrapper.jar: lib
+	javac -cp ".:lib/*" Bolt11InvoiceWrapper.java
+	jar cf Bolt11InvoiceWrapper.jar Bolt11InvoiceWrapper.class
+	cp Bolt11InvoiceWrapper.jar lib/Bolt11InvoiceWrapper.jar
+
+module.a: lib module.o lib/Bolt11InvoiceWrapper.jar
+	$(AR) rcs $@ module.o
+	ranlib $@
+
+module.o: module.cpp module.h
+	$(CXX) $(CXXFLAGS) -fPIC -c module.cpp -o module.o
+
+clean:
+	rm -f *.o *.a eclair.zip *.class *.jar
+	rm -rf lib eclair_extracted

--- a/modules/eclair/module.cpp
+++ b/modules/eclair/module.cpp
@@ -1,0 +1,133 @@
+#include "module.h"
+#include <jni.h>
+#include <string>
+#include <optional>
+#include <iostream>
+#include <filesystem>
+#include <cstring>
+#include <sstream>
+
+namespace fs = std::filesystem;
+
+static JavaVM* jvm = nullptr;
+static jclass decoderClass = nullptr;
+static jmethodID decodeMethod = nullptr;
+
+static std::string cached_classpath;
+
+static const std::string build_classpath() {
+    if (!cached_classpath.empty()) return cached_classpath;
+    
+    std::ostringstream cp;
+    cp << "-Djava.class.path=";
+    bool first = true;
+    
+    try {
+        for (const auto& entry : fs::directory_iterator("./modules/eclair/lib")) {
+            auto ext = entry.path().extension();
+            if (ext == ".jar" || ext == ".class") {
+                if (!first) cp << ":";
+                cp << entry.path().string();
+                first = false;
+            }
+        }
+    } catch (const fs::filesystem_error& e) {
+        std::cerr << "Filesystem error: " << e.what() << std::endl;
+    }
+    
+    cached_classpath = cp.str();
+    return cached_classpath;
+}
+
+static bool init_jvm() {
+    if (jvm != nullptr) return true;
+
+    JavaVMInitArgs vm_args;
+    JavaVMOption options[7];
+
+    std::string classpathStr = build_classpath();
+    options[0].optionString = const_cast<char*>(classpathStr.c_str());
+    options[1].optionString = const_cast<char*>("-Xmx512m");
+    options[2].optionString = const_cast<char*>("-XX:+UseSignalChaining");
+    options[3].optionString = const_cast<char*>("-XX:+ExitOnOutOfMemoryError");
+    options[4].optionString = const_cast<char*>("-XX:ErrorFile=./hs_err_pid%p.log");
+    options[5].optionString = const_cast<char*>("-Xrs"); 
+    options[6].optionString = const_cast<char*>("-Dsun.misc.SignalHandler.handlers=allow");
+
+    vm_args.version = JNI_VERSION_1_8;
+    vm_args.nOptions = 7;
+    vm_args.options = options;
+    vm_args.ignoreUnrecognized = JNI_FALSE;
+
+    JNIEnv* env = nullptr;
+    jint res = JNI_CreateJavaVM(&jvm, (void**)&env, &vm_args);
+    if (res != JNI_OK) {
+        return false;
+    }
+
+    decoderClass = env->FindClass("Bolt11InvoiceWrapper");
+    if (!decoderClass) {
+        return false;
+    }
+    
+    decoderClass = static_cast<jclass>(env->NewGlobalRef(decoderClass));
+    
+    decodeMethod = env->GetStaticMethodID(decoderClass, "decodeBolt11Invoice", "(Ljava/lang/String;)Ljava/lang/String;");
+    if (!decodeMethod) {
+        return false;
+    }
+
+    return true;
+}
+
+static std::optional<std::string> eclair_decode_invoice(const char* invoiceStr) {
+    if (!init_jvm() || !jvm) {
+        std::abort();
+    }
+
+    JNIEnv* env = nullptr;
+    jint status = jvm->GetEnv((void**)&env, JNI_VERSION_1_8);
+
+    jstring jInvoiceStr = env->NewStringUTF(invoiceStr);
+    if (!jInvoiceStr) {
+        return "";
+    }
+
+    jstring jResult = static_cast<jstring>(
+        env->CallStaticObjectMethod(decoderClass, decodeMethod, jInvoiceStr)
+    );
+    env->DeleteLocalRef(jInvoiceStr);
+
+    if (!jResult) {
+        return "";
+    }
+    
+    const char* resultChars = env->GetStringUTFChars(jResult, nullptr);
+    if (!resultChars) {
+        env->DeleteLocalRef(jResult);
+        return "";
+    }
+    
+    std::string result(resultChars);
+    env->ReleaseStringUTFChars(jResult, resultChars);
+    env->DeleteLocalRef(jResult);
+
+    // Handle invoices without payment secrets by returning null
+    // This is needed because LND don't require payment secrets,
+    // and we need to maintain compatibility with that implementation
+    if(result == "payment_secret_error") {
+        return std::nullopt;
+    }
+    
+    return result;
+}
+
+namespace bitcoinfuzz {
+    namespace module {
+        Eclair::Eclair(void) : BaseModule("Eclair") {}
+
+        std::optional<std::string> Eclair::deserialize_invoice(std::string str) const {
+            return eclair_decode_invoice(str.c_str());
+        }
+    }
+}

--- a/modules/eclair/module.h
+++ b/modules/eclair/module.h
@@ -1,0 +1,21 @@
+#include <optional>
+#include <span>
+#include <vector>
+#include <cstddef>
+#include <cstdint>
+#include <bitcoinfuzz/basemodule.h>
+
+namespace bitcoinfuzz
+{
+    namespace module
+    {
+        class Eclair : public BaseModule
+        {
+        public:
+            Eclair(void);
+            std::optional<std::string> deserialize_invoice(std::string str) const override;
+            ~Eclair() noexcept override = default;
+        };
+
+    }
+}


### PR DESCRIPTION
This pr introduces support for deserializing Lightning Network invoices using the Eclair implementation.

Key changes include:

- Added Eclair as a Git submodule (`external/eclair`).
- Created a new C++ module (`modules/eclair`) that uses JNI (Java
  Native Interface) to interact with Eclair's Java/Scala code.
- Created a wrapper that calls
  `fr.acinq.eclair.payment.Bolt11Invoice.fromString` to parse
  invoice and extract fields, then used JNI to invoke this wrapper to
  get the parsed result formatted.
- Updated the main Makefile to include JVM linking flags and
  automatically detect `JAVA_HOME`.
- Added a Makefile within the `modules/eclair` directory to handle
  building Eclair (using `mvnw`), extracting necessary JARs, and
  compiling the C++ JNI wrapper.
- Modified the GitHub Actions workflow (`workflow.yml`) to:
  - Set up JDK 21 using `actions/setup-java`.
  - Add a build step for the Eclair module.
  - Include the `-DECLAIR` CXX flag in the `deserialize_invoice`
    fuzz test step.
- Updated `.gitignore` to exclude `*.jar` and `*.zip` files.

Closes #94