### PR TITLE
fix: Fix Rust FFI string truncation on embedded null bytes

### DIFF
--- a/modules/ldk/ldk_lib/ldk_lib.h
+++ b/modules/ldk/ldk_lib/ldk_lib.h
@@ -1,7 +1,7 @@
 #include <cstdint>
 
-extern "C" char* ldk_des_invoice(const char* input);
+extern "C" char* ldk_des_invoice(const char* input, size_t length);
 
-extern "C" char* ldk_des_offer(const char* input);
+extern "C" char* ldk_des_offer(const char* input, size_t length);
 
 extern "C" void ldk_free_string(const char* ptr);

--- a/modules/ldk/ldk_lib/src/lib.rs
+++ b/modules/ldk/ldk_lib/src/lib.rs
@@ -5,25 +5,25 @@ use lightning::bolt11_invoice::{
 use lightning::offers::offer::{self, Offer};
 use std::ffi::CString;
 use std::os::raw::c_char;
-use std::{ffi::CStr, str::FromStr};
+use std::str::FromStr;
 
 unsafe fn str_to_c_string(input: &str) -> *mut c_char {
     CString::new(input).unwrap().into_raw()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ldk_des_invoice(input: *const std::os::raw::c_char) -> *mut c_char {
-    if input.is_null() {
+pub unsafe extern "C" fn ldk_des_invoice(
+    input: *const std::os::raw::c_char,
+    length: usize,
+) -> *mut c_char {
+    if input.is_null() || length == 0 {
         return str_to_c_string("");
     }
 
-    // Convert C string to Rust string
-    let c_str = match CStr::from_ptr(input).to_str() {
-        Ok(s) => s,
-        Err(_) => return str_to_c_string(""),
-    };
+    let byte_slice = std::slice::from_raw_parts(input as *const u8, length);
+    let rust_string = String::from_utf8_lossy(byte_slice).into_owned();
 
-    match Bolt11Invoice::from_str(c_str) {
+    match Bolt11Invoice::from_str(&rust_string) {
         Ok(invoice) => {
             if invoice.currency() != Currency::Bitcoin {
                 return str_to_c_string("");
@@ -97,18 +97,18 @@ pub unsafe extern "C" fn ldk_des_invoice(input: *const std::os::raw::c_char) -> 
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ldk_des_offer(input: *const std::os::raw::c_char) -> *mut c_char {
-    if input.is_null() {
+pub unsafe extern "C" fn ldk_des_offer(
+    input: *const std::os::raw::c_char,
+    length: usize,
+) -> *mut c_char {
+    if input.is_null() || length == 0 {
         return str_to_c_string("");
     }
 
-    // Convert C string to Rust string
-    let c_str = match CStr::from_ptr(input).to_str() {
-        Ok(s) => s,
-        Err(_) => return str_to_c_string(""),
-    };
+    let byte_slice = std::slice::from_raw_parts(input as *const u8, length);
+    let rust_string = String::from_utf8_lossy(byte_slice).into_owned();
 
-    match Offer::from_str(c_str) {
+    match Offer::from_str(&rust_string) {
         Ok(offer) => {
             let mut result = String::new();
 

--- a/modules/ldk/module.cpp
+++ b/modules/ldk/module.cpp
@@ -11,7 +11,7 @@ namespace bitcoinfuzz
 
         std::optional<std::string> Ldk::deserialize_invoice(std::string str) const
         {
-            auto result = ldk_des_invoice(str.c_str());
+            auto result = ldk_des_invoice(str.data(), str.length());
             if (result == nullptr) {
                 return std::nullopt;
             }
@@ -22,7 +22,7 @@ namespace bitcoinfuzz
 
         std::optional<std::string> Ldk::deserialize_offer(std::string str) const
         {
-            auto result = ldk_des_offer(str.c_str());
+            auto result = ldk_des_offer(str.data(), str.length());
             if (result == nullptr) {
                 return std::nullopt;
             }

--- a/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
+++ b/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
@@ -2,8 +2,7 @@
 
 extern "C" char* rust_bitcoin_script(const uint8_t *data, size_t len);
 extern "C" char* rust_bitcoin_des_block(const uint8_t *data, size_t len);
-extern "C" char* rust_bitcoin_script_asm(const char* input);
-extern "C" char* rust_bitcoin_address_parse(const char* address);
+extern "C" char* rust_bitcoin_address_parse(const char* input, size_t length);
 extern "C" char* rust_bitcoin_psbt_parse(const uint8_t *data, size_t len);
 extern "C" char* rust_bitcoin_addrv2(const uint8_t *data, size_t len);
 extern "C" void free_c_string(char* ptr);

--- a/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
+++ b/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
@@ -72,17 +72,18 @@ pub unsafe extern "C" fn rust_bitcoin_script(data: *const u8, len: usize) -> *mu
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rust_bitcoin_address_parse(address: *const c_char) -> *mut c_char {
-    if address.is_null() {
-        return std::ptr::null_mut();
+pub unsafe extern "C" fn rust_bitcoin_address_parse(
+    input: *const std::os::raw::c_char,
+    length: usize,
+) -> *mut c_char {
+    if input.is_null() || length == 0 {
+        return str_to_c_string("");
     }
 
-    let address_str = match c_str_to_str(address) {
-        Ok(s) => s,
-        Err(_) => return str_to_c_string("INVALID"),
-    };
+    let byte_slice = std::slice::from_raw_parts(input as *const u8, length);
+    let rust_string = String::from_utf8_lossy(byte_slice).into_owned();
 
-    match Address::from_str(address_str) {
+    match Address::from_str(&rust_string) {
         Ok(addr_unchecked) => match addr_unchecked.require_network(bitcoin::Network::Bitcoin) {
             Ok(addr) => {
                 let prefix = match addr.address_type() {


### PR DESCRIPTION
Replace null-terminated string handling with length-based approach in Rust FFI functions to prevent data loss when input contains null bytes.

- Add length parameter to `ldk_des_invoice`, `ldk_des_offer`, and `rust_bitcoin_address_parse`
- Use `slice::from_raw_parts` instead of `CStr::from_ptr` in Rust
- Pass `str.data()` and `str.length()` from C++ instead of `str.c_str()`