### PR TITLE
Add Target for BOLT12 Invoice Request Decode

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -205,3 +205,9 @@ jobs:
           export CXXFLAGS="-DLDK -DCLIGHTNING -DCUSTOM_MUTATOR_BOLT12_OFFER"
           make
           ASAN_OPTIONS=detect_leaks=0 FUZZ=deserialize_offer ./bitcoinfuzz -runs=100
+
+      - name: Test - deserialize_invoice_request
+        run: |
+          export CXXFLAGS="-DLDK -DCLIGHTNING"
+          make
+          ASAN_OPTIONS=detect_leaks=0 FUZZ=deserialize_invoice_request ./bitcoinfuzz -runs=100

--- a/driver.cpp
+++ b/driver.cpp
@@ -275,6 +275,33 @@ namespace bitcoinfuzz
         }
     }
 
+    void Driver::InvoiceRequestDeserializationTarget(std::span<const uint8_t> buffer) const
+    {
+        FuzzedDataProvider provider(buffer.data(), buffer.size());
+        std::string invoice_request{provider.ConsumeRemainingBytesAsString()};
+        std::optional<std::string> last_response{std::nullopt};
+        std::string last_module_name;
+
+        for (auto &module : modules)
+        {
+            std::optional<std::string> res{module.second->deserialize_invoice_request(invoice_request)};
+            if (!res.has_value()) continue;
+            if (last_response.has_value()) {
+                if (*res != *last_response) {
+                    std::cout << "Invoice Request deserialization failed for " << invoice_request << std::endl;
+                    std::cout << "Module: " << module.first << std::endl;
+                    std::cout << "Result: " << *res << std::endl;
+                    std::cout << "Module: " << last_module_name << std::endl;
+                    std::cout << "Result: " << *last_response << std::endl;
+                }
+                assert(*res == *last_response);
+            }
+
+            last_response = res.value();
+            last_module_name = module.first;
+        }
+    }
+
     void Driver::Run(const uint8_t *data, const size_t size, const std::string &target) const
     {
         std::span<const uint8_t> buffer{data, size};
@@ -300,6 +327,8 @@ namespace bitcoinfuzz
             this->AddrV2Target(buffer);
         } else if (target == "deserialize_offer") {
             this->OfferDeserializationTarget(buffer);
+        } else if (target == "deserialize_invoice_request") {
+            this->InvoiceRequestDeserializationTarget(buffer);
         } else {
             std::cout << "Target not defined!" << std::endl;
             assert(false);

--- a/driver.h
+++ b/driver.h
@@ -31,5 +31,6 @@ namespace bitcoinfuzz
         void PSBTParseTarget(std::span<const uint8_t> buffer) const;
         void AddrV2Target(std::span<const uint8_t> buffer) const;
         void OfferDeserializationTarget(std::span<const uint8_t> buffer) const;
+        void InvoiceRequestDeserializationTarget(std::span<const uint8_t> buffer) const;
     };
 }

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -62,4 +62,9 @@ namespace bitcoinfuzz
     {
         return std::nullopt;
     }
+
+    std::optional<std::string> BaseModule::deserialize_invoice_request(std::string str) const
+    {
+        return std::nullopt;
+    }
 }

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -28,6 +28,7 @@ namespace bitcoinfuzz
         virtual std::optional<std::string> psbt_parse(std::span<const uint8_t> buffer) const;
         virtual std::optional<std::string> addrv2_parse(std::span<const uint8_t> buffer) const;
         virtual std::optional<std::string> deserialize_offer(std::string str) const;
+        virtual std::optional<std::string> deserialize_invoice_request(std::string str) const;
         
         virtual ~BaseModule() noexcept;
     };

--- a/modules/clightning/module.cpp
+++ b/modules/clightning/module.cpp
@@ -230,6 +230,163 @@ std::string clightning_des_offer(const std::string_view input) {
     return result.str();
 }
 
+std::string clightning_des_invoice_request(const std::string_view input) {
+    char* fail = nullptr;
+    const struct chainparams* params = chainparams_for_network("bitcoin");
+
+    // Get the truncated length of the string (in case it contains null bytes)
+    size_t c_string_len = strnlen(input.data(), input.size());
+
+    struct tlv_invoice_request * invoice_req = invrequest_decode(tmpctx, input.data(), c_string_len, nullptr, params, &fail);
+    if (!invoice_req) {
+        clean_tmpctx();
+        return "";
+    }
+
+    std::ostringstream result;
+
+    // offer fields
+    result << "CHAINS=";
+    if (invoice_req->offer_chains && tal_count(invoice_req->offer_chains) > 0) {
+        for (size_t i = 0; i < tal_count(invoice_req->offer_chains); i++) {
+            if (i > 0) result << ";";
+            result << hex_encode(invoice_req->offer_chains[i].shad.sha.u.u8, 32);
+        }
+    } else {
+        // If no chains are specified, Clightning defaults to bitcoin
+        struct bitcoin_blkid chain = chainparams_for_network("bitcoin")->genesis_blockhash;
+        result << hex_encode(chain.shad.sha.u.u8, 32);
+    }
+
+    result << ";METADATA=";
+    if (invoice_req->offer_metadata) {
+        result << hex_encode(invoice_req->offer_metadata, tal_bytelen(invoice_req->offer_metadata));
+    }
+
+    if (invoice_req->offer_amount) {
+        result << ";AMOUNT=";
+        result << *invoice_req->offer_amount;
+    }
+
+    if (invoice_req->offer_currency) {
+        result << ";CURRENCY=";
+        size_t len = tal_bytelen(invoice_req->offer_currency);
+        result.write((const char*)invoice_req->offer_currency, len);
+    }
+
+    result << ";DESCRIPTION=";
+    if (invoice_req->offer_description) {
+        size_t len = tal_bytelen(invoice_req->offer_description);
+        result.write((const char*)invoice_req->offer_description, len);
+    }
+
+    result << ";FEATURES=";
+    if (invoice_req->offer_features) {
+        result << hex_encode(invoice_req->offer_features, tal_bytelen(invoice_req->offer_features));
+    }
+
+    result << ";ABSOLUTE_EXPIRY=";
+    if (invoice_req->offer_absolute_expiry) {
+        result << *invoice_req->offer_absolute_expiry;
+    }
+
+    if (invoice_req->offer_paths) {
+        for (size_t i = 0; i < tal_count(invoice_req->offer_paths); i++) {
+            struct blinded_path_hop **blinded_path_hops = invoice_req->offer_paths[i]->path;
+
+            for (size_t j = 0; j < tal_count(blinded_path_hops); j++) {
+                result << ";PATH_" << i << "_HOP=";
+                struct pubkey pubkey = blinded_path_hops[j]->blinded_node_id;
+                uint8_t compressed[33];
+                pubkey_to_der(compressed, &pubkey);
+                result << hex_encode(compressed, 33);
+            }
+        }
+    }
+
+    result << ";ISSUER=";
+    if (invoice_req->offer_issuer) {
+        size_t len = tal_bytelen(invoice_req->offer_issuer);
+        result.write((const char*)invoice_req->offer_issuer, len);
+    }
+
+    result << ";QUANTITY=";
+    if (invoice_req->offer_quantity_max) {
+        result << *invoice_req->offer_quantity_max;
+    }
+
+    result << ";ISSUER_ID=";
+    if (invoice_req->offer_issuer_id) {
+        uint8_t compressed[33];
+        pubkey_to_der(compressed, invoice_req->offer_issuer_id);
+        result << hex_encode(compressed, 33);
+    }
+
+    // invoice_request fields
+    result << ";INV_REQ_METADATA=";
+    if (invoice_req->invreq_metadata) {
+        result << hex_encode(invoice_req->invreq_metadata, tal_bytelen(invoice_req->invreq_metadata));
+    }
+
+    result << ";INV_REQ_CHAIN=";
+    if (invoice_req->invreq_chain) {
+        result << hex_encode(invoice_req->invreq_chain->shad.sha.u.u8, 32);
+    }
+
+    result << ";INV_REQ_AMOUNT=";
+    if (invoice_req->invreq_amount) {
+        result << invoice_req->invreq_amount;
+    }
+
+    result << ";INV_REQ_FEATURES=";
+    if (invoice_req->invreq_features) {
+        result << hex_encode(invoice_req->invreq_features, tal_bytelen(invoice_req->invreq_features));
+    }
+
+    result << ";INV_REQ_QUANTITY=";
+    if (invoice_req->invreq_quantity) {
+        result << invoice_req->invreq_quantity;
+    }
+
+    result << ";INV_REQ_PAYER_ID=";
+    if (invoice_req->invreq_payer_id) {
+        uint8_t compressed[33];
+        pubkey_to_der(compressed, invoice_req->invreq_payer_id);
+        result << hex_encode(compressed, 33);
+    }
+
+    result << ";INV_REQ_PAYER_NOTE=";
+    if (invoice_req->invreq_payer_note) {
+        size_t len = tal_bytelen(invoice_req->invreq_payer_note);
+        result.write((const char*)invoice_req->invreq_payer_note, len);
+    }
+
+    if (invoice_req->invreq_paths) {
+        for (size_t i = 0; i < tal_count(invoice_req->invreq_paths); i++) {
+            struct blinded_path_hop **blinded_path_hops = invoice_req->invreq_paths[i]->path;
+
+            for (size_t j = 0; j < tal_count(blinded_path_hops); j++) {
+                result << ";INV_REQ_PATH_" << i << "_HOP=";
+                struct pubkey pubkey = blinded_path_hops[j]->blinded_node_id;
+                uint8_t compressed[33];
+                pubkey_to_der(compressed, &pubkey);
+                result << hex_encode(compressed, 33);
+            }
+        }
+    }
+
+    result << ";INV_REQ_BIP_353_NAME=";
+    if (invoice_req->invreq_bip_353_name) {
+        result << "NAME=";
+        result << invoice_req->invreq_bip_353_name->name;
+        result << ";DOMAIN=";
+        result << invoice_req->invreq_bip_353_name->domain;
+    }
+    
+    clean_tmpctx();
+    return result.str();
+}
+
 namespace bitcoinfuzz
 {
     namespace module
@@ -246,6 +403,11 @@ namespace bitcoinfuzz
         std::optional<std::string> CLightning::deserialize_offer(std::string str) const
         {
             return clightning_des_offer(str);
+        }
+
+        std::optional<std::string> CLightning::deserialize_invoice_request(std::string str) const
+        {
+            return clightning_des_invoice_request(str);
         }
     }
 }

--- a/modules/clightning/module.h
+++ b/modules/clightning/module.h
@@ -15,6 +15,7 @@ namespace bitcoinfuzz
             CLightning(void);
             std::optional<std::string> deserialize_invoice(std::string str) const override;
             std::optional<std::string> deserialize_offer(std::string str) const override;
+            std::optional<std::string> deserialize_invoice_request(std::string str) const override;
             ~CLightning() noexcept override = default;
         };
 

--- a/modules/ldk/ldk_lib/ldk_lib.h
+++ b/modules/ldk/ldk_lib/ldk_lib.h
@@ -4,4 +4,6 @@ extern "C" char* ldk_des_invoice(const char* input);
 
 extern "C" char* ldk_des_offer(const char* input);
 
+extern "C" char* ldk_des_invoice_request(const char* input);
+
 extern "C" void ldk_free_string(const char* ptr);

--- a/modules/ldk/ldk_lib/src/lib.rs
+++ b/modules/ldk/ldk_lib/src/lib.rs
@@ -1,8 +1,13 @@
+use lightning::bitcoin::bech32::primitives::decode::CheckedHrpstring;
+use lightning::bitcoin::bech32::NoChecksum;
 use lightning::bitcoin::hex::{Case, DisplayHex};
 use lightning::bolt11_invoice::{
     Bolt11Invoice, Bolt11InvoiceDescriptionRef, Bolt11SemanticError, Currency, ParseOrSemanticError,
 };
+use lightning::offers::invoice_request;
 use lightning::offers::offer::{self, Offer};
+use lightning::offers::parse::Bolt12ParseError;
+use lightning::offers::refund::Refund;
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::{ffi::CStr, str::FromStr};
@@ -238,6 +243,226 @@ pub unsafe extern "C" fn ldk_des_offer(input: *const std::os::raw::c_char) -> *m
             if let Some(issuer_id) = offer.issuer_signing_pubkey() {
                 result.push_str(&issuer_id.to_string());
             }
+
+            str_to_c_string(&result)
+        }
+        Err(_) => str_to_c_string(""),
+    }
+}
+
+// The invoice_request type in BOLT12 does not currently provide a method to parse a
+// Bech32-encoded string into raw bytes, so we replicate the necessary Bech32 handling
+// logic from rust-lightning to support this functionality.
+
+// -- lightning/src/offers/parse.rs --
+// Used to avoid copying a bech32 string not containing the continuation character (+).
+enum Bech32String<'a> {
+    Borrowed(&'a str),
+    Owned(String),
+}
+
+impl<'a> AsRef<str> for Bech32String<'a> {
+    fn as_ref(&self) -> &str {
+        match self {
+            Bech32String::Borrowed(s) => s,
+            Bech32String::Owned(s) => s,
+        }
+    }
+}
+
+const INVOICE_REQUEST_BECH32_HRP: &str = "lnr";
+
+fn invoice_request_from_bech32_str(s: &str) -> Result<Vec<u8>, Bolt12ParseError> {
+    // Offer encoding may be split by '+' followed by optional whitespace.
+    let encoded = match s.split('+').skip(1).next() {
+        Some(_) => {
+            for chunk in s.split('+') {
+                let chunk = chunk.trim_start();
+                if chunk.is_empty() || chunk.contains(char::is_whitespace) {
+                    return Err(Bolt12ParseError::InvalidContinuation);
+                }
+            }
+
+            let s: String = s
+                .chars()
+                .filter(|c| *c != '+' && !c.is_whitespace())
+                .collect();
+            Bech32String::Owned(s)
+        }
+        None => Bech32String::Borrowed(s),
+    };
+
+    let parsed = CheckedHrpstring::new::<NoChecksum>(encoded.as_ref())?;
+    let hrp = parsed.hrp();
+    // Compare the lowercase'd iter to allow for all-uppercase HRPs
+    if hrp
+        .lowercase_char_iter()
+        .ne(INVOICE_REQUEST_BECH32_HRP.chars())
+    {
+        return Err(Bolt12ParseError::InvalidBech32Hrp);
+    }
+
+    let data = parsed.byte_iter().collect::<Vec<u8>>();
+    Ok(data)
+}
+// -- end of lightning/src/offers/parse.rs --
+
+#[no_mangle]
+pub unsafe extern "C" fn ldk_des_invoice_request(
+    input: *const std::os::raw::c_char,
+) -> *mut c_char {
+    if input.is_null() {
+        return str_to_c_string("");
+    }
+
+    // Convert C string to Rust string
+    let c_str = match CStr::from_ptr(input).to_str() {
+        Ok(s) => s,
+        Err(_) => return str_to_c_string(""),
+    };
+
+    let bytes = match invoice_request_from_bech32_str(c_str) {
+        Ok(bytes) => bytes,
+        Err(_) => return str_to_c_string(""),
+    };
+
+    match invoice_request::InvoiceRequest::try_from(bytes) {
+        Ok(invoice_req) => {
+            let mut result = String::new();
+
+            // Since we could parse the `InvoiceRequest` struct, we should be
+            // able to parse the `Refund` struct as well.
+            let refund = Refund::from_str(c_str).unwrap();
+
+            // offer fields
+            result.push_str("CHAINS=");
+            invoice_req.chains().iter().for_each(|chain| {
+                result.push_str(&format!("{};", chain.to_string()));
+            });
+
+            result.push_str("METADATA=");
+            if let Some(metadata) = invoice_req.metadata() {
+                result.push_str(&metadata.to_hex_string(Case::Lower));
+            }
+
+            if let Some(amount) = invoice_req.amount() {
+                match amount {
+                    offer::Amount::Bitcoin { amount_msats } => {
+                        result.push_str(";AMOUNT=");
+                        result.push_str(&amount_msats.to_string());
+                    }
+                    offer::Amount::Currency {
+                        iso4217_code,
+                        amount,
+                    } => {
+                        result.push_str(";AMOUNT=");
+                        result.push_str(&amount.to_string());
+                        result.push_str(";CURRENCY=");
+                        let code_str = match std::str::from_utf8(&iso4217_code) {
+                            Ok(s) => s,
+                            Err(_) => "Unknown",
+                        };
+                        result.push_str(code_str);
+                    }
+                }
+            }
+
+            result.push_str(";DESCRIPTION=");
+            if let Some(description) = invoice_req.description() {
+                result.push_str(description.0);
+            }
+
+            result.push_str(";FEATURES=");
+            let features = invoice_req.offer_features();
+            let mut be_flags = features.le_flags().to_vec();
+            be_flags.reverse();
+            result.push_str(be_flags.to_hex_string(Case::Lower).as_str());
+
+            result.push_str(";ABSOLUTE_EXPIRY=");
+            if let Some(absolute_expiry) = invoice_req.absolute_expiry() {
+                result.push_str(absolute_expiry.as_secs().to_string().as_str());
+            }
+
+            invoice_req
+                .paths()
+                .iter()
+                .enumerate()
+                .for_each(|(i, path)| {
+                    path.blinded_hops().iter().for_each(|hop| {
+                        result.push_str(&format!(";PATH_{}_HOP=", i));
+                        result.push_str(hop.blinded_node_id.to_string().as_str());
+                    });
+                });
+
+            result.push_str(";ISSUER=");
+            if let Some(issuer) = invoice_req.issuer() {
+                result.push_str(issuer.0);
+            }
+
+            result.push_str(";QUANTITY=");
+            let quantity = invoice_req.supported_quantity();
+            match quantity {
+                offer::Quantity::Bounded(n) => result.push_str(&n.to_string()),
+                _ => (),
+            }
+
+            result.push_str(";ISSUER_ID=");
+            if let Some(issuer_id) = invoice_req.issuer_signing_pubkey() {
+                result.push_str(&issuer_id.to_string());
+            }
+
+            // invoice_request fields
+            result.push_str(";INV_REQ_METADATA=");
+            result.push_str(&invoice_req.payer_metadata().to_hex_string(Case::Lower));
+
+            result.push_str(";INV_REQ_CHAIN=");
+            result.push_str(&invoice_req.chain().to_string());
+
+            result.push_str(";INV_REQ_AMOUNT=");
+            if let Some(amount) = invoice_req.amount_msats() {
+                result.push_str(&amount.to_string());
+            }
+
+            result.push_str(";INV_REQ_FEATURES=");
+            let features = invoice_req.invoice_request_features();
+            let mut be_flags = features.le_flags().to_vec();
+            be_flags.reverse();
+            result.push_str(be_flags.to_hex_string(Case::Lower).as_str());
+
+            result.push_str(";INV_REQ_QUANTITY=");
+            if let Some(quantity) = invoice_req.quantity() {
+                result.push_str(&quantity.to_string());
+            }
+
+            result.push_str(";INV_REQ_PAYER_ID=");
+            result.push_str(&invoice_req.payer_signing_pubkey().to_string());
+
+            result.push_str(";INV_REQ_PAYER_NOTE=");
+            if let Some(payer_note) = invoice_req.payer_note() {
+                result.push_str(payer_note.0);
+            }
+
+            refund
+                .paths()
+                .iter()
+                .enumerate()
+                .for_each(|(i, path)| {
+                    path.blinded_hops().iter().for_each(|hop| {
+                        result.push_str(&format!(";INV_REQ_PATH_{}_HOP=", i));
+                        result.push_str(hop.blinded_node_id.to_string().as_str());
+                    });
+                });
+
+            result.push_str(";INV_REQ_BIP_353_NAME=");
+            if let Some(human_readable) = invoice_req.offer_from_hrn() {
+                result.push_str("NAME=");
+                result.push_str(human_readable.user());
+                result.push_str(";DOMAIN=");
+                result.push_str(human_readable.domain());
+            }
+
+            result.push_str(";INV_REQ_SIGNATURE=");
+            result.push_str(&invoice_req.signature().to_string());
 
             str_to_c_string(&result)
         }

--- a/modules/ldk/module.cpp
+++ b/modules/ldk/module.cpp
@@ -30,5 +30,16 @@ namespace bitcoinfuzz
             ldk_free_string(result);
             return result_str;
         }
+
+        std::optional<std::string> Ldk::deserialize_invoice_request(std::string str) const
+        {
+            auto result = ldk_des_invoice_request(str.c_str());
+            if (result == nullptr) {
+                return std::nullopt;
+            }
+            std::string result_str(result);
+            ldk_free_string(result);
+            return result_str;
+        }
     }
 }

--- a/modules/ldk/module.h
+++ b/modules/ldk/module.h
@@ -15,6 +15,7 @@ namespace bitcoinfuzz
             Ldk(void);
             std::optional<std::string> deserialize_invoice(std::string str) const override;
             std::optional<std::string> deserialize_offer(std::string str) const override;
+            std::optional<std::string> deserialize_invoice_request(std::string str) const override;
             ~Ldk() noexcept override = default;
         };
 


### PR DESCRIPTION
This PR adds a new fuzzing target for BOLT12 offer decoding to our differential fuzzing. It implements the `deserialize_invoice_request` target and adds support for it in the `clightning` and `ldk` modules.

Closes #164