### PR TITLE
Improve bitcoin build

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ export CXXFLAGS="$CXXFLAGS -DEMBIT"
 cd modules/bitcoin
 make
 export CXXFLAGS="$CXXFLAGS -DBITCOIN_CORE"
-export BOOST_LIB_DIR="path/to/boost/"
 ```
 
 ## Lightning modules:

--- a/modules/bitcoin/Makefile
+++ b/modules/bitcoin/Makefile
@@ -12,7 +12,16 @@ CXXFLAGS += -Wall -Wextra -std=c++20 \
             -I ./primitives \
             -I ./script
 
-# BOOST_LIB_DIR = /opt/homebrew/lib/
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S), Darwin)
+	BOOST_LIB_DIR ?= /opt/homebrew/lib/
+endif
+
+ifeq ($(UNAME_S), Linux)
+	BOOST_LIB_DIR ?= /usr/lib/
+endif
+
 BOOST_FILESYSTEM = $(BOOST_LIB_DIR)libboost_filesystem.a
 BOOST_SYSTEM = $(BOOST_LIB_DIR)libboost_system.a
 SECP256K1_LIB = ../secp256k1/.libs/libsecp256k1.a

--- a/modules/bitcoin/univalue/CMakeLists.txt
+++ b/modules/bitcoin/univalue/CMakeLists.txt
@@ -2,6 +2,8 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
+cmake_minimum_required(VERSION 3.16)
+
 add_library(univalue STATIC EXCLUDE_FROM_ALL
   lib/univalue.cpp
   lib/univalue_get.cpp


### PR DESCRIPTION
* Add `cmake_minimum_required(VERSION 3.16)` to be able to build with CMAKE 4 version
* Set default BOOST_LIB_DIR to Linux and macOS systems.