### PR TITLE
Add Target for BOLT12 offer decode

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -203,3 +203,9 @@ jobs:
           (cd ./modules/bitcoin && make clean)
           make
           ASAN_OPTIONS=detect_leaks=0 FUZZ=deserialize_invoice ./bitcoinfuzz -runs=100
+
+      - name: Test - deserialize_offer
+        run: |
+          export CXXFLAGS="-DLDK -DCLIGHTNING"
+          make
+          ASAN_OPTIONS=detect_leaks=0 FUZZ=deserialize_offer ./bitcoinfuzz -runs=100

--- a/driver.cpp
+++ b/driver.cpp
@@ -225,6 +225,33 @@ namespace bitcoinfuzz
             last_response = *res;
         }
     }
+    
+    void Driver::OfferDeserializationTarget(std::span<const uint8_t> buffer) const
+    {
+        FuzzedDataProvider provider(buffer.data(), buffer.size());
+        std::string offer{provider.ConsumeRemainingBytesAsString()};
+        std::optional<std::string> last_response{std::nullopt};
+        std::string last_module_name;
+
+        for (auto &module : modules)
+        {
+            std::optional<std::string> res{module.second->deserialize_offer(offer)};
+            if (!res.has_value()) continue;
+            if (last_response.has_value()) {
+                if (*res != *last_response) {
+                    std::cout << "Offer deserialization failed for " << offer << std::endl;
+                    std::cout << "Module: " << module.first << std::endl;
+                    std::cout << "Result: " << *res << std::endl;
+                    std::cout << "Module: " << last_module_name << std::endl;
+                    std::cout << "Result: " << *last_response << std::endl;
+                }
+                assert(*res == *last_response);
+            }
+
+            last_response = res.value();
+            last_module_name = module.first;
+        }
+    }
 
     void Driver::Run(const uint8_t *data, const size_t size, const std::string &target) const
     {
@@ -249,6 +276,8 @@ namespace bitcoinfuzz
             this->PSBTParseTarget(buffer);
         } else if (target == "addrv2") {
             this->AddrV2Target(buffer);
+        } else if (target == "deserialize_offer") {
+            this->OfferDeserializationTarget(buffer);
         } else {
             std::cout << "Target not defined!" << std::endl;
             assert(false);

--- a/driver.h
+++ b/driver.h
@@ -30,5 +30,6 @@ namespace bitcoinfuzz
         void AddressParseTarget(std::span<const uint8_t> buffer) const;
         void PSBTParseTarget(std::span<const uint8_t> buffer) const;
         void AddrV2Target(std::span<const uint8_t> buffer) const;
+        void OfferDeserializationTarget(std::span<const uint8_t> buffer) const;
     };
 }

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -57,4 +57,9 @@ namespace bitcoinfuzz
     {
         return std::nullopt;
     }
+    
+    std::optional<std::string> BaseModule::deserialize_offer(std::string str) const
+    {
+        return std::nullopt;
+    }
 }

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -27,7 +27,8 @@ namespace bitcoinfuzz
         virtual std::optional<std::string> address_parse(std::string str) const;
         virtual std::optional<std::string> psbt_parse(std::span<const uint8_t> buffer) const;
         virtual std::optional<std::string> addrv2_parse(std::span<const uint8_t> buffer) const;
-
+        virtual std::optional<std::string> deserialize_offer(std::string str) const;
+        
         virtual ~BaseModule() noexcept;
     };
 }

--- a/modules/clightning/Makefile-clightning
+++ b/modules/clightning/Makefile-clightning
@@ -1,6 +1,6 @@
 
-libcln.a: libccan.a $(BITCOIN_OBJS) $(COMMON_OBJS) $(WIRE_OBJS) $(EXTERNAL_LIBS) $(CCAN_OBJS)
-	@$(call VERBOSE, "ar $@", $(AR) r $@ $(BITCOIN_OBJS) $(COMMON_OBJS) $(WIRE_OBJS) $(CCAN_OBJS))
+libcln.a: libccan.a $(BITCOIN_OBJS) $(COMMON_OBJS) $(WIRE_OBJS) $(WIRE_BOLT12_OBJS) $(EXTERNAL_LIBS) $(CCAN_OBJS)
+	@$(call VERBOSE, "ar $@", $(AR) r $@ $(BITCOIN_OBJS) $(COMMON_OBJS) $(WIRE_OBJS) $(WIRE_BOLT12_OBJS) $(CCAN_OBJS))
 	@echo "Extracting external libraries..."
 	@for lib in ${EXTERNAL_LIBS}; do \
     echo "Processing $$lib"; \

--- a/modules/clightning/module.cpp
+++ b/modules/clightning/module.cpp
@@ -2,6 +2,7 @@
 
 extern "C" {
     #include "common/bolt11.h"
+    #include "common/bolt12.h"
     #include "bitcoin/pubkey.h"
     #include "common/node_id.h"
     #include "common/utils.h"
@@ -80,6 +81,94 @@ std::string clightning_des_invoice(const std::string& input) {
     return result.str();
 }
 
+std::string clightning_des_offer(const std::string_view input) {
+    char* fail = nullptr;
+    const struct chainparams* params = chainparams_for_network("bitcoin");
+
+    struct tlv_offer *offer = offer_decode(tmpctx, input.data(), input.size(), nullptr, params, &fail);
+    if (!offer) {
+        clean_tmpctx();
+        return "";
+    }
+
+    std::ostringstream result;
+    result << "CHAINS=";
+    if (offer->offer_chains) {
+        result << hex_encode(offer->offer_chains->shad.sha.u.u8, 32);
+    } else {
+        // If no chains are specified, Clightning defaults to bitcoin
+        struct bitcoin_blkid chain = chainparams_for_network("bitcoin")->genesis_blockhash;
+        result << hex_encode(chain.shad.sha.u.u8, 32);
+    }
+
+    result << ";METADATA=";
+    if (offer->offer_metadata) {
+        result << hex_encode(offer->offer_metadata, tal_bytelen(offer->offer_metadata));
+    }
+
+    if (offer->offer_amount) {
+        result << ";AMOUNT=";
+        result << *offer->offer_amount;
+    }
+
+    if (offer->offer_currency) {
+        result << ";CURRENCY=";
+        size_t len = tal_bytelen(offer->offer_currency);
+        result.write((const char*)offer->offer_currency, len);
+    }
+
+    result << ";DESCRIPTION=";
+    if (offer->offer_description) {
+        size_t len = tal_bytelen(offer->offer_description);
+        result.write((const char*)offer->offer_description, len);
+    }
+
+    result << ";FEATURES=";
+    if (offer->offer_features) {
+        result << hex_encode(offer->offer_features, tal_bytelen(offer->offer_features));
+    }
+
+    result << ";ABSOLUTE_EXPIRY=";
+    if (offer->offer_absolute_expiry) {
+        result << *offer->offer_absolute_expiry;
+    }
+
+    if (offer->offer_paths) {
+        for (size_t i = 0; offer->offer_paths[i] != NULL; i++) {
+            struct blinded_path_hop **blinded_path_hops = offer->offer_paths[i]->path;
+
+            for (size_t j = 0; blinded_path_hops[j] != NULL; j++) {
+                result << ";PATH_" << i << "_HOP=";
+                struct pubkey pubkey = blinded_path_hops[j]->blinded_node_id;
+                uint8_t compressed[33];
+                pubkey_to_der(compressed, &pubkey);
+                result << hex_encode(compressed, 33);
+            }
+        }
+    }
+
+    result << ";ISSUER=";
+    if (offer->offer_issuer) {
+        size_t len = tal_bytelen(offer->offer_issuer);
+        result.write((const char*)offer->offer_issuer, len);
+    }
+
+    result << ";QUANTITY=";
+    if (offer->offer_quantity_max) {
+        result << *offer->offer_quantity_max;
+    }
+
+    result << ";ISSUER_ID=";
+    if (offer->offer_issuer_id) {
+        uint8_t compressed[33];
+        pubkey_to_der(compressed, offer->offer_issuer_id);
+        result << hex_encode(compressed, 33);
+    }
+    
+    clean_tmpctx();
+    return result.str();
+}
+
 namespace bitcoinfuzz
 {
     namespace module
@@ -91,6 +180,11 @@ namespace bitcoinfuzz
         std::optional<std::string> CLightning::deserialize_invoice(std::string str) const
         {
             return clightning_des_invoice(str.c_str());
+        }
+
+        std::optional<std::string> CLightning::deserialize_offer(std::string str) const
+        {
+            return clightning_des_offer(str);
         }
     }
 }

--- a/modules/clightning/module.h
+++ b/modules/clightning/module.h
@@ -14,6 +14,7 @@ namespace bitcoinfuzz
         public:
             CLightning(void);
             std::optional<std::string> deserialize_invoice(std::string str) const override;
+            std::optional<std::string> deserialize_offer(std::string str) const override;
             ~CLightning() noexcept override = default;
         };
 

--- a/modules/ldk/ldk_lib/Cargo.lock
+++ b/modules/ldk/ldk_lib/Cargo.lock
@@ -82,6 +82,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "dnssec-prover"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f9e1163868b86c37d43c586af9d917e699c87f1266ebfdf356ad1003458118"
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
 name = "hex-conservative"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,7 +129,35 @@ checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 name = "ldk_lib"
 version = "0.1.0"
 dependencies = [
+ "lightning",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "lightning"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad202bfb8960e3043d167d507693b0ca853e727cf93ad0ba4b3663cc08b54eda"
+dependencies = [
+ "bech32",
+ "bitcoin",
+ "dnssec-prover",
+ "hashbrown",
+ "libm",
  "lightning-invoice",
+ "lightning-types",
+ "possiblyrandom",
 ]
 
 [[package]]
@@ -121,6 +178,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
 dependencies = [
  "bitcoin",
+]
+
+[[package]]
+name = "possiblyrandom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b122a615d72104fb3d8b26523fdf9232cd8ee06949fb37e4ce3ff964d15dffd"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -147,3 +213,9 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"

--- a/modules/ldk/ldk_lib/Cargo.toml
+++ b/modules/ldk/ldk_lib/Cargo.toml
@@ -8,4 +8,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-lightning-invoice = "0.33.1"
+lightning = "0.1.3"

--- a/modules/ldk/ldk_lib/ldk_lib.h
+++ b/modules/ldk/ldk_lib/ldk_lib.h
@@ -2,4 +2,6 @@
 
 extern "C" char* ldk_des_invoice(const char* input);
 
+extern "C" char* ldk_des_offer(const char* input);
+
 extern "C" void ldk_free_string(const char* ptr);

--- a/modules/ldk/ldk_lib/src/lib.rs
+++ b/modules/ldk/ldk_lib/src/lib.rs
@@ -1,6 +1,8 @@
-use lightning_invoice::{
-    Bolt11InvoiceDescriptionRef, Bolt11SemanticError, Currency, ParseOrSemanticError,
+use lightning::bitcoin::hex::{Case, DisplayHex};
+use lightning::bolt11_invoice::{
+    Bolt11Invoice, Bolt11InvoiceDescriptionRef, Bolt11SemanticError, Currency, ParseOrSemanticError,
 };
+use lightning::offers::offer::{self, Offer};
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::{ffi::CStr, str::FromStr};
@@ -21,7 +23,7 @@ pub unsafe extern "C" fn ldk_des_invoice(input: *const std::os::raw::c_char) -> 
         Err(_) => return str_to_c_string(""),
     };
 
-    match lightning_invoice::Bolt11Invoice::from_str(c_str) {
+    match Bolt11Invoice::from_str(c_str) {
         Ok(invoice) => {
             if invoice.currency() != Currency::Bitcoin {
                 return str_to_c_string("");
@@ -89,6 +91,100 @@ pub unsafe extern "C" fn ldk_des_invoice(input: *const std::os::raw::c_char) -> 
         // and we need to maintain compatibility with these implementations
         Err(ParseOrSemanticError::SemanticError(Bolt11SemanticError::MultipleDescriptions)) => {
             std::ptr::null_mut()
+        }
+        Err(_) => str_to_c_string(""),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ldk_des_offer(input: *const std::os::raw::c_char) -> *mut c_char {
+    if input.is_null() {
+        return str_to_c_string("");
+    }
+
+    // Convert C string to Rust string
+    let c_str = match CStr::from_ptr(input).to_str() {
+        Ok(s) => s,
+        Err(_) => return str_to_c_string(""),
+    };
+
+    match Offer::from_str(c_str) {
+        Ok(offer) => {
+            let mut result = String::new();
+
+            result.push_str("CHAINS=");
+            offer.chains().iter().for_each(|chain| {
+                result.push_str(&chain.to_string());
+            });
+
+            result.push_str(";METADATA=");
+            if let Some(metadata) = offer.metadata() {
+                result.push_str(&metadata.to_hex_string(Case::Lower));
+            }
+
+            if let Some(amount) = offer.amount() {
+                match amount {
+                    offer::Amount::Bitcoin { amount_msats } => {
+                        result.push_str(";AMOUNT=");
+                        result.push_str(&amount_msats.to_string());
+                    }
+                    offer::Amount::Currency {
+                        iso4217_code,
+                        amount,
+                    } => {
+                        result.push_str(";AMOUNT=");
+                        result.push_str(&amount.to_string());
+                        result.push_str(";CURRENCY=");
+                        let code_str = match std::str::from_utf8(&iso4217_code) {
+                            Ok(s) => s,
+                            Err(_) => "Unknown",
+                        };
+                        result.push_str(code_str);
+                    }
+                }
+            }
+
+            result.push_str(";DESCRIPTION=");
+            if let Some(description) = offer.description() {
+                result.push_str(description.0);
+            }
+
+            result.push_str(";FEATURES=");
+            let features = offer.offer_features();
+            let mut be_flags = features.le_flags().to_vec();
+            be_flags.reverse();
+            result.push_str(be_flags.to_hex_string(Case::Lower).as_str());
+
+            result.push_str(";ABSOLUTE_EXPIRY=");
+            if let Some(absolute_expiry) = offer.absolute_expiry() {
+                result.push_str(absolute_expiry.as_secs().to_string().as_str());
+            }
+
+            offer.paths().iter().enumerate().for_each(|(i, path)| {
+                path.blinded_hops().iter().for_each(|hop| {
+                    result.push_str(&format!(";PATH_{}_HOP=", i));
+                    result.push_str(hop.blinded_node_id.to_string().as_str());
+                });
+            });
+
+            result.push_str(";ISSUER=");
+            if let Some(issuer) = offer.issuer() {
+                result.push_str(issuer.0);
+            }
+
+            result.push_str(";QUANTITY=");
+            let quantity = offer.supported_quantity();
+            match quantity {
+                offer::Quantity::Bounded(n) => result.push_str(&n.to_string()),
+                _ => (),
+            }
+
+            result.push_str(";ISSUER_ID=");
+            if let Some(issuer_id) = offer.issuer_signing_pubkey() {
+                result.push_str(&issuer_id.to_string());
+            }
+
+            str_to_c_string(&result)
         }
         Err(_) => str_to_c_string(""),
     }

--- a/modules/ldk/module.cpp
+++ b/modules/ldk/module.cpp
@@ -20,5 +20,15 @@ namespace bitcoinfuzz
             return result_str;
         }
 
+        std::optional<std::string> Ldk::deserialize_offer(std::string str) const
+        {
+            auto result = ldk_des_offer(str.c_str());
+            if (result == nullptr) {
+                return std::nullopt;
+            }
+            std::string result_str(result);
+            ldk_free_string(result);
+            return result_str;
+        }
     }
 }

--- a/modules/ldk/module.h
+++ b/modules/ldk/module.h
@@ -14,6 +14,7 @@ namespace bitcoinfuzz
         public:
             Ldk(void);
             std::optional<std::string> deserialize_invoice(std::string str) const override;
+            std::optional<std::string> deserialize_offer(std::string str) const override;
             ~Ldk() noexcept override = default;
         };
 


### PR DESCRIPTION
This PR adds a new fuzzing target for BOLT12 offer decoding to our differential fuzzing. It implements the `deserialize_offer` target and adds support for it in the core-lightning and LDK modules.

Closes #162