### PR TITLE
Update NLightning to version 4.0.0 and .NET SDK to version 9.0

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "9.0.x"
 
       - name: Setup Python and install embit
         uses: actions/setup-python@v5

--- a/modules/nlightning/src/Bolts/BOLT11/InvoiceBridge.cs
+++ b/modules/nlightning/src/Bolts/BOLT11/InvoiceBridge.cs
@@ -3,7 +3,8 @@ using System.Runtime.InteropServices;
 namespace NLightning.CppBridge.Bolts.BOLT11;
 
 using System.Text;
-using NLightning.Bolts.BOLT11;
+using NLightning.Bolt11.Models;
+
 public static class InvoiceBridge
 {
     [UnmanagedCallersOnly(EntryPoint = "DecodeInvoice")]
@@ -22,7 +23,7 @@ public static class InvoiceBridge
             StringBuilder resultBuilder = new();
 
             resultBuilder.Append("HASH=").Append(invoice.PaymentHash);
-            resultBuilder.Append(";AMOUNT=").Append(invoice.AmountMilliSats);
+            resultBuilder.Append(";AMOUNT=").Append(invoice.Amount.MilliSatoshi);
             resultBuilder.Append(";DESCRIPTION=").Append(invoice.Description);
             resultBuilder.Append(";RECIPIENT=").Append(invoice.PayeePubKey);
             resultBuilder.Append(";EXPIRY=").Append((int)(invoice.ExpiryDate - DateTimeOffset.FromUnixTimeSeconds(invoice.Timestamp)).TotalSeconds);

--- a/modules/nlightning/src/NLightning.CppBridge.csproj
+++ b/modules/nlightning/src/NLightning.CppBridge.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>NLightning.CppBridge</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLightning.Bolt11" Version="0.2.4" />
+    <PackageReference Include="NLightning.Bolt11" Version="4.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgraded NLightning to version 4.0.0 (see [release notes](https://github.com/ipms-io/nlightning/releases/tag/bolt11-v4.0.0)), which introduces stricter validation of required fields in BOLT11 invoices. This change improves protocol compliance and ensures convergence with other Lightning implementations.

Also updated the .NET SDK to version 9.0 to match NLightning’s new target framework.
