### PR TITLE
bitcoin: drop Boost usage

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -59,15 +59,10 @@ jobs:
           export PATH="$(brew --prefix llvm@18)/bin:$PATH"
         shell: bash
 
-      - name: Install Boost - Ubuntu
-        if: matrix.os == 'ubuntu-24.04'
-        run: |
-          sudo apt install libboost-all-dev
-
-      - name: Install Boost and build dependencies - macOS
+      - name: Install build dependencies - macOS
         if: matrix.os == 'macos-14'
         run: |
-          brew install boost autoconf gnu-sed automake libtool gettext pkg-config protobuf libsodium
+          brew install autoconf gnu-sed automake libtool gettext pkg-config protobuf libsodium
 
       - name: Setup common environment - Ubuntu
         if: matrix.os == 'ubuntu-24.04'
@@ -88,10 +83,7 @@ jobs:
       - name: Build - Bitcoin Core
         timeout-minutes: 40
         run: |
-          if [ "${{ matrix.os }}" == "ubuntu-24.04" ]; then
-            export BOOST_LIB_DIR=/usr/lib/x86_64-linux-gnu/
-          elif [ "${{ matrix.os }}" == "macos-14" ]; then
-            export BOOST_LIB_DIR=$(brew --prefix boost)/lib/
+          if [ "${{ matrix.os }}" == "macos-14" ]; then
             export PATH="/usr/local/opt/autoconf/bin:/usr/local/opt/automake/bin:/usr/local/opt/libtool/bin:$PATH"
           fi
           cd modules/bitcoin && make

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,14 +44,9 @@ RUN apt-get update && apt-get install -y \
     ln -sfT /usr/bin/clang-18 /usr/bin/clang && \
     rm -rf /var/lib/apt/lists/*
 
-# Installs Boost
-RUN apt-get update && apt-get install -y libboost-all-dev && \
-    rm -rf /var/lib/apt/lists/*
-
 # Configures environment variables
 ENV CC=/usr/bin/clang
 ENV CXX=/usr/bin/clang++
-ENV BOOST_LIB_DIR=/usr/lib/x86_64-linux-gnu/
 ENV LDFLAGS="-lsodium"
 
 # Working directory

--- a/README.md
+++ b/README.md
@@ -27,22 +27,6 @@ Note this project is a WIP and might be not stable.
 
 * To install it from source check [clang_get_started](https://clang.llvm.org/get_started.html). You must build it with this cmake option: `-DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt"`
 
-
-### boost
-
-To build the bitcoin core module the boost library is required. Minimum version
-
-The module uses only libboost-filesystem and libboost-system modules. For ubuntu you can install with:
-
-```
-sudo apt install libboost-filesystem-dev libboost-system-dev
-```
-
-Or install the complete boost library with
-```
-sudo apt install libboost-all-dev
-```
-
 # Build Options
 
 You can build the modules in two ways: **manual** or **automatic**. The automatic method is provided by the `auto_build.sh` script, which simplifies the build and clean processes. Additionally, you can use **Docker** or **Docker Compose** to run the application without installing dependencies directly on your machine.
@@ -208,7 +192,6 @@ If you prefer, you can still build the modules manually. Below are the steps for
     cd modules/bitcoin
     make
     export CXXFLAGS="$CXXFLAGS -DBITCOIN_CORE"
-    export BOOST_LIB_DIR="path/to/boost/"
     ```
 
 ### Lightning modules:

--- a/modules/bitcoin/Makefile
+++ b/modules/bitcoin/Makefile
@@ -12,18 +12,6 @@ CXXFLAGS += -Wall -Wextra -std=c++20 \
             -I ./primitives \
             -I ./script
 
-UNAME_S := $(shell uname -s)
-
-ifeq ($(UNAME_S), Darwin)
-	BOOST_LIB_DIR ?= /opt/homebrew/lib/
-endif
-
-ifeq ($(UNAME_S), Linux)
-	BOOST_LIB_DIR ?= /usr/lib/
-endif
-
-BOOST_FILESYSTEM = $(BOOST_LIB_DIR)libboost_filesystem.a
-BOOST_SYSTEM = $(BOOST_LIB_DIR)libboost_system.a
 SECP256K1_LIB = ../secp256k1/.libs/libsecp256k1.a
 UNIVALUE_LIB = ../univalue/build/libunivalue.a
 MAKE = make
@@ -50,14 +38,6 @@ $(UNIVALUE_LIB):
 module.a: $(SECP256K1_LIB) $(UNIVALUE_LIB) module.o cleanse.o $(BITCOIN_OBJS)
 	$(AR) rcs $@ module.o cleanse.o $(BITCOIN_OBJS)
 	mkdir -p tmp_obj
-	# Extract and add Boost filesystem
-	cd tmp_obj && $(AR) x "$(BOOST_FILESYSTEM)"
-	$(AR) rcs $@ tmp_obj/*.o
-	rm -rf tmp_obj/*
-	# Extract and add Boost system
-	cd tmp_obj && $(AR) x "$(BOOST_SYSTEM)"
-	$(AR) rcs $@ tmp_obj/*.o
-	rm -rf tmp_obj/*
 	# Extract and add secp256k1
 	cd tmp_obj && $(AR) x "$(SECP256K1_LIB)"
 	$(AR) rcs $@ tmp_obj/*.o


### PR DESCRIPTION
I was following the instructions for a manual build of the bitcoin module, and it wasn't clear why Core would have a dependency on Boost. It seems like everything builds fine without it? The only (real) reference to Boost I could find is in the `interfaces/handler.h` header.