### PR TITLE
Add Target for Bitcoin p2p message parsing

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -199,6 +199,12 @@ jobs:
           make
           FUZZ=cmpctblocks_parse ./bitcoinfuzz -runs=100
 
+      - name: Test - parse_p2p_message
+        run: |
+          export CXXFLAGS="-DRUST_BITCOIN -DBTCD -DCUSTOM_MUTATOR_P2P_MESSAGE"
+          make
+          ASAN_OPTIONS=detect_leaks=0 FUZZ=parse_p2p_message ./bitcoinfuzz -runs=100
+
       - name: Test - deserialize_invoice
         run: |
           export CXXFLAGS="-DLDK -DLND -DCLIGHTNING -DCUSTOM_MUTATOR_BOLT11"

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ The `docker-compose.yml` file simplifies running multiple fuzzing scenarios. Eac
      ├── deserialize_invoice/
      ├── address_parse/
      ├── addrv2/
-     └── psbt_parse/
+     ├── psbt_parse/
+     └── parse_p2p_message/
      ```
    - To ensure the corpus is saved locally, the `docker-compose.yml` file maps the `/app/data` directory inside the container to the corresponding subdirectory in `docker`.
 

--- a/auto_build.sh
+++ b/auto_build.sh
@@ -72,8 +72,12 @@ custom_mutator_bolt12_offer() {
     execute_in_module "modules/custommutator" "$1"
 }
 
+custom_mutator_p2p_message() {
+    execute_in_module "modules/custommutator" "$1"
+}
+
 # Define the list of modules
-modules="bitcoin_core rust_bitcoin rust_miniscript btcd nbitcoin embit lnd ldk nlightning clightning custom_mutator_bolt11 custom_mutator_bolt12_offer"
+modules="bitcoin_core rust_bitcoin rust_miniscript btcd nbitcoin embit lnd ldk nlightning clightning custom_mutator_bolt11 custom_mutator_bolt12_offer custom_mutator_p2p_message"
 
 # Full clean: runs `make clean` in all module directories
 full_clean() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,17 @@ services:
     volumes:
       - ./docker/addrv2:/app/data
 
+  parse_p2p_message:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      <<: *common-env
+      CXXFLAGS: "-DRUST_BITCOIN -DBTCD -DCUSTOM_MUTATOR_P2P_MESSAGE"
+      FUZZ: parse_p2p_message
+    volumes:
+      - ./docker/parse_p2p_message:/app/data
+
   psbt_parse:
     build:
       context: .

--- a/driver.cpp
+++ b/driver.cpp
@@ -326,6 +326,31 @@ namespace bitcoinfuzz
         }
     }
 
+    void Driver::ParseP2PMessageTarget(std::span<const uint8_t> buffer) const
+    {
+        std::optional<std::string> last_response{std::nullopt};
+        std::string last_module_name;
+
+        for (auto &module : modules)
+        {
+            std::optional<std::string> res{module.second->parse_p2p_message(buffer)};
+            if (!res.has_value()) continue;
+            if (last_response.has_value()) {
+                if (*res != *last_response) {
+                    std::cout << "P2P message parsing failed" << std::endl;
+                    std::cout << "Module: " << module.first << std::endl;
+                    std::cout << "Result: " << *res << std::endl;
+                    std::cout << "Module: " << last_module_name << std::endl;
+                    std::cout << "Result: " << *last_response << std::endl;
+                }
+                assert(*res == *last_response);
+            }
+
+            last_response = res.value();
+            last_module_name = module.first;
+        }
+    }
+
     void Driver::Run(const uint8_t *data, const size_t size, const std::string &target) const
     {
         std::span<const uint8_t> buffer{data, size};
@@ -353,6 +378,8 @@ namespace bitcoinfuzz
             this->OfferDeserializationTarget(buffer);
         } else if (target == "cmpctblocks_parse") {
             this->CompactBlocksTarget(buffer);
+        } else if (target == "parse_p2p_message") {
+            this->ParseP2PMessageTarget(buffer);
         } else {
             std::cout << "Target not defined!" << std::endl;
             assert(false);

--- a/driver.h
+++ b/driver.h
@@ -32,5 +32,6 @@ namespace bitcoinfuzz
         void AddrV2Target(std::span<const uint8_t> buffer) const;
         void OfferDeserializationTarget(std::span<const uint8_t> buffer) const;
         void CompactBlocksTarget(std::span<const uint8_t> buffer) const;
+        void ParseP2PMessageTarget(std::span<const uint8_t> buffer) const;
     };
 }

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -67,4 +67,9 @@ namespace bitcoinfuzz
     {
         return std::nullopt;
     }
+    
+    std::optional<std::string> BaseModule::parse_p2p_message(std::span<const uint8_t> buffer) const
+    {
+        return std::nullopt;
+    }
 }

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -29,6 +29,8 @@ namespace bitcoinfuzz
         virtual std::optional<std::string> addrv2_parse(std::span<const uint8_t> buffer) const;
         virtual std::optional<std::string> deserialize_offer(std::string str) const;
         virtual std::optional<int> cmpctblocks_parse(std::span<const uint8_t> buffer) const;
+        virtual std::optional<std::string> parse_p2p_message(std::span<const uint8_t> buffer) const;
+        
         virtual ~BaseModule() noexcept;
     };
 }

--- a/main.cpp
+++ b/main.cpp
@@ -161,6 +161,77 @@ extern "C" size_t LLVMFuzzerCustomCrossOver(const uint8_t *in1, size_t in1_size,
 #endif
 
 
+#ifdef CUSTOM_MUTATOR_P2P_MESSAGE
+// Custom mutator for Bitcoin P2P messages that maintains valid checksums.
+// This enables efficient fuzzing of Bitcoin message parsing logic without
+// the fuzzer getting stuck on checksum validation failures.
+//
+// This custom mutator does the following:
+//   1. Mutate the input using libFuzzer's default mutator `LLVMFuzzerMutate`
+//   2. If the data is large enough to contain a header, recalculate and fix the checksum
+//   3. Return the mutated data with valid checksum
+
+#include <cstring>
+#include <cstdlib>
+#include <algorithm>
+#include <modules/custommutator/crypto/sha256.h>
+
+extern "C" size_t LLVMFuzzerMutate(uint8_t *Data, size_t Size, size_t MaxSize);
+extern "C" size_t LLVMFuzzerCustomMutator(uint8_t *fuzz_data, size_t size, size_t max_size,
+                                         unsigned int seed);
+
+// Bitcoin message constants
+static constexpr size_t BITCOIN_HEADER_SIZE = 24;
+static constexpr size_t PAYLOAD_LENGTH_OFFSET = 16;
+static constexpr size_t CHECKSUM_OFFSET = 20;
+
+// Bitcoin double SHA256 using Bitcoin Core's CSHA256 class
+static void bitcoin_double_sha256(const uint8_t* data, size_t len, uint8_t* hash) {
+    CSHA256 hasher;
+    hasher.Write(data, len);
+    unsigned char first_hash[CSHA256::OUTPUT_SIZE];
+    hasher.Finalize(first_hash);
+    
+    hasher.Reset();
+    hasher.Write(first_hash, CSHA256::OUTPUT_SIZE);
+    hasher.Finalize(hash);
+}
+
+// Fix the checksum in a Bitcoin P2P message
+static void fix_bitcoin_checksum(uint8_t* data, size_t size) {
+    if (size < BITCOIN_HEADER_SIZE) {
+        return;
+    }
+    
+    uint32_t payload_length;
+    memcpy(&payload_length, data + PAYLOAD_LENGTH_OFFSET, 4);
+    
+    // Validate that we have the complete message
+    if (size < BITCOIN_HEADER_SIZE + payload_length) {
+        return;
+    }
+    
+    // Calculate checksum for the payload
+    const uint8_t* payload = data + BITCOIN_HEADER_SIZE;
+    uint8_t calculated_checksum[32];
+    bitcoin_double_sha256(payload, payload_length, calculated_checksum);
+    
+    // Update checksum in header (first 4 bytes of hash)
+    memcpy(data + CHECKSUM_OFFSET, calculated_checksum, 4);
+}
+
+size_t LLVMFuzzerCustomMutator(uint8_t *fuzz_data, size_t size, size_t max_size,
+                               unsigned int seed) {
+    // First, mutate the data using LibFuzzer's default mutator
+    size_t new_size = LLVMFuzzerMutate(fuzz_data, size, max_size);
+    
+    // Then fix the checksum if the data looks like it could be a Bitcoin message
+    fix_bitcoin_checksum(fuzz_data, new_size);
+    
+    return new_size;
+}
+#endif
+
 #ifdef CUSTOM_MUTATOR_BOLT11
 // We use a custom mutator to produce an input corpus that consists entirely of
 // correctly encoded bech32 strings. This enables us to efficiently fuzz the

--- a/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
+++ b/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
@@ -86,6 +86,7 @@ extern "C" {
 #endif
 
 extern int BTCDEvalScript(ByteArray scriptData, uint32_t flags);
+extern char* BTCDParseP2PMessage(ByteArray messageData);
 extern char* BTCDAddrv2(ByteArray addrv2Data);
 extern char* BTCDScriptAsm(ByteArray scriptData);
 extern char* BTCDDesBlock(ByteArray scriptData);

--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -59,6 +59,19 @@ func BTCDEvalScript(scriptData C.ByteArray, flags C.uint32_t) C.int {
 	return 1
 }
 
+//export BTCDParseP2PMessage
+func BTCDParseP2PMessage(messageData C.ByteArray) *C.char {
+	data := C.GoBytes(unsafe.Pointer(messageData.data), messageData.length)
+	reader := bytes.NewReader(data)
+
+	_, msg, _, err := wire.ReadMessageN(reader, 70016, wire.MainNet)
+	if err != nil {
+		return C.CString("0")
+	}
+
+	return C.CString(msg.Command())
+}
+
 //export BTCDAddrv2
 func BTCDAddrv2(addrv2Data C.ByteArray) *C.char {
 	data := C.GoBytes(unsafe.Pointer(addrv2Data.data), addrv2Data.length)

--- a/modules/btcd/module.cpp
+++ b/modules/btcd/module.cpp
@@ -1,4 +1,5 @@
 #include <span>
+#include <cstring>
 
 #include "module.h"
 #include "btcd_wrapper/libbtcd_wrapper.h"
@@ -16,6 +17,27 @@ namespace bitcoinfuzz
                 .length = static_cast<int>(input_data.size())};
 
             return BTCDEvalScript(script_data, /*flags=*/0) == 1;
+        }
+
+        std::optional<std::string> Btcd::parse_p2p_message(std::span<const uint8_t> buffer) const
+        {
+            ByteArray message_data{
+                .data = reinterpret_cast<char *>(const_cast<uint8_t *>(buffer.data())),
+                .length = static_cast<int>(buffer.size())};
+
+            const auto message_res = BTCDParseP2PMessage(message_data);
+        
+            if (message_res == nullptr) {
+                return std::nullopt;
+            }
+            if (strlen(message_res) == 0) {
+                free(message_res);
+                return std::nullopt;
+            }
+
+            std::string res(message_res);
+            free(message_res);
+            return res;
         }
 
         std::optional<std::string> Btcd::script_asm(std::span<const uint8_t> buffer) const

--- a/modules/btcd/module.h
+++ b/modules/btcd/module.h
@@ -19,6 +19,7 @@ namespace bitcoinfuzz
             std::optional<std::string> address_parse(std::string str) const override;
             std::optional<std::string> psbt_parse(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> addrv2_parse(std::span<const uint8_t> buffer) const override;
+            std::optional<std::string> parse_p2p_message(std::span<const uint8_t> buffer) const override;
             ~Btcd() noexcept override = default;
         };
 

--- a/modules/custommutator/bitcoin-build-config.h
+++ b/modules/custommutator/bitcoin-build-config.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#ifndef BITCOIN_CONFIG_H
+#define BITCOIN_CONFIG_H
+
+// Use random/fake values here
+
+/* Version Build */
+#define CLIENT_VERSION_BUILD 9999
+
+/* Version is release */
+#define CLIENT_VERSION_IS_RELEASE 9999
+
+/* Major version */
+#define CLIENT_VERSION_MAJOR 9999
+
+/* Minor version */
+#define CLIENT_VERSION_MINOR 9998
+
+/* Copyright holder(s) before %s replacement */
+#define COPYRIGHT_HOLDERS "Bitcoin Core"
+
+/* Copyright holder(s) */
+#define COPYRIGHT_HOLDERS_FINAL "Bitcoin Core"
+
+/* Replacement for %s in copyright holders string */
+#define COPYRIGHT_HOLDERS_SUBSTITUTION "Bitcoin Core"
+
+/* Copyright year */
+#define COPYRIGHT_YEAR 2024
+
+/* Define to the address where bug reports for this package should be sent. */
+#define CLIENT_BUGREPORT "Bitcoin Core"
+
+/* Define to the full name of this package. */
+#define CLIENT_NAME "Bitcoin Core"
+
+/* Define to the home page for this package. */
+#define CLIENT_URL "Bitcoin Core"
+
+/* Define to the version of this package. */
+#define CLIENT_VERSION_STRING "Bitcoin Core"
+
+#endif //BITCOIN_CONFIG_H

--- a/modules/custommutator/compat/byteswap.h
+++ b/modules/custommutator/compat/byteswap.h
@@ -1,0 +1,79 @@
+// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMPAT_BYTESWAP_H
+#define BITCOIN_COMPAT_BYTESWAP_H
+
+#include <cstdint>
+#ifdef _MSC_VER
+#include <cstdlib>
+#endif
+
+
+// All internal_bswap_* functions can be replaced with std::byteswap once we
+// require c++23. Both libstdc++ and libc++ implement std::byteswap via these
+// builtins.
+
+#ifndef DISABLE_BUILTIN_BSWAPS
+#  if defined __has_builtin
+#    if __has_builtin(__builtin_bswap16)
+#      define bitcoin_builtin_bswap16(x) __builtin_bswap16(x)
+#    endif
+#    if __has_builtin(__builtin_bswap32)
+#      define bitcoin_builtin_bswap32(x) __builtin_bswap32(x)
+#    endif
+#    if __has_builtin(__builtin_bswap64)
+#      define bitcoin_builtin_bswap64(x) __builtin_bswap64(x)
+#    endif
+#  elif defined(_MSC_VER)
+#      define bitcoin_builtin_bswap16(x) _byteswap_ushort(x)
+#      define bitcoin_builtin_bswap32(x) _byteswap_ulong(x)
+#      define bitcoin_builtin_bswap64(x) _byteswap_uint64(x)
+#  endif
+#endif
+
+// MSVC's _byteswap_* functions are not constexpr
+
+#ifndef _MSC_VER
+#define BSWAP_CONSTEXPR constexpr
+#else
+#define BSWAP_CONSTEXPR
+#endif
+
+inline BSWAP_CONSTEXPR uint16_t internal_bswap_16(uint16_t x)
+{
+#ifdef bitcoin_builtin_bswap16
+    return bitcoin_builtin_bswap16(x);
+#else
+    return (x >> 8) | (x << 8);
+#endif
+}
+
+inline BSWAP_CONSTEXPR uint32_t internal_bswap_32(uint32_t x)
+{
+#ifdef bitcoin_builtin_bswap32
+    return bitcoin_builtin_bswap32(x);
+#else
+    return (((x & 0xff000000U) >> 24) | ((x & 0x00ff0000U) >>  8) |
+            ((x & 0x0000ff00U) <<  8) | ((x & 0x000000ffU) << 24));
+#endif
+}
+
+inline BSWAP_CONSTEXPR uint64_t internal_bswap_64(uint64_t x)
+{
+#ifdef bitcoin_builtin_bswap64
+    return bitcoin_builtin_bswap64(x);
+#else
+     return (((x & 0xff00000000000000ull) >> 56)
+          | ((x & 0x00ff000000000000ull) >> 40)
+          | ((x & 0x0000ff0000000000ull) >> 24)
+          | ((x & 0x000000ff00000000ull) >> 8)
+          | ((x & 0x00000000ff000000ull) << 8)
+          | ((x & 0x0000000000ff0000ull) << 24)
+          | ((x & 0x000000000000ff00ull) << 40)
+          | ((x & 0x00000000000000ffull) << 56));
+#endif
+}
+
+#endif // BITCOIN_COMPAT_BYTESWAP_H

--- a/modules/custommutator/compat/cpuid.h
+++ b/modules/custommutator/compat/cpuid.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2017-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMPAT_CPUID_H
+#define BITCOIN_COMPAT_CPUID_H
+
+#if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+#define HAVE_GETCPUID
+
+#include <cpuid.h>
+
+#include <cstdint>
+
+// We can't use cpuid.h's __get_cpuid as it does not support subleafs.
+void static inline GetCPUID(uint32_t leaf, uint32_t subleaf, uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d)
+{
+#ifdef __GNUC__
+    __cpuid_count(leaf, subleaf, a, b, c, d);
+#else
+  __asm__ ("cpuid" : "=a"(a), "=b"(b), "=c"(c), "=d"(d) : "0"(leaf), "2"(subleaf));
+#endif
+}
+
+#endif // defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+#endif // BITCOIN_COMPAT_CPUID_H

--- a/modules/custommutator/compat/endian.h
+++ b/modules/custommutator/compat/endian.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMPAT_ENDIAN_H
+#define BITCOIN_COMPAT_ENDIAN_H
+
+#include <compat/byteswap.h>
+
+#include <bit>
+#include <cstdint>
+
+inline BSWAP_CONSTEXPR uint16_t htobe16_internal(uint16_t host_16bits)
+{
+    if constexpr (std::endian::native == std::endian::little) return internal_bswap_16(host_16bits);
+        else return host_16bits;
+}
+inline BSWAP_CONSTEXPR uint16_t htole16_internal(uint16_t host_16bits)
+{
+    if constexpr (std::endian::native == std::endian::big) return internal_bswap_16(host_16bits);
+        else return host_16bits;
+}
+inline BSWAP_CONSTEXPR uint16_t be16toh_internal(uint16_t big_endian_16bits)
+{
+    if constexpr (std::endian::native == std::endian::little) return internal_bswap_16(big_endian_16bits);
+        else return big_endian_16bits;
+}
+inline BSWAP_CONSTEXPR uint16_t le16toh_internal(uint16_t little_endian_16bits)
+{
+    if constexpr (std::endian::native == std::endian::big) return internal_bswap_16(little_endian_16bits);
+        else return little_endian_16bits;
+}
+inline BSWAP_CONSTEXPR uint32_t htobe32_internal(uint32_t host_32bits)
+{
+    if constexpr (std::endian::native == std::endian::little) return internal_bswap_32(host_32bits);
+        else return host_32bits;
+}
+inline BSWAP_CONSTEXPR uint32_t htole32_internal(uint32_t host_32bits)
+{
+    if constexpr (std::endian::native == std::endian::big) return internal_bswap_32(host_32bits);
+        else return host_32bits;
+}
+inline BSWAP_CONSTEXPR uint32_t be32toh_internal(uint32_t big_endian_32bits)
+{
+    if constexpr (std::endian::native == std::endian::little) return internal_bswap_32(big_endian_32bits);
+        else return big_endian_32bits;
+}
+inline BSWAP_CONSTEXPR uint32_t le32toh_internal(uint32_t little_endian_32bits)
+{
+    if constexpr (std::endian::native == std::endian::big) return internal_bswap_32(little_endian_32bits);
+        else return little_endian_32bits;
+}
+inline BSWAP_CONSTEXPR uint64_t htobe64_internal(uint64_t host_64bits)
+{
+    if constexpr (std::endian::native == std::endian::little) return internal_bswap_64(host_64bits);
+        else return host_64bits;
+}
+inline BSWAP_CONSTEXPR uint64_t htole64_internal(uint64_t host_64bits)
+{
+    if constexpr (std::endian::native == std::endian::big) return internal_bswap_64(host_64bits);
+        else return host_64bits;
+}
+inline BSWAP_CONSTEXPR uint64_t be64toh_internal(uint64_t big_endian_64bits)
+{
+    if constexpr (std::endian::native == std::endian::little) return internal_bswap_64(big_endian_64bits);
+        else return big_endian_64bits;
+}
+inline BSWAP_CONSTEXPR uint64_t le64toh_internal(uint64_t little_endian_64bits)
+{
+    if constexpr (std::endian::native == std::endian::big) return internal_bswap_64(little_endian_64bits);
+        else return little_endian_64bits;
+}
+
+#endif // BITCOIN_COMPAT_ENDIAN_H

--- a/modules/custommutator/crypto/common.h
+++ b/modules/custommutator/crypto/common.h
@@ -1,0 +1,108 @@
+// Copyright (c) 2014-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CRYPTO_COMMON_H
+#define BITCOIN_CRYPTO_COMMON_H
+
+#include <compat/endian.h>
+
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+template <typename B>
+concept ByteType = std::same_as<B, unsigned char> || std::same_as<B, std::byte>;
+
+template <ByteType B>
+inline uint16_t ReadLE16(const B* ptr)
+{
+    uint16_t x;
+    memcpy(&x, ptr, 2);
+    return le16toh_internal(x);
+}
+
+template <ByteType B>
+inline uint32_t ReadLE32(const B* ptr)
+{
+    uint32_t x;
+    memcpy(&x, ptr, 4);
+    return le32toh_internal(x);
+}
+
+template <ByteType B>
+inline uint64_t ReadLE64(const B* ptr)
+{
+    uint64_t x;
+    memcpy(&x, ptr, 8);
+    return le64toh_internal(x);
+}
+
+template <ByteType B>
+inline void WriteLE16(B* ptr, uint16_t x)
+{
+    uint16_t v = htole16_internal(x);
+    memcpy(ptr, &v, 2);
+}
+
+template <ByteType B>
+inline void WriteLE32(B* ptr, uint32_t x)
+{
+    uint32_t v = htole32_internal(x);
+    memcpy(ptr, &v, 4);
+}
+
+template <ByteType B>
+inline void WriteLE64(B* ptr, uint64_t x)
+{
+    uint64_t v = htole64_internal(x);
+    memcpy(ptr, &v, 8);
+}
+
+template <ByteType B>
+inline uint16_t ReadBE16(const B* ptr)
+{
+    uint16_t x;
+    memcpy(&x, ptr, 2);
+    return be16toh_internal(x);
+}
+
+template <ByteType B>
+inline uint32_t ReadBE32(const B* ptr)
+{
+    uint32_t x;
+    memcpy(&x, ptr, 4);
+    return be32toh_internal(x);
+}
+
+template <ByteType B>
+inline uint64_t ReadBE64(const B* ptr)
+{
+    uint64_t x;
+    memcpy(&x, ptr, 8);
+    return be64toh_internal(x);
+}
+
+template <ByteType B>
+inline void WriteBE16(B* ptr, uint16_t x)
+{
+    uint16_t v = htobe16_internal(x);
+    memcpy(ptr, &v, 2);
+}
+
+template <ByteType B>
+inline void WriteBE32(B* ptr, uint32_t x)
+{
+    uint32_t v = htobe32_internal(x);
+    memcpy(ptr, &v, 4);
+}
+
+template <ByteType B>
+inline void WriteBE64(B* ptr, uint64_t x)
+{
+    uint64_t v = htobe64_internal(x);
+    memcpy(ptr, &v, 8);
+}
+
+#endif // BITCOIN_CRYPTO_COMMON_H

--- a/modules/custommutator/crypto/sha256.h
+++ b/modules/custommutator/crypto/sha256.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CRYPTO_SHA256_H
+#define BITCOIN_CRYPTO_SHA256_H
+
+#include <cstdlib>
+#include <stdint.h>
+#include <string>
+
+/** A hasher class for SHA-256. */
+class CSHA256
+{
+private:
+    uint32_t s[8];
+    unsigned char buf[64];
+    uint64_t bytes{0};
+
+public:
+    static const size_t OUTPUT_SIZE = 32;
+
+    CSHA256();
+    CSHA256& Write(const unsigned char* data, size_t len);
+    void Finalize(unsigned char hash[OUTPUT_SIZE]);
+    CSHA256& Reset();
+};
+
+namespace sha256_implementation {
+enum UseImplementation : uint8_t {
+    STANDARD = 0,
+    USE_SSE4 = 1 << 0,
+    USE_AVX2 = 1 << 1,
+    USE_SHANI = 1 << 2,
+    USE_SSE4_AND_AVX2 = USE_SSE4 | USE_AVX2,
+    USE_SSE4_AND_SHANI = USE_SSE4 | USE_SHANI,
+    USE_ALL = USE_SSE4 | USE_AVX2 | USE_SHANI,
+};
+}
+
+/** Autodetect the best available SHA256 implementation.
+ *  Returns the name of the implementation.
+ */
+std::string SHA256AutoDetect(sha256_implementation::UseImplementation use_implementation = sha256_implementation::USE_ALL);
+
+/** Compute multiple double-SHA256's of 64-byte blobs.
+ *  output:  pointer to a blocks*32 byte output buffer
+ *  input:   pointer to a blocks*64 byte input buffer
+ *  blocks:  the number of hashes to compute.
+ */
+void SHA256D64(unsigned char* output, const unsigned char* input, size_t blocks);
+
+#endif // BITCOIN_CRYPTO_SHA256_H

--- a/modules/custommutator/sha256.cpp
+++ b/modules/custommutator/sha256.cpp
@@ -1,0 +1,783 @@
+// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bitcoin-build-config.h> // IWYU pragma: keep
+
+#include <crypto/sha256.h>
+#include <crypto/common.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+
+#if !defined(DISABLE_OPTIMIZED_SHA256)
+#include <compat/cpuid.h>
+
+#if defined(__linux__) && defined(ENABLE_ARM_SHANI)
+#include <sys/auxv.h>
+#include <asm/hwcap.h>
+#endif
+
+#if defined(__APPLE__) && defined(ENABLE_ARM_SHANI)
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#endif
+
+#if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+namespace sha256_sse4
+{
+void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks);
+}
+#endif
+
+namespace sha256d64_sse41
+{
+void Transform_4way(unsigned char* out, const unsigned char* in);
+}
+
+namespace sha256d64_avx2
+{
+void Transform_8way(unsigned char* out, const unsigned char* in);
+}
+
+namespace sha256d64_x86_shani
+{
+void Transform_2way(unsigned char* out, const unsigned char* in);
+}
+
+namespace sha256_x86_shani
+{
+void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks);
+}
+
+namespace sha256_arm_shani
+{
+void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks);
+}
+
+namespace sha256d64_arm_shani
+{
+void Transform_2way(unsigned char* out, const unsigned char* in);
+}
+#endif // DISABLE_OPTIMIZED_SHA256
+
+// Internal implementation code.
+namespace
+{
+/// Internal SHA-256 implementation.
+namespace sha256
+{
+uint32_t inline Ch(uint32_t x, uint32_t y, uint32_t z) { return z ^ (x & (y ^ z)); }
+uint32_t inline Maj(uint32_t x, uint32_t y, uint32_t z) { return (x & y) | (z & (x | y)); }
+uint32_t inline Sigma0(uint32_t x) { return (x >> 2 | x << 30) ^ (x >> 13 | x << 19) ^ (x >> 22 | x << 10); }
+uint32_t inline Sigma1(uint32_t x) { return (x >> 6 | x << 26) ^ (x >> 11 | x << 21) ^ (x >> 25 | x << 7); }
+uint32_t inline sigma0(uint32_t x) { return (x >> 7 | x << 25) ^ (x >> 18 | x << 14) ^ (x >> 3); }
+uint32_t inline sigma1(uint32_t x) { return (x >> 17 | x << 15) ^ (x >> 19 | x << 13) ^ (x >> 10); }
+
+/** One round of SHA-256. */
+void inline Round(uint32_t a, uint32_t b, uint32_t c, uint32_t& d, uint32_t e, uint32_t f, uint32_t g, uint32_t& h, uint32_t k)
+{
+    uint32_t t1 = h + Sigma1(e) + Ch(e, f, g) + k;
+    uint32_t t2 = Sigma0(a) + Maj(a, b, c);
+    d += t1;
+    h = t1 + t2;
+}
+
+/** Initialize SHA-256 state. */
+void inline Initialize(uint32_t* s)
+{
+    s[0] = 0x6a09e667ul;
+    s[1] = 0xbb67ae85ul;
+    s[2] = 0x3c6ef372ul;
+    s[3] = 0xa54ff53aul;
+    s[4] = 0x510e527ful;
+    s[5] = 0x9b05688cul;
+    s[6] = 0x1f83d9abul;
+    s[7] = 0x5be0cd19ul;
+}
+
+/** Perform a number of SHA-256 transformations, processing 64-byte chunks. */
+void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks)
+{
+    while (blocks--) {
+        uint32_t a = s[0], b = s[1], c = s[2], d = s[3], e = s[4], f = s[5], g = s[6], h = s[7];
+        uint32_t w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14, w15;
+
+        Round(a, b, c, d, e, f, g, h, 0x428a2f98 + (w0 = ReadBE32(chunk + 0)));
+        Round(h, a, b, c, d, e, f, g, 0x71374491 + (w1 = ReadBE32(chunk + 4)));
+        Round(g, h, a, b, c, d, e, f, 0xb5c0fbcf + (w2 = ReadBE32(chunk + 8)));
+        Round(f, g, h, a, b, c, d, e, 0xe9b5dba5 + (w3 = ReadBE32(chunk + 12)));
+        Round(e, f, g, h, a, b, c, d, 0x3956c25b + (w4 = ReadBE32(chunk + 16)));
+        Round(d, e, f, g, h, a, b, c, 0x59f111f1 + (w5 = ReadBE32(chunk + 20)));
+        Round(c, d, e, f, g, h, a, b, 0x923f82a4 + (w6 = ReadBE32(chunk + 24)));
+        Round(b, c, d, e, f, g, h, a, 0xab1c5ed5 + (w7 = ReadBE32(chunk + 28)));
+        Round(a, b, c, d, e, f, g, h, 0xd807aa98 + (w8 = ReadBE32(chunk + 32)));
+        Round(h, a, b, c, d, e, f, g, 0x12835b01 + (w9 = ReadBE32(chunk + 36)));
+        Round(g, h, a, b, c, d, e, f, 0x243185be + (w10 = ReadBE32(chunk + 40)));
+        Round(f, g, h, a, b, c, d, e, 0x550c7dc3 + (w11 = ReadBE32(chunk + 44)));
+        Round(e, f, g, h, a, b, c, d, 0x72be5d74 + (w12 = ReadBE32(chunk + 48)));
+        Round(d, e, f, g, h, a, b, c, 0x80deb1fe + (w13 = ReadBE32(chunk + 52)));
+        Round(c, d, e, f, g, h, a, b, 0x9bdc06a7 + (w14 = ReadBE32(chunk + 56)));
+        Round(b, c, d, e, f, g, h, a, 0xc19bf174 + (w15 = ReadBE32(chunk + 60)));
+
+        Round(a, b, c, d, e, f, g, h, 0xe49b69c1 + (w0 += sigma1(w14) + w9 + sigma0(w1)));
+        Round(h, a, b, c, d, e, f, g, 0xefbe4786 + (w1 += sigma1(w15) + w10 + sigma0(w2)));
+        Round(g, h, a, b, c, d, e, f, 0x0fc19dc6 + (w2 += sigma1(w0) + w11 + sigma0(w3)));
+        Round(f, g, h, a, b, c, d, e, 0x240ca1cc + (w3 += sigma1(w1) + w12 + sigma0(w4)));
+        Round(e, f, g, h, a, b, c, d, 0x2de92c6f + (w4 += sigma1(w2) + w13 + sigma0(w5)));
+        Round(d, e, f, g, h, a, b, c, 0x4a7484aa + (w5 += sigma1(w3) + w14 + sigma0(w6)));
+        Round(c, d, e, f, g, h, a, b, 0x5cb0a9dc + (w6 += sigma1(w4) + w15 + sigma0(w7)));
+        Round(b, c, d, e, f, g, h, a, 0x76f988da + (w7 += sigma1(w5) + w0 + sigma0(w8)));
+        Round(a, b, c, d, e, f, g, h, 0x983e5152 + (w8 += sigma1(w6) + w1 + sigma0(w9)));
+        Round(h, a, b, c, d, e, f, g, 0xa831c66d + (w9 += sigma1(w7) + w2 + sigma0(w10)));
+        Round(g, h, a, b, c, d, e, f, 0xb00327c8 + (w10 += sigma1(w8) + w3 + sigma0(w11)));
+        Round(f, g, h, a, b, c, d, e, 0xbf597fc7 + (w11 += sigma1(w9) + w4 + sigma0(w12)));
+        Round(e, f, g, h, a, b, c, d, 0xc6e00bf3 + (w12 += sigma1(w10) + w5 + sigma0(w13)));
+        Round(d, e, f, g, h, a, b, c, 0xd5a79147 + (w13 += sigma1(w11) + w6 + sigma0(w14)));
+        Round(c, d, e, f, g, h, a, b, 0x06ca6351 + (w14 += sigma1(w12) + w7 + sigma0(w15)));
+        Round(b, c, d, e, f, g, h, a, 0x14292967 + (w15 += sigma1(w13) + w8 + sigma0(w0)));
+
+        Round(a, b, c, d, e, f, g, h, 0x27b70a85 + (w0 += sigma1(w14) + w9 + sigma0(w1)));
+        Round(h, a, b, c, d, e, f, g, 0x2e1b2138 + (w1 += sigma1(w15) + w10 + sigma0(w2)));
+        Round(g, h, a, b, c, d, e, f, 0x4d2c6dfc + (w2 += sigma1(w0) + w11 + sigma0(w3)));
+        Round(f, g, h, a, b, c, d, e, 0x53380d13 + (w3 += sigma1(w1) + w12 + sigma0(w4)));
+        Round(e, f, g, h, a, b, c, d, 0x650a7354 + (w4 += sigma1(w2) + w13 + sigma0(w5)));
+        Round(d, e, f, g, h, a, b, c, 0x766a0abb + (w5 += sigma1(w3) + w14 + sigma0(w6)));
+        Round(c, d, e, f, g, h, a, b, 0x81c2c92e + (w6 += sigma1(w4) + w15 + sigma0(w7)));
+        Round(b, c, d, e, f, g, h, a, 0x92722c85 + (w7 += sigma1(w5) + w0 + sigma0(w8)));
+        Round(a, b, c, d, e, f, g, h, 0xa2bfe8a1 + (w8 += sigma1(w6) + w1 + sigma0(w9)));
+        Round(h, a, b, c, d, e, f, g, 0xa81a664b + (w9 += sigma1(w7) + w2 + sigma0(w10)));
+        Round(g, h, a, b, c, d, e, f, 0xc24b8b70 + (w10 += sigma1(w8) + w3 + sigma0(w11)));
+        Round(f, g, h, a, b, c, d, e, 0xc76c51a3 + (w11 += sigma1(w9) + w4 + sigma0(w12)));
+        Round(e, f, g, h, a, b, c, d, 0xd192e819 + (w12 += sigma1(w10) + w5 + sigma0(w13)));
+        Round(d, e, f, g, h, a, b, c, 0xd6990624 + (w13 += sigma1(w11) + w6 + sigma0(w14)));
+        Round(c, d, e, f, g, h, a, b, 0xf40e3585 + (w14 += sigma1(w12) + w7 + sigma0(w15)));
+        Round(b, c, d, e, f, g, h, a, 0x106aa070 + (w15 += sigma1(w13) + w8 + sigma0(w0)));
+
+        Round(a, b, c, d, e, f, g, h, 0x19a4c116 + (w0 += sigma1(w14) + w9 + sigma0(w1)));
+        Round(h, a, b, c, d, e, f, g, 0x1e376c08 + (w1 += sigma1(w15) + w10 + sigma0(w2)));
+        Round(g, h, a, b, c, d, e, f, 0x2748774c + (w2 += sigma1(w0) + w11 + sigma0(w3)));
+        Round(f, g, h, a, b, c, d, e, 0x34b0bcb5 + (w3 += sigma1(w1) + w12 + sigma0(w4)));
+        Round(e, f, g, h, a, b, c, d, 0x391c0cb3 + (w4 += sigma1(w2) + w13 + sigma0(w5)));
+        Round(d, e, f, g, h, a, b, c, 0x4ed8aa4a + (w5 += sigma1(w3) + w14 + sigma0(w6)));
+        Round(c, d, e, f, g, h, a, b, 0x5b9cca4f + (w6 += sigma1(w4) + w15 + sigma0(w7)));
+        Round(b, c, d, e, f, g, h, a, 0x682e6ff3 + (w7 += sigma1(w5) + w0 + sigma0(w8)));
+        Round(a, b, c, d, e, f, g, h, 0x748f82ee + (w8 += sigma1(w6) + w1 + sigma0(w9)));
+        Round(h, a, b, c, d, e, f, g, 0x78a5636f + (w9 += sigma1(w7) + w2 + sigma0(w10)));
+        Round(g, h, a, b, c, d, e, f, 0x84c87814 + (w10 += sigma1(w8) + w3 + sigma0(w11)));
+        Round(f, g, h, a, b, c, d, e, 0x8cc70208 + (w11 += sigma1(w9) + w4 + sigma0(w12)));
+        Round(e, f, g, h, a, b, c, d, 0x90befffa + (w12 += sigma1(w10) + w5 + sigma0(w13)));
+        Round(d, e, f, g, h, a, b, c, 0xa4506ceb + (w13 += sigma1(w11) + w6 + sigma0(w14)));
+        Round(c, d, e, f, g, h, a, b, 0xbef9a3f7 + (w14 + sigma1(w12) + w7 + sigma0(w15)));
+        Round(b, c, d, e, f, g, h, a, 0xc67178f2 + (w15 + sigma1(w13) + w8 + sigma0(w0)));
+
+        s[0] += a;
+        s[1] += b;
+        s[2] += c;
+        s[3] += d;
+        s[4] += e;
+        s[5] += f;
+        s[6] += g;
+        s[7] += h;
+        chunk += 64;
+    }
+}
+
+void TransformD64(unsigned char* out, const unsigned char* in)
+{
+    // Transform 1
+    uint32_t a = 0x6a09e667ul;
+    uint32_t b = 0xbb67ae85ul;
+    uint32_t c = 0x3c6ef372ul;
+    uint32_t d = 0xa54ff53aul;
+    uint32_t e = 0x510e527ful;
+    uint32_t f = 0x9b05688cul;
+    uint32_t g = 0x1f83d9abul;
+    uint32_t h = 0x5be0cd19ul;
+
+    uint32_t w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14, w15;
+
+    Round(a, b, c, d, e, f, g, h, 0x428a2f98ul + (w0 = ReadBE32(in + 0)));
+    Round(h, a, b, c, d, e, f, g, 0x71374491ul + (w1 = ReadBE32(in + 4)));
+    Round(g, h, a, b, c, d, e, f, 0xb5c0fbcful + (w2 = ReadBE32(in + 8)));
+    Round(f, g, h, a, b, c, d, e, 0xe9b5dba5ul + (w3 = ReadBE32(in + 12)));
+    Round(e, f, g, h, a, b, c, d, 0x3956c25bul + (w4 = ReadBE32(in + 16)));
+    Round(d, e, f, g, h, a, b, c, 0x59f111f1ul + (w5 = ReadBE32(in + 20)));
+    Round(c, d, e, f, g, h, a, b, 0x923f82a4ul + (w6 = ReadBE32(in + 24)));
+    Round(b, c, d, e, f, g, h, a, 0xab1c5ed5ul + (w7 = ReadBE32(in + 28)));
+    Round(a, b, c, d, e, f, g, h, 0xd807aa98ul + (w8 = ReadBE32(in + 32)));
+    Round(h, a, b, c, d, e, f, g, 0x12835b01ul + (w9 = ReadBE32(in + 36)));
+    Round(g, h, a, b, c, d, e, f, 0x243185beul + (w10 = ReadBE32(in + 40)));
+    Round(f, g, h, a, b, c, d, e, 0x550c7dc3ul + (w11 = ReadBE32(in + 44)));
+    Round(e, f, g, h, a, b, c, d, 0x72be5d74ul + (w12 = ReadBE32(in + 48)));
+    Round(d, e, f, g, h, a, b, c, 0x80deb1feul + (w13 = ReadBE32(in + 52)));
+    Round(c, d, e, f, g, h, a, b, 0x9bdc06a7ul + (w14 = ReadBE32(in + 56)));
+    Round(b, c, d, e, f, g, h, a, 0xc19bf174ul + (w15 = ReadBE32(in + 60)));
+    Round(a, b, c, d, e, f, g, h, 0xe49b69c1ul + (w0 += sigma1(w14) + w9 + sigma0(w1)));
+    Round(h, a, b, c, d, e, f, g, 0xefbe4786ul + (w1 += sigma1(w15) + w10 + sigma0(w2)));
+    Round(g, h, a, b, c, d, e, f, 0x0fc19dc6ul + (w2 += sigma1(w0) + w11 + sigma0(w3)));
+    Round(f, g, h, a, b, c, d, e, 0x240ca1ccul + (w3 += sigma1(w1) + w12 + sigma0(w4)));
+    Round(e, f, g, h, a, b, c, d, 0x2de92c6ful + (w4 += sigma1(w2) + w13 + sigma0(w5)));
+    Round(d, e, f, g, h, a, b, c, 0x4a7484aaul + (w5 += sigma1(w3) + w14 + sigma0(w6)));
+    Round(c, d, e, f, g, h, a, b, 0x5cb0a9dcul + (w6 += sigma1(w4) + w15 + sigma0(w7)));
+    Round(b, c, d, e, f, g, h, a, 0x76f988daul + (w7 += sigma1(w5) + w0 + sigma0(w8)));
+    Round(a, b, c, d, e, f, g, h, 0x983e5152ul + (w8 += sigma1(w6) + w1 + sigma0(w9)));
+    Round(h, a, b, c, d, e, f, g, 0xa831c66dul + (w9 += sigma1(w7) + w2 + sigma0(w10)));
+    Round(g, h, a, b, c, d, e, f, 0xb00327c8ul + (w10 += sigma1(w8) + w3 + sigma0(w11)));
+    Round(f, g, h, a, b, c, d, e, 0xbf597fc7ul + (w11 += sigma1(w9) + w4 + sigma0(w12)));
+    Round(e, f, g, h, a, b, c, d, 0xc6e00bf3ul + (w12 += sigma1(w10) + w5 + sigma0(w13)));
+    Round(d, e, f, g, h, a, b, c, 0xd5a79147ul + (w13 += sigma1(w11) + w6 + sigma0(w14)));
+    Round(c, d, e, f, g, h, a, b, 0x06ca6351ul + (w14 += sigma1(w12) + w7 + sigma0(w15)));
+    Round(b, c, d, e, f, g, h, a, 0x14292967ul + (w15 += sigma1(w13) + w8 + sigma0(w0)));
+    Round(a, b, c, d, e, f, g, h, 0x27b70a85ul + (w0 += sigma1(w14) + w9 + sigma0(w1)));
+    Round(h, a, b, c, d, e, f, g, 0x2e1b2138ul + (w1 += sigma1(w15) + w10 + sigma0(w2)));
+    Round(g, h, a, b, c, d, e, f, 0x4d2c6dfcul + (w2 += sigma1(w0) + w11 + sigma0(w3)));
+    Round(f, g, h, a, b, c, d, e, 0x53380d13ul + (w3 += sigma1(w1) + w12 + sigma0(w4)));
+    Round(e, f, g, h, a, b, c, d, 0x650a7354ul + (w4 += sigma1(w2) + w13 + sigma0(w5)));
+    Round(d, e, f, g, h, a, b, c, 0x766a0abbul + (w5 += sigma1(w3) + w14 + sigma0(w6)));
+    Round(c, d, e, f, g, h, a, b, 0x81c2c92eul + (w6 += sigma1(w4) + w15 + sigma0(w7)));
+    Round(b, c, d, e, f, g, h, a, 0x92722c85ul + (w7 += sigma1(w5) + w0 + sigma0(w8)));
+    Round(a, b, c, d, e, f, g, h, 0xa2bfe8a1ul + (w8 += sigma1(w6) + w1 + sigma0(w9)));
+    Round(h, a, b, c, d, e, f, g, 0xa81a664bul + (w9 += sigma1(w7) + w2 + sigma0(w10)));
+    Round(g, h, a, b, c, d, e, f, 0xc24b8b70ul + (w10 += sigma1(w8) + w3 + sigma0(w11)));
+    Round(f, g, h, a, b, c, d, e, 0xc76c51a3ul + (w11 += sigma1(w9) + w4 + sigma0(w12)));
+    Round(e, f, g, h, a, b, c, d, 0xd192e819ul + (w12 += sigma1(w10) + w5 + sigma0(w13)));
+    Round(d, e, f, g, h, a, b, c, 0xd6990624ul + (w13 += sigma1(w11) + w6 + sigma0(w14)));
+    Round(c, d, e, f, g, h, a, b, 0xf40e3585ul + (w14 += sigma1(w12) + w7 + sigma0(w15)));
+    Round(b, c, d, e, f, g, h, a, 0x106aa070ul + (w15 += sigma1(w13) + w8 + sigma0(w0)));
+    Round(a, b, c, d, e, f, g, h, 0x19a4c116ul + (w0 += sigma1(w14) + w9 + sigma0(w1)));
+    Round(h, a, b, c, d, e, f, g, 0x1e376c08ul + (w1 += sigma1(w15) + w10 + sigma0(w2)));
+    Round(g, h, a, b, c, d, e, f, 0x2748774cul + (w2 += sigma1(w0) + w11 + sigma0(w3)));
+    Round(f, g, h, a, b, c, d, e, 0x34b0bcb5ul + (w3 += sigma1(w1) + w12 + sigma0(w4)));
+    Round(e, f, g, h, a, b, c, d, 0x391c0cb3ul + (w4 += sigma1(w2) + w13 + sigma0(w5)));
+    Round(d, e, f, g, h, a, b, c, 0x4ed8aa4aul + (w5 += sigma1(w3) + w14 + sigma0(w6)));
+    Round(c, d, e, f, g, h, a, b, 0x5b9cca4ful + (w6 += sigma1(w4) + w15 + sigma0(w7)));
+    Round(b, c, d, e, f, g, h, a, 0x682e6ff3ul + (w7 += sigma1(w5) + w0 + sigma0(w8)));
+    Round(a, b, c, d, e, f, g, h, 0x748f82eeul + (w8 += sigma1(w6) + w1 + sigma0(w9)));
+    Round(h, a, b, c, d, e, f, g, 0x78a5636ful + (w9 += sigma1(w7) + w2 + sigma0(w10)));
+    Round(g, h, a, b, c, d, e, f, 0x84c87814ul + (w10 += sigma1(w8) + w3 + sigma0(w11)));
+    Round(f, g, h, a, b, c, d, e, 0x8cc70208ul + (w11 += sigma1(w9) + w4 + sigma0(w12)));
+    Round(e, f, g, h, a, b, c, d, 0x90befffaul + (w12 += sigma1(w10) + w5 + sigma0(w13)));
+    Round(d, e, f, g, h, a, b, c, 0xa4506cebul + (w13 += sigma1(w11) + w6 + sigma0(w14)));
+    Round(c, d, e, f, g, h, a, b, 0xbef9a3f7ul + (w14 + sigma1(w12) + w7 + sigma0(w15)));
+    Round(b, c, d, e, f, g, h, a, 0xc67178f2ul + (w15 + sigma1(w13) + w8 + sigma0(w0)));
+
+    a += 0x6a09e667ul;
+    b += 0xbb67ae85ul;
+    c += 0x3c6ef372ul;
+    d += 0xa54ff53aul;
+    e += 0x510e527ful;
+    f += 0x9b05688cul;
+    g += 0x1f83d9abul;
+    h += 0x5be0cd19ul;
+
+    uint32_t t0 = a, t1 = b, t2 = c, t3 = d, t4 = e, t5 = f, t6 = g, t7 = h;
+
+    // Transform 2
+    Round(a, b, c, d, e, f, g, h, 0xc28a2f98ul);
+    Round(h, a, b, c, d, e, f, g, 0x71374491ul);
+    Round(g, h, a, b, c, d, e, f, 0xb5c0fbcful);
+    Round(f, g, h, a, b, c, d, e, 0xe9b5dba5ul);
+    Round(e, f, g, h, a, b, c, d, 0x3956c25bul);
+    Round(d, e, f, g, h, a, b, c, 0x59f111f1ul);
+    Round(c, d, e, f, g, h, a, b, 0x923f82a4ul);
+    Round(b, c, d, e, f, g, h, a, 0xab1c5ed5ul);
+    Round(a, b, c, d, e, f, g, h, 0xd807aa98ul);
+    Round(h, a, b, c, d, e, f, g, 0x12835b01ul);
+    Round(g, h, a, b, c, d, e, f, 0x243185beul);
+    Round(f, g, h, a, b, c, d, e, 0x550c7dc3ul);
+    Round(e, f, g, h, a, b, c, d, 0x72be5d74ul);
+    Round(d, e, f, g, h, a, b, c, 0x80deb1feul);
+    Round(c, d, e, f, g, h, a, b, 0x9bdc06a7ul);
+    Round(b, c, d, e, f, g, h, a, 0xc19bf374ul);
+    Round(a, b, c, d, e, f, g, h, 0x649b69c1ul);
+    Round(h, a, b, c, d, e, f, g, 0xf0fe4786ul);
+    Round(g, h, a, b, c, d, e, f, 0x0fe1edc6ul);
+    Round(f, g, h, a, b, c, d, e, 0x240cf254ul);
+    Round(e, f, g, h, a, b, c, d, 0x4fe9346ful);
+    Round(d, e, f, g, h, a, b, c, 0x6cc984beul);
+    Round(c, d, e, f, g, h, a, b, 0x61b9411eul);
+    Round(b, c, d, e, f, g, h, a, 0x16f988faul);
+    Round(a, b, c, d, e, f, g, h, 0xf2c65152ul);
+    Round(h, a, b, c, d, e, f, g, 0xa88e5a6dul);
+    Round(g, h, a, b, c, d, e, f, 0xb019fc65ul);
+    Round(f, g, h, a, b, c, d, e, 0xb9d99ec7ul);
+    Round(e, f, g, h, a, b, c, d, 0x9a1231c3ul);
+    Round(d, e, f, g, h, a, b, c, 0xe70eeaa0ul);
+    Round(c, d, e, f, g, h, a, b, 0xfdb1232bul);
+    Round(b, c, d, e, f, g, h, a, 0xc7353eb0ul);
+    Round(a, b, c, d, e, f, g, h, 0x3069bad5ul);
+    Round(h, a, b, c, d, e, f, g, 0xcb976d5ful);
+    Round(g, h, a, b, c, d, e, f, 0x5a0f118ful);
+    Round(f, g, h, a, b, c, d, e, 0xdc1eeefdul);
+    Round(e, f, g, h, a, b, c, d, 0x0a35b689ul);
+    Round(d, e, f, g, h, a, b, c, 0xde0b7a04ul);
+    Round(c, d, e, f, g, h, a, b, 0x58f4ca9dul);
+    Round(b, c, d, e, f, g, h, a, 0xe15d5b16ul);
+    Round(a, b, c, d, e, f, g, h, 0x007f3e86ul);
+    Round(h, a, b, c, d, e, f, g, 0x37088980ul);
+    Round(g, h, a, b, c, d, e, f, 0xa507ea32ul);
+    Round(f, g, h, a, b, c, d, e, 0x6fab9537ul);
+    Round(e, f, g, h, a, b, c, d, 0x17406110ul);
+    Round(d, e, f, g, h, a, b, c, 0x0d8cd6f1ul);
+    Round(c, d, e, f, g, h, a, b, 0xcdaa3b6dul);
+    Round(b, c, d, e, f, g, h, a, 0xc0bbbe37ul);
+    Round(a, b, c, d, e, f, g, h, 0x83613bdaul);
+    Round(h, a, b, c, d, e, f, g, 0xdb48a363ul);
+    Round(g, h, a, b, c, d, e, f, 0x0b02e931ul);
+    Round(f, g, h, a, b, c, d, e, 0x6fd15ca7ul);
+    Round(e, f, g, h, a, b, c, d, 0x521afacaul);
+    Round(d, e, f, g, h, a, b, c, 0x31338431ul);
+    Round(c, d, e, f, g, h, a, b, 0x6ed41a95ul);
+    Round(b, c, d, e, f, g, h, a, 0x6d437890ul);
+    Round(a, b, c, d, e, f, g, h, 0xc39c91f2ul);
+    Round(h, a, b, c, d, e, f, g, 0x9eccabbdul);
+    Round(g, h, a, b, c, d, e, f, 0xb5c9a0e6ul);
+    Round(f, g, h, a, b, c, d, e, 0x532fb63cul);
+    Round(e, f, g, h, a, b, c, d, 0xd2c741c6ul);
+    Round(d, e, f, g, h, a, b, c, 0x07237ea3ul);
+    Round(c, d, e, f, g, h, a, b, 0xa4954b68ul);
+    Round(b, c, d, e, f, g, h, a, 0x4c191d76ul);
+
+    w0 = t0 + a;
+    w1 = t1 + b;
+    w2 = t2 + c;
+    w3 = t3 + d;
+    w4 = t4 + e;
+    w5 = t5 + f;
+    w6 = t6 + g;
+    w7 = t7 + h;
+
+    // Transform 3
+    a = 0x6a09e667ul;
+    b = 0xbb67ae85ul;
+    c = 0x3c6ef372ul;
+    d = 0xa54ff53aul;
+    e = 0x510e527ful;
+    f = 0x9b05688cul;
+    g = 0x1f83d9abul;
+    h = 0x5be0cd19ul;
+
+    Round(a, b, c, d, e, f, g, h, 0x428a2f98ul + w0);
+    Round(h, a, b, c, d, e, f, g, 0x71374491ul + w1);
+    Round(g, h, a, b, c, d, e, f, 0xb5c0fbcful + w2);
+    Round(f, g, h, a, b, c, d, e, 0xe9b5dba5ul + w3);
+    Round(e, f, g, h, a, b, c, d, 0x3956c25bul + w4);
+    Round(d, e, f, g, h, a, b, c, 0x59f111f1ul + w5);
+    Round(c, d, e, f, g, h, a, b, 0x923f82a4ul + w6);
+    Round(b, c, d, e, f, g, h, a, 0xab1c5ed5ul + w7);
+    Round(a, b, c, d, e, f, g, h, 0x5807aa98ul);
+    Round(h, a, b, c, d, e, f, g, 0x12835b01ul);
+    Round(g, h, a, b, c, d, e, f, 0x243185beul);
+    Round(f, g, h, a, b, c, d, e, 0x550c7dc3ul);
+    Round(e, f, g, h, a, b, c, d, 0x72be5d74ul);
+    Round(d, e, f, g, h, a, b, c, 0x80deb1feul);
+    Round(c, d, e, f, g, h, a, b, 0x9bdc06a7ul);
+    Round(b, c, d, e, f, g, h, a, 0xc19bf274ul);
+    Round(a, b, c, d, e, f, g, h, 0xe49b69c1ul + (w0 += sigma0(w1)));
+    Round(h, a, b, c, d, e, f, g, 0xefbe4786ul + (w1 += 0xa00000ul + sigma0(w2)));
+    Round(g, h, a, b, c, d, e, f, 0x0fc19dc6ul + (w2 += sigma1(w0) + sigma0(w3)));
+    Round(f, g, h, a, b, c, d, e, 0x240ca1ccul + (w3 += sigma1(w1) + sigma0(w4)));
+    Round(e, f, g, h, a, b, c, d, 0x2de92c6ful + (w4 += sigma1(w2) + sigma0(w5)));
+    Round(d, e, f, g, h, a, b, c, 0x4a7484aaul + (w5 += sigma1(w3) + sigma0(w6)));
+    Round(c, d, e, f, g, h, a, b, 0x5cb0a9dcul + (w6 += sigma1(w4) + 0x100ul + sigma0(w7)));
+    Round(b, c, d, e, f, g, h, a, 0x76f988daul + (w7 += sigma1(w5) + w0 + 0x11002000ul));
+    Round(a, b, c, d, e, f, g, h, 0x983e5152ul + (w8 = 0x80000000ul + sigma1(w6) + w1));
+    Round(h, a, b, c, d, e, f, g, 0xa831c66dul + (w9 = sigma1(w7) + w2));
+    Round(g, h, a, b, c, d, e, f, 0xb00327c8ul + (w10 = sigma1(w8) + w3));
+    Round(f, g, h, a, b, c, d, e, 0xbf597fc7ul + (w11 = sigma1(w9) + w4));
+    Round(e, f, g, h, a, b, c, d, 0xc6e00bf3ul + (w12 = sigma1(w10) + w5));
+    Round(d, e, f, g, h, a, b, c, 0xd5a79147ul + (w13 = sigma1(w11) + w6));
+    Round(c, d, e, f, g, h, a, b, 0x06ca6351ul + (w14 = sigma1(w12) + w7 + 0x400022ul));
+    Round(b, c, d, e, f, g, h, a, 0x14292967ul + (w15 = 0x100ul + sigma1(w13) + w8 + sigma0(w0)));
+    Round(a, b, c, d, e, f, g, h, 0x27b70a85ul + (w0 += sigma1(w14) + w9 + sigma0(w1)));
+    Round(h, a, b, c, d, e, f, g, 0x2e1b2138ul + (w1 += sigma1(w15) + w10 + sigma0(w2)));
+    Round(g, h, a, b, c, d, e, f, 0x4d2c6dfcul + (w2 += sigma1(w0) + w11 + sigma0(w3)));
+    Round(f, g, h, a, b, c, d, e, 0x53380d13ul + (w3 += sigma1(w1) + w12 + sigma0(w4)));
+    Round(e, f, g, h, a, b, c, d, 0x650a7354ul + (w4 += sigma1(w2) + w13 + sigma0(w5)));
+    Round(d, e, f, g, h, a, b, c, 0x766a0abbul + (w5 += sigma1(w3) + w14 + sigma0(w6)));
+    Round(c, d, e, f, g, h, a, b, 0x81c2c92eul + (w6 += sigma1(w4) + w15 + sigma0(w7)));
+    Round(b, c, d, e, f, g, h, a, 0x92722c85ul + (w7 += sigma1(w5) + w0 + sigma0(w8)));
+    Round(a, b, c, d, e, f, g, h, 0xa2bfe8a1ul + (w8 += sigma1(w6) + w1 + sigma0(w9)));
+    Round(h, a, b, c, d, e, f, g, 0xa81a664bul + (w9 += sigma1(w7) + w2 + sigma0(w10)));
+    Round(g, h, a, b, c, d, e, f, 0xc24b8b70ul + (w10 += sigma1(w8) + w3 + sigma0(w11)));
+    Round(f, g, h, a, b, c, d, e, 0xc76c51a3ul + (w11 += sigma1(w9) + w4 + sigma0(w12)));
+    Round(e, f, g, h, a, b, c, d, 0xd192e819ul + (w12 += sigma1(w10) + w5 + sigma0(w13)));
+    Round(d, e, f, g, h, a, b, c, 0xd6990624ul + (w13 += sigma1(w11) + w6 + sigma0(w14)));
+    Round(c, d, e, f, g, h, a, b, 0xf40e3585ul + (w14 += sigma1(w12) + w7 + sigma0(w15)));
+    Round(b, c, d, e, f, g, h, a, 0x106aa070ul + (w15 += sigma1(w13) + w8 + sigma0(w0)));
+    Round(a, b, c, d, e, f, g, h, 0x19a4c116ul + (w0 += sigma1(w14) + w9 + sigma0(w1)));
+    Round(h, a, b, c, d, e, f, g, 0x1e376c08ul + (w1 += sigma1(w15) + w10 + sigma0(w2)));
+    Round(g, h, a, b, c, d, e, f, 0x2748774cul + (w2 += sigma1(w0) + w11 + sigma0(w3)));
+    Round(f, g, h, a, b, c, d, e, 0x34b0bcb5ul + (w3 += sigma1(w1) + w12 + sigma0(w4)));
+    Round(e, f, g, h, a, b, c, d, 0x391c0cb3ul + (w4 += sigma1(w2) + w13 + sigma0(w5)));
+    Round(d, e, f, g, h, a, b, c, 0x4ed8aa4aul + (w5 += sigma1(w3) + w14 + sigma0(w6)));
+    Round(c, d, e, f, g, h, a, b, 0x5b9cca4ful + (w6 += sigma1(w4) + w15 + sigma0(w7)));
+    Round(b, c, d, e, f, g, h, a, 0x682e6ff3ul + (w7 += sigma1(w5) + w0 + sigma0(w8)));
+    Round(a, b, c, d, e, f, g, h, 0x748f82eeul + (w8 += sigma1(w6) + w1 + sigma0(w9)));
+    Round(h, a, b, c, d, e, f, g, 0x78a5636ful + (w9 += sigma1(w7) + w2 + sigma0(w10)));
+    Round(g, h, a, b, c, d, e, f, 0x84c87814ul + (w10 += sigma1(w8) + w3 + sigma0(w11)));
+    Round(f, g, h, a, b, c, d, e, 0x8cc70208ul + (w11 += sigma1(w9) + w4 + sigma0(w12)));
+    Round(e, f, g, h, a, b, c, d, 0x90befffaul + (w12 += sigma1(w10) + w5 + sigma0(w13)));
+    Round(d, e, f, g, h, a, b, c, 0xa4506cebul + (w13 += sigma1(w11) + w6 + sigma0(w14)));
+    Round(c, d, e, f, g, h, a, b, 0xbef9a3f7ul + (w14 + sigma1(w12) + w7 + sigma0(w15)));
+    Round(b, c, d, e, f, g, h, a, 0xc67178f2ul + (w15 + sigma1(w13) + w8 + sigma0(w0)));
+
+    // Output
+    WriteBE32(out + 0, a + 0x6a09e667ul);
+    WriteBE32(out + 4, b + 0xbb67ae85ul);
+    WriteBE32(out + 8, c + 0x3c6ef372ul);
+    WriteBE32(out + 12, d + 0xa54ff53aul);
+    WriteBE32(out + 16, e + 0x510e527ful);
+    WriteBE32(out + 20, f + 0x9b05688cul);
+    WriteBE32(out + 24, g + 0x1f83d9abul);
+    WriteBE32(out + 28, h + 0x5be0cd19ul);
+}
+
+} // namespace sha256
+
+typedef void (*TransformType)(uint32_t*, const unsigned char*, size_t);
+typedef void (*TransformD64Type)(unsigned char*, const unsigned char*);
+
+template<TransformType tr>
+void TransformD64Wrapper(unsigned char* out, const unsigned char* in)
+{
+    uint32_t s[8];
+    static const unsigned char padding1[64] = {
+        0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0
+    };
+    unsigned char buffer2[64] = {
+        0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0
+    };
+    sha256::Initialize(s);
+    tr(s, in, 1);
+    tr(s, padding1, 1);
+    WriteBE32(buffer2 + 0, s[0]);
+    WriteBE32(buffer2 + 4, s[1]);
+    WriteBE32(buffer2 + 8, s[2]);
+    WriteBE32(buffer2 + 12, s[3]);
+    WriteBE32(buffer2 + 16, s[4]);
+    WriteBE32(buffer2 + 20, s[5]);
+    WriteBE32(buffer2 + 24, s[6]);
+    WriteBE32(buffer2 + 28, s[7]);
+    sha256::Initialize(s);
+    tr(s, buffer2, 1);
+    WriteBE32(out + 0, s[0]);
+    WriteBE32(out + 4, s[1]);
+    WriteBE32(out + 8, s[2]);
+    WriteBE32(out + 12, s[3]);
+    WriteBE32(out + 16, s[4]);
+    WriteBE32(out + 20, s[5]);
+    WriteBE32(out + 24, s[6]);
+    WriteBE32(out + 28, s[7]);
+}
+
+TransformType Transform = sha256::Transform;
+TransformD64Type TransformD64 = sha256::TransformD64;
+TransformD64Type TransformD64_2way = nullptr;
+TransformD64Type TransformD64_4way = nullptr;
+TransformD64Type TransformD64_8way = nullptr;
+
+bool SelfTest() {
+    // Input state (equal to the initial SHA256 state)
+    static const uint32_t init[8] = {
+        0x6a09e667ul, 0xbb67ae85ul, 0x3c6ef372ul, 0xa54ff53aul, 0x510e527ful, 0x9b05688cul, 0x1f83d9abul, 0x5be0cd19ul
+    };
+    // Some random input data to test with
+    static const unsigned char data[641] = "-" // Intentionally not aligned
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do "
+        "eiusmod tempor incididunt ut labore et dolore magna aliqua. Et m"
+        "olestie ac feugiat sed lectus vestibulum mattis ullamcorper. Mor"
+        "bi blandit cursus risus at ultrices mi tempus imperdiet nulla. N"
+        "unc congue nisi vita suscipit tellus mauris. Imperdiet proin fer"
+        "mentum leo vel orci. Massa tempor nec feugiat nisl pretium fusce"
+        " id velit. Telus in metus vulputate eu scelerisque felis. Mi tem"
+        "pus imperdiet nulla malesuada pellentesque. Tristique magna sit.";
+    // Expected output state for hashing the i*64 first input bytes above (excluding SHA256 padding).
+    static const uint32_t result[9][8] = {
+        {0x6a09e667ul, 0xbb67ae85ul, 0x3c6ef372ul, 0xa54ff53aul, 0x510e527ful, 0x9b05688cul, 0x1f83d9abul, 0x5be0cd19ul},
+        {0x91f8ec6bul, 0x4da10fe3ul, 0x1c9c292cul, 0x45e18185ul, 0x435cc111ul, 0x3ca26f09ul, 0xeb954caeul, 0x402a7069ul},
+        {0xcabea5acul, 0x374fb97cul, 0x182ad996ul, 0x7bd69cbful, 0x450ff900ul, 0xc1d2be8aul, 0x6a41d505ul, 0xe6212dc3ul},
+        {0xbcff09d6ul, 0x3e76f36eul, 0x3ecb2501ul, 0x78866e97ul, 0xe1c1e2fdul, 0x32f4eafful, 0x8aa6c4e5ul, 0xdfc024bcul},
+        {0xa08c5d94ul, 0x0a862f93ul, 0x6b7f2f40ul, 0x8f9fae76ul, 0x6d40439ful, 0x79dcee0cul, 0x3e39ff3aul, 0xdc3bdbb1ul},
+        {0x216a0895ul, 0x9f1a3662ul, 0xe99946f9ul, 0x87ba4364ul, 0x0fb5db2cul, 0x12bed3d3ul, 0x6689c0c7ul, 0x292f1b04ul},
+        {0xca3067f8ul, 0xbc8c2656ul, 0x37cb7e0dul, 0x9b6b8b0ful, 0x46dc380bul, 0xf1287f57ul, 0xc42e4b23ul, 0x3fefe94dul},
+        {0x3e4c4039ul, 0xbb6fca8cul, 0x6f27d2f7ul, 0x301e44a4ul, 0x8352ba14ul, 0x5769ce37ul, 0x48a1155ful, 0xc0e1c4c6ul},
+        {0xfe2fa9ddul, 0x69d0862bul, 0x1ae0db23ul, 0x471f9244ul, 0xf55c0145ul, 0xc30f9c3bul, 0x40a84ea0ul, 0x5b8a266cul},
+    };
+    // Expected output for each of the individual 8 64-byte messages under full double SHA256 (including padding).
+    static const unsigned char result_d64[256] = {
+        0x09, 0x3a, 0xc4, 0xd0, 0x0f, 0xf7, 0x57, 0xe1, 0x72, 0x85, 0x79, 0x42, 0xfe, 0xe7, 0xe0, 0xa0,
+        0xfc, 0x52, 0xd7, 0xdb, 0x07, 0x63, 0x45, 0xfb, 0x53, 0x14, 0x7d, 0x17, 0x22, 0x86, 0xf0, 0x52,
+        0x48, 0xb6, 0x11, 0x9e, 0x6e, 0x48, 0x81, 0x6d, 0xcc, 0x57, 0x1f, 0xb2, 0x97, 0xa8, 0xd5, 0x25,
+        0x9b, 0x82, 0xaa, 0x89, 0xe2, 0xfd, 0x2d, 0x56, 0xe8, 0x28, 0x83, 0x0b, 0xe2, 0xfa, 0x53, 0xb7,
+        0xd6, 0x6b, 0x07, 0x85, 0x83, 0xb0, 0x10, 0xa2, 0xf5, 0x51, 0x3c, 0xf9, 0x60, 0x03, 0xab, 0x45,
+        0x6c, 0x15, 0x6e, 0xef, 0xb5, 0xac, 0x3e, 0x6c, 0xdf, 0xb4, 0x92, 0x22, 0x2d, 0xce, 0xbf, 0x3e,
+        0xe9, 0xe5, 0xf6, 0x29, 0x0e, 0x01, 0x4f, 0xd2, 0xd4, 0x45, 0x65, 0xb3, 0xbb, 0xf2, 0x4c, 0x16,
+        0x37, 0x50, 0x3c, 0x6e, 0x49, 0x8c, 0x5a, 0x89, 0x2b, 0x1b, 0xab, 0xc4, 0x37, 0xd1, 0x46, 0xe9,
+        0x3d, 0x0e, 0x85, 0xa2, 0x50, 0x73, 0xa1, 0x5e, 0x54, 0x37, 0xd7, 0x94, 0x17, 0x56, 0xc2, 0xd8,
+        0xe5, 0x9f, 0xed, 0x4e, 0xae, 0x15, 0x42, 0x06, 0x0d, 0x74, 0x74, 0x5e, 0x24, 0x30, 0xce, 0xd1,
+        0x9e, 0x50, 0xa3, 0x9a, 0xb8, 0xf0, 0x4a, 0x57, 0x69, 0x78, 0x67, 0x12, 0x84, 0x58, 0xbe, 0xc7,
+        0x36, 0xaa, 0xee, 0x7c, 0x64, 0xa3, 0x76, 0xec, 0xff, 0x55, 0x41, 0x00, 0x2a, 0x44, 0x68, 0x4d,
+        0xb6, 0x53, 0x9e, 0x1c, 0x95, 0xb7, 0xca, 0xdc, 0x7f, 0x7d, 0x74, 0x27, 0x5c, 0x8e, 0xa6, 0x84,
+        0xb5, 0xac, 0x87, 0xa9, 0xf3, 0xff, 0x75, 0xf2, 0x34, 0xcd, 0x1a, 0x3b, 0x82, 0x2c, 0x2b, 0x4e,
+        0x6a, 0x46, 0x30, 0xa6, 0x89, 0x86, 0x23, 0xac, 0xf8, 0xa5, 0x15, 0xe9, 0x0a, 0xaa, 0x1e, 0x9a,
+        0xd7, 0x93, 0x6b, 0x28, 0xe4, 0x3b, 0xfd, 0x59, 0xc6, 0xed, 0x7c, 0x5f, 0xa5, 0x41, 0xcb, 0x51
+    };
+
+
+    // Test Transform() for 0 through 8 transformations.
+    for (size_t i = 0; i <= 8; ++i) {
+        uint32_t state[8];
+        std::copy(init, init + 8, state);
+        Transform(state, data + 1, i);
+        if (!std::equal(state, state + 8, result[i])) return false;
+    }
+
+    // Test TransformD64
+    unsigned char out[32];
+    TransformD64(out, data + 1);
+    if (!std::equal(out, out + 32, result_d64)) return false;
+
+    // Test TransformD64_2way, if available.
+    if (TransformD64_2way) {
+        unsigned char out[64];
+        TransformD64_2way(out, data + 1);
+        if (!std::equal(out, out + 64, result_d64)) return false;
+    }
+
+    // Test TransformD64_4way, if available.
+    if (TransformD64_4way) {
+        unsigned char out[128];
+        TransformD64_4way(out, data + 1);
+        if (!std::equal(out, out + 128, result_d64)) return false;
+    }
+
+    // Test TransformD64_8way, if available.
+    if (TransformD64_8way) {
+        unsigned char out[256];
+        TransformD64_8way(out, data + 1);
+        if (!std::equal(out, out + 256, result_d64)) return false;
+    }
+
+    return true;
+}
+
+#if !defined(DISABLE_OPTIMIZED_SHA256)
+#if (defined(__x86_64__) || defined(__amd64__) || defined(__i386__))
+/** Check whether the OS has enabled AVX registers. */
+bool AVXEnabled()
+{
+    uint32_t a, d;
+    __asm__("xgetbv" : "=a"(a), "=d"(d) : "c"(0));
+    return (a & 6) == 6;
+}
+#endif
+#endif // DISABLE_OPTIMIZED_SHA256
+} // namespace
+
+
+std::string SHA256AutoDetect(sha256_implementation::UseImplementation use_implementation)
+{
+    std::string ret = "standard";
+    Transform = sha256::Transform;
+    TransformD64 = sha256::TransformD64;
+    TransformD64_2way = nullptr;
+    TransformD64_4way = nullptr;
+    TransformD64_8way = nullptr;
+
+#if !defined(DISABLE_OPTIMIZED_SHA256)
+#if defined(HAVE_GETCPUID)
+    bool have_sse4 = false;
+    bool have_xsave = false;
+    bool have_avx = false;
+    [[maybe_unused]] bool have_avx2 = false;
+    [[maybe_unused]] bool have_x86_shani = false;
+    [[maybe_unused]] bool enabled_avx = false;
+
+    uint32_t eax, ebx, ecx, edx;
+    GetCPUID(1, 0, eax, ebx, ecx, edx);
+    if (use_implementation & sha256_implementation::USE_SSE4) {
+        have_sse4 = (ecx >> 19) & 1;
+    }
+    have_xsave = (ecx >> 27) & 1;
+    have_avx = (ecx >> 28) & 1;
+    if (have_xsave && have_avx) {
+        enabled_avx = AVXEnabled();
+    }
+    if (have_sse4) {
+        GetCPUID(7, 0, eax, ebx, ecx, edx);
+        if (use_implementation & sha256_implementation::USE_AVX2) {
+            have_avx2 = (ebx >> 5) & 1;
+        }
+        if (use_implementation & sha256_implementation::USE_SHANI) {
+            have_x86_shani = (ebx >> 29) & 1;
+        }
+    }
+
+#if defined(ENABLE_SSE41) && defined(ENABLE_X86_SHANI)
+    if (have_x86_shani) {
+        Transform = sha256_x86_shani::Transform;
+        TransformD64 = TransformD64Wrapper<sha256_x86_shani::Transform>;
+        TransformD64_2way = sha256d64_x86_shani::Transform_2way;
+        ret = "x86_shani(1way,2way)";
+        have_sse4 = false; // Disable SSE4/AVX2;
+        have_avx2 = false;
+    }
+#endif
+
+    if (have_sse4) {
+#if defined(__x86_64__) || defined(__amd64__)
+        Transform = sha256_sse4::Transform;
+        TransformD64 = TransformD64Wrapper<sha256_sse4::Transform>;
+        ret = "sse4(1way)";
+#endif
+#if defined(ENABLE_SSE41)
+        TransformD64_4way = sha256d64_sse41::Transform_4way;
+        ret += ",sse41(4way)";
+#endif
+    }
+
+#if defined(ENABLE_AVX2)
+    if (have_avx2 && have_avx && enabled_avx) {
+        TransformD64_8way = sha256d64_avx2::Transform_8way;
+        ret += ",avx2(8way)";
+    }
+#endif
+#endif // defined(HAVE_GETCPUID)
+
+#if defined(ENABLE_ARM_SHANI)
+    bool have_arm_shani = false;
+    if (use_implementation & sha256_implementation::USE_SHANI) {
+#if defined(__linux__)
+#if defined(__arm__) // 32-bit
+        if (getauxval(AT_HWCAP2) & HWCAP2_SHA2) {
+            have_arm_shani = true;
+        }
+#endif
+#if defined(__aarch64__) // 64-bit
+        if (getauxval(AT_HWCAP) & HWCAP_SHA2) {
+            have_arm_shani = true;
+        }
+#endif
+#endif
+
+#if defined(__APPLE__)
+        int val = 0;
+        size_t len = sizeof(val);
+        if (sysctlbyname("hw.optional.arm.FEAT_SHA256", &val, &len, nullptr, 0) == 0) {
+            have_arm_shani = val != 0;
+        }
+#endif
+    }
+
+    if (have_arm_shani) {
+        Transform = sha256_arm_shani::Transform;
+        TransformD64 = TransformD64Wrapper<sha256_arm_shani::Transform>;
+        TransformD64_2way = sha256d64_arm_shani::Transform_2way;
+        ret = "arm_shani(1way,2way)";
+    }
+#endif
+#endif // DISABLE_OPTIMIZED_SHA256
+
+    assert(SelfTest());
+    return ret;
+}
+
+////// SHA-256
+
+CSHA256::CSHA256()
+{
+    sha256::Initialize(s);
+}
+
+CSHA256& CSHA256::Write(const unsigned char* data, size_t len)
+{
+    const unsigned char* end = data + len;
+    size_t bufsize = bytes % 64;
+    if (bufsize && bufsize + len >= 64) {
+        // Fill the buffer, and process it.
+        memcpy(buf + bufsize, data, 64 - bufsize);
+        bytes += 64 - bufsize;
+        data += 64 - bufsize;
+        Transform(s, buf, 1);
+        bufsize = 0;
+    }
+    if (end - data >= 64) {
+        size_t blocks = (end - data) / 64;
+        Transform(s, data, blocks);
+        data += 64 * blocks;
+        bytes += 64 * blocks;
+    }
+    if (end > data) {
+        // Fill the buffer with what remains.
+        memcpy(buf + bufsize, data, end - data);
+        bytes += end - data;
+    }
+    return *this;
+}
+
+void CSHA256::Finalize(unsigned char hash[OUTPUT_SIZE])
+{
+    static const unsigned char pad[64] = {0x80};
+    unsigned char sizedesc[8];
+    WriteBE64(sizedesc, bytes << 3);
+    Write(pad, 1 + ((119 - (bytes % 64)) % 64));
+    Write(sizedesc, 8);
+    WriteBE32(hash, s[0]);
+    WriteBE32(hash + 4, s[1]);
+    WriteBE32(hash + 8, s[2]);
+    WriteBE32(hash + 12, s[3]);
+    WriteBE32(hash + 16, s[4]);
+    WriteBE32(hash + 20, s[5]);
+    WriteBE32(hash + 24, s[6]);
+    WriteBE32(hash + 28, s[7]);
+}
+
+CSHA256& CSHA256::Reset()
+{
+    bytes = 0;
+    sha256::Initialize(s);
+    return *this;
+}
+
+void SHA256D64(unsigned char* out, const unsigned char* in, size_t blocks)
+{
+    if (TransformD64_8way) {
+        while (blocks >= 8) {
+            TransformD64_8way(out, in);
+            out += 256;
+            in += 512;
+            blocks -= 8;
+        }
+    }
+    if (TransformD64_4way) {
+        while (blocks >= 4) {
+            TransformD64_4way(out, in);
+            out += 128;
+            in += 256;
+            blocks -= 4;
+        }
+    }
+    if (TransformD64_2way) {
+        while (blocks >= 2) {
+            TransformD64_2way(out, in);
+            out += 64;
+            in += 128;
+            blocks -= 2;
+        }
+    }
+    while (blocks) {
+        TransformD64(out, in);
+        out += 32;
+        in += 64;
+        --blocks;
+    }
+}

--- a/modules/custommutator/util/sha256_sse4.cpp
+++ b/modules/custommutator/util/sha256_sse4.cpp
@@ -1,0 +1,1513 @@
+// Copyright (c) 2017-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+// This is a translation to GCC extended asm syntax from YASM code by Intel
+// (available at the bottom of this file).
+
+#include <cstdlib>
+#include <stdint.h>
+
+#if defined(__x86_64__) || defined(__amd64__)
+
+namespace sha256_sse4
+{
+void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks)
+#if defined(__clang__) && !defined(__OPTIMIZE__)
+  /*
+  clang is unable to compile this with -O0 and -fsanitize=address.
+  See upstream bug: https://github.com/llvm/llvm-project/issues/92182
+  */
+  __attribute__((no_sanitize("address")))
+#endif
+{
+    static const uint32_t K256 alignas(16) [] = {
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+        0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+        0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+        0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+        0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+        0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+        0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+        0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+    };
+    static const uint32_t FLIP_MASK alignas(16) [] = {0x00010203, 0x04050607, 0x08090a0b, 0x0c0d0e0f};
+    static const uint32_t SHUF_00BA alignas(16) [] = {0x03020100, 0x0b0a0908, 0xffffffff, 0xffffffff};
+    static const uint32_t SHUF_DC00 alignas(16) [] = {0xffffffff, 0xffffffff, 0x03020100, 0x0b0a0908};
+    uint32_t a, b, c, d, f, g, h, y0, y1, y2;
+    uint64_t tbl;
+    uint64_t inp_end, inp;
+    uint32_t xfer alignas(16) [4];
+
+    __asm__ __volatile__(
+        "shl    $0x6,%2;"
+        "je     Ldone_hash_%=;"
+        "add    %1,%2;"
+        "mov    %2,%14;"
+        "mov    (%0),%3;"
+        "mov    0x4(%0),%4;"
+        "mov    0x8(%0),%5;"
+        "mov    0xc(%0),%6;"
+        "mov    0x10(%0),%k2;"
+        "mov    0x14(%0),%7;"
+        "mov    0x18(%0),%8;"
+        "mov    0x1c(%0),%9;"
+        "movdqa %18,%%xmm12;"
+        "movdqa %19,%%xmm10;"
+        "movdqa %20,%%xmm11;"
+
+        "Lloop0_%=:"
+        "lea    %17,%13;"
+        "movdqu (%1),%%xmm4;"
+        "pshufb %%xmm12,%%xmm4;"
+        "movdqu 0x10(%1),%%xmm5;"
+        "pshufb %%xmm12,%%xmm5;"
+        "movdqu 0x20(%1),%%xmm6;"
+        "pshufb %%xmm12,%%xmm6;"
+        "movdqu 0x30(%1),%%xmm7;"
+        "pshufb %%xmm12,%%xmm7;"
+        "mov    %1,%15;"
+        "mov    $3,%1;"
+
+        "Lloop1_%=:"
+        "movdqa 0x0(%13),%%xmm9;"
+        "paddd  %%xmm4,%%xmm9;"
+        "movdqa %%xmm9,%16;"
+        "movdqa %%xmm7,%%xmm0;"
+        "mov    %k2,%10;"
+        "ror    $0xe,%10;"
+        "mov    %3,%11;"
+        "palignr $0x4,%%xmm6,%%xmm0;"
+        "ror    $0x9,%11;"
+        "xor    %k2,%10;"
+        "mov    %7,%12;"
+        "ror    $0x5,%10;"
+        "movdqa %%xmm5,%%xmm1;"
+        "xor    %3,%11;"
+        "xor    %8,%12;"
+        "paddd  %%xmm4,%%xmm0;"
+        "xor    %k2,%10;"
+        "and    %k2,%12;"
+        "ror    $0xb,%11;"
+        "palignr $0x4,%%xmm4,%%xmm1;"
+        "xor    %3,%11;"
+        "ror    $0x6,%10;"
+        "xor    %8,%12;"
+        "movdqa %%xmm1,%%xmm2;"
+        "ror    $0x2,%11;"
+        "add    %10,%12;"
+        "add    %16,%12;"
+        "movdqa %%xmm1,%%xmm3;"
+        "mov    %3,%10;"
+        "add    %12,%9;"
+        "mov    %3,%12;"
+        "pslld  $0x19,%%xmm1;"
+        "or     %5,%10;"
+        "add    %9,%6;"
+        "and    %5,%12;"
+        "psrld  $0x7,%%xmm2;"
+        "and    %4,%10;"
+        "add    %11,%9;"
+        "por    %%xmm2,%%xmm1;"
+        "or     %12,%10;"
+        "add    %10,%9;"
+        "movdqa %%xmm3,%%xmm2;"
+        "mov    %6,%10;"
+        "mov    %9,%11;"
+        "movdqa %%xmm3,%%xmm8;"
+        "ror    $0xe,%10;"
+        "xor    %6,%10;"
+        "mov    %k2,%12;"
+        "ror    $0x9,%11;"
+        "pslld  $0xe,%%xmm3;"
+        "xor    %9,%11;"
+        "ror    $0x5,%10;"
+        "xor    %7,%12;"
+        "psrld  $0x12,%%xmm2;"
+        "ror    $0xb,%11;"
+        "xor    %6,%10;"
+        "and    %6,%12;"
+        "ror    $0x6,%10;"
+        "pxor   %%xmm3,%%xmm1;"
+        "xor    %9,%11;"
+        "xor    %7,%12;"
+        "psrld  $0x3,%%xmm8;"
+        "add    %10,%12;"
+        "add    4+%16,%12;"
+        "ror    $0x2,%11;"
+        "pxor   %%xmm2,%%xmm1;"
+        "mov    %9,%10;"
+        "add    %12,%8;"
+        "mov    %9,%12;"
+        "pxor   %%xmm8,%%xmm1;"
+        "or     %4,%10;"
+        "add    %8,%5;"
+        "and    %4,%12;"
+        "pshufd $0xfa,%%xmm7,%%xmm2;"
+        "and    %3,%10;"
+        "add    %11,%8;"
+        "paddd  %%xmm1,%%xmm0;"
+        "or     %12,%10;"
+        "add    %10,%8;"
+        "movdqa %%xmm2,%%xmm3;"
+        "mov    %5,%10;"
+        "mov    %8,%11;"
+        "ror    $0xe,%10;"
+        "movdqa %%xmm2,%%xmm8;"
+        "xor    %5,%10;"
+        "ror    $0x9,%11;"
+        "mov    %6,%12;"
+        "xor    %8,%11;"
+        "ror    $0x5,%10;"
+        "psrlq  $0x11,%%xmm2;"
+        "xor    %k2,%12;"
+        "psrlq  $0x13,%%xmm3;"
+        "xor    %5,%10;"
+        "and    %5,%12;"
+        "psrld  $0xa,%%xmm8;"
+        "ror    $0xb,%11;"
+        "xor    %8,%11;"
+        "xor    %k2,%12;"
+        "ror    $0x6,%10;"
+        "pxor   %%xmm3,%%xmm2;"
+        "add    %10,%12;"
+        "ror    $0x2,%11;"
+        "add    8+%16,%12;"
+        "pxor   %%xmm2,%%xmm8;"
+        "mov    %8,%10;"
+        "add    %12,%7;"
+        "mov    %8,%12;"
+        "pshufb %%xmm10,%%xmm8;"
+        "or     %3,%10;"
+        "add    %7,%4;"
+        "and    %3,%12;"
+        "paddd  %%xmm8,%%xmm0;"
+        "and    %9,%10;"
+        "add    %11,%7;"
+        "pshufd $0x50,%%xmm0,%%xmm2;"
+        "or     %12,%10;"
+        "add    %10,%7;"
+        "movdqa %%xmm2,%%xmm3;"
+        "mov    %4,%10;"
+        "ror    $0xe,%10;"
+        "mov    %7,%11;"
+        "movdqa %%xmm2,%%xmm4;"
+        "ror    $0x9,%11;"
+        "xor    %4,%10;"
+        "mov    %5,%12;"
+        "ror    $0x5,%10;"
+        "psrlq  $0x11,%%xmm2;"
+        "xor    %7,%11;"
+        "xor    %6,%12;"
+        "psrlq  $0x13,%%xmm3;"
+        "xor    %4,%10;"
+        "and    %4,%12;"
+        "ror    $0xb,%11;"
+        "psrld  $0xa,%%xmm4;"
+        "xor    %7,%11;"
+        "ror    $0x6,%10;"
+        "xor    %6,%12;"
+        "pxor   %%xmm3,%%xmm2;"
+        "ror    $0x2,%11;"
+        "add    %10,%12;"
+        "add    12+%16,%12;"
+        "pxor   %%xmm2,%%xmm4;"
+        "mov    %7,%10;"
+        "add    %12,%k2;"
+        "mov    %7,%12;"
+        "pshufb %%xmm11,%%xmm4;"
+        "or     %9,%10;"
+        "add    %k2,%3;"
+        "and    %9,%12;"
+        "paddd  %%xmm0,%%xmm4;"
+        "and    %8,%10;"
+        "add    %11,%k2;"
+        "or     %12,%10;"
+        "add    %10,%k2;"
+        "movdqa 0x10(%13),%%xmm9;"
+        "paddd  %%xmm5,%%xmm9;"
+        "movdqa %%xmm9,%16;"
+        "movdqa %%xmm4,%%xmm0;"
+        "mov    %3,%10;"
+        "ror    $0xe,%10;"
+        "mov    %k2,%11;"
+        "palignr $0x4,%%xmm7,%%xmm0;"
+        "ror    $0x9,%11;"
+        "xor    %3,%10;"
+        "mov    %4,%12;"
+        "ror    $0x5,%10;"
+        "movdqa %%xmm6,%%xmm1;"
+        "xor    %k2,%11;"
+        "xor    %5,%12;"
+        "paddd  %%xmm5,%%xmm0;"
+        "xor    %3,%10;"
+        "and    %3,%12;"
+        "ror    $0xb,%11;"
+        "palignr $0x4,%%xmm5,%%xmm1;"
+        "xor    %k2,%11;"
+        "ror    $0x6,%10;"
+        "xor    %5,%12;"
+        "movdqa %%xmm1,%%xmm2;"
+        "ror    $0x2,%11;"
+        "add    %10,%12;"
+        "add    %16,%12;"
+        "movdqa %%xmm1,%%xmm3;"
+        "mov    %k2,%10;"
+        "add    %12,%6;"
+        "mov    %k2,%12;"
+        "pslld  $0x19,%%xmm1;"
+        "or     %8,%10;"
+        "add    %6,%9;"
+        "and    %8,%12;"
+        "psrld  $0x7,%%xmm2;"
+        "and    %7,%10;"
+        "add    %11,%6;"
+        "por    %%xmm2,%%xmm1;"
+        "or     %12,%10;"
+        "add    %10,%6;"
+        "movdqa %%xmm3,%%xmm2;"
+        "mov    %9,%10;"
+        "mov    %6,%11;"
+        "movdqa %%xmm3,%%xmm8;"
+        "ror    $0xe,%10;"
+        "xor    %9,%10;"
+        "mov    %3,%12;"
+        "ror    $0x9,%11;"
+        "pslld  $0xe,%%xmm3;"
+        "xor    %6,%11;"
+        "ror    $0x5,%10;"
+        "xor    %4,%12;"
+        "psrld  $0x12,%%xmm2;"
+        "ror    $0xb,%11;"
+        "xor    %9,%10;"
+        "and    %9,%12;"
+        "ror    $0x6,%10;"
+        "pxor   %%xmm3,%%xmm1;"
+        "xor    %6,%11;"
+        "xor    %4,%12;"
+        "psrld  $0x3,%%xmm8;"
+        "add    %10,%12;"
+        "add    4+%16,%12;"
+        "ror    $0x2,%11;"
+        "pxor   %%xmm2,%%xmm1;"
+        "mov    %6,%10;"
+        "add    %12,%5;"
+        "mov    %6,%12;"
+        "pxor   %%xmm8,%%xmm1;"
+        "or     %7,%10;"
+        "add    %5,%8;"
+        "and    %7,%12;"
+        "pshufd $0xfa,%%xmm4,%%xmm2;"
+        "and    %k2,%10;"
+        "add    %11,%5;"
+        "paddd  %%xmm1,%%xmm0;"
+        "or     %12,%10;"
+        "add    %10,%5;"
+        "movdqa %%xmm2,%%xmm3;"
+        "mov    %8,%10;"
+        "mov    %5,%11;"
+        "ror    $0xe,%10;"
+        "movdqa %%xmm2,%%xmm8;"
+        "xor    %8,%10;"
+        "ror    $0x9,%11;"
+        "mov    %9,%12;"
+        "xor    %5,%11;"
+        "ror    $0x5,%10;"
+        "psrlq  $0x11,%%xmm2;"
+        "xor    %3,%12;"
+        "psrlq  $0x13,%%xmm3;"
+        "xor    %8,%10;"
+        "and    %8,%12;"
+        "psrld  $0xa,%%xmm8;"
+        "ror    $0xb,%11;"
+        "xor    %5,%11;"
+        "xor    %3,%12;"
+        "ror    $0x6,%10;"
+        "pxor   %%xmm3,%%xmm2;"
+        "add    %10,%12;"
+        "ror    $0x2,%11;"
+        "add    8+%16,%12;"
+        "pxor   %%xmm2,%%xmm8;"
+        "mov    %5,%10;"
+        "add    %12,%4;"
+        "mov    %5,%12;"
+        "pshufb %%xmm10,%%xmm8;"
+        "or     %k2,%10;"
+        "add    %4,%7;"
+        "and    %k2,%12;"
+        "paddd  %%xmm8,%%xmm0;"
+        "and    %6,%10;"
+        "add    %11,%4;"
+        "pshufd $0x50,%%xmm0,%%xmm2;"
+        "or     %12,%10;"
+        "add    %10,%4;"
+        "movdqa %%xmm2,%%xmm3;"
+        "mov    %7,%10;"
+        "ror    $0xe,%10;"
+        "mov    %4,%11;"
+        "movdqa %%xmm2,%%xmm5;"
+        "ror    $0x9,%11;"
+        "xor    %7,%10;"
+        "mov    %8,%12;"
+        "ror    $0x5,%10;"
+        "psrlq  $0x11,%%xmm2;"
+        "xor    %4,%11;"
+        "xor    %9,%12;"
+        "psrlq  $0x13,%%xmm3;"
+        "xor    %7,%10;"
+        "and    %7,%12;"
+        "ror    $0xb,%11;"
+        "psrld  $0xa,%%xmm5;"
+        "xor    %4,%11;"
+        "ror    $0x6,%10;"
+        "xor    %9,%12;"
+        "pxor   %%xmm3,%%xmm2;"
+        "ror    $0x2,%11;"
+        "add    %10,%12;"
+        "add    12+%16,%12;"
+        "pxor   %%xmm2,%%xmm5;"
+        "mov    %4,%10;"
+        "add    %12,%3;"
+        "mov    %4,%12;"
+        "pshufb %%xmm11,%%xmm5;"
+        "or     %6,%10;"
+        "add    %3,%k2;"
+        "and    %6,%12;"
+        "paddd  %%xmm0,%%xmm5;"
+        "and    %5,%10;"
+        "add    %11,%3;"
+        "or     %12,%10;"
+        "add    %10,%3;"
+        "movdqa 0x20(%13),%%xmm9;"
+        "paddd  %%xmm6,%%xmm9;"
+        "movdqa %%xmm9,%16;"
+        "movdqa %%xmm5,%%xmm0;"
+        "mov    %k2,%10;"
+        "ror    $0xe,%10;"
+        "mov    %3,%11;"
+        "palignr $0x4,%%xmm4,%%xmm0;"
+        "ror    $0x9,%11;"
+        "xor    %k2,%10;"
+        "mov    %7,%12;"
+        "ror    $0x5,%10;"
+        "movdqa %%xmm7,%%xmm1;"
+        "xor    %3,%11;"
+        "xor    %8,%12;"
+        "paddd  %%xmm6,%%xmm0;"
+        "xor    %k2,%10;"
+        "and    %k2,%12;"
+        "ror    $0xb,%11;"
+        "palignr $0x4,%%xmm6,%%xmm1;"
+        "xor    %3,%11;"
+        "ror    $0x6,%10;"
+        "xor    %8,%12;"
+        "movdqa %%xmm1,%%xmm2;"
+        "ror    $0x2,%11;"
+        "add    %10,%12;"
+        "add    %16,%12;"
+        "movdqa %%xmm1,%%xmm3;"
+        "mov    %3,%10;"
+        "add    %12,%9;"
+        "mov    %3,%12;"
+        "pslld  $0x19,%%xmm1;"
+        "or     %5,%10;"
+        "add    %9,%6;"
+        "and    %5,%12;"
+        "psrld  $0x7,%%xmm2;"
+        "and    %4,%10;"
+        "add    %11,%9;"
+        "por    %%xmm2,%%xmm1;"
+        "or     %12,%10;"
+        "add    %10,%9;"
+        "movdqa %%xmm3,%%xmm2;"
+        "mov    %6,%10;"
+        "mov    %9,%11;"
+        "movdqa %%xmm3,%%xmm8;"
+        "ror    $0xe,%10;"
+        "xor    %6,%10;"
+        "mov    %k2,%12;"
+        "ror    $0x9,%11;"
+        "pslld  $0xe,%%xmm3;"
+        "xor    %9,%11;"
+        "ror    $0x5,%10;"
+        "xor    %7,%12;"
+        "psrld  $0x12,%%xmm2;"
+        "ror    $0xb,%11;"
+        "xor    %6,%10;"
+        "and    %6,%12;"
+        "ror    $0x6,%10;"
+        "pxor   %%xmm3,%%xmm1;"
+        "xor    %9,%11;"
+        "xor    %7,%12;"
+        "psrld  $0x3,%%xmm8;"
+        "add    %10,%12;"
+        "add    4+%16,%12;"
+        "ror    $0x2,%11;"
+        "pxor   %%xmm2,%%xmm1;"
+        "mov    %9,%10;"
+        "add    %12,%8;"
+        "mov    %9,%12;"
+        "pxor   %%xmm8,%%xmm1;"
+        "or     %4,%10;"
+        "add    %8,%5;"
+        "and    %4,%12;"
+        "pshufd $0xfa,%%xmm5,%%xmm2;"
+        "and    %3,%10;"
+        "add    %11,%8;"
+        "paddd  %%xmm1,%%xmm0;"
+        "or     %12,%10;"
+        "add    %10,%8;"
+        "movdqa %%xmm2,%%xmm3;"
+        "mov    %5,%10;"
+        "mov    %8,%11;"
+        "ror    $0xe,%10;"
+        "movdqa %%xmm2,%%xmm8;"
+        "xor    %5,%10;"
+        "ror    $0x9,%11;"
+        "mov    %6,%12;"
+        "xor    %8,%11;"
+        "ror    $0x5,%10;"
+        "psrlq  $0x11,%%xmm2;"
+        "xor    %k2,%12;"
+        "psrlq  $0x13,%%xmm3;"
+        "xor    %5,%10;"
+        "and    %5,%12;"
+        "psrld  $0xa,%%xmm8;"
+        "ror    $0xb,%11;"
+        "xor    %8,%11;"
+        "xor    %k2,%12;"
+        "ror    $0x6,%10;"
+        "pxor   %%xmm3,%%xmm2;"
+        "add    %10,%12;"
+        "ror    $0x2,%11;"
+        "add    8+%16,%12;"
+        "pxor   %%xmm2,%%xmm8;"
+        "mov    %8,%10;"
+        "add    %12,%7;"
+        "mov    %8,%12;"
+        "pshufb %%xmm10,%%xmm8;"
+        "or     %3,%10;"
+        "add    %7,%4;"
+        "and    %3,%12;"
+        "paddd  %%xmm8,%%xmm0;"
+        "and    %9,%10;"
+        "add    %11,%7;"
+        "pshufd $0x50,%%xmm0,%%xmm2;"
+        "or     %12,%10;"
+        "add    %10,%7;"
+        "movdqa %%xmm2,%%xmm3;"
+        "mov    %4,%10;"
+        "ror    $0xe,%10;"
+        "mov    %7,%11;"
+        "movdqa %%xmm2,%%xmm6;"
+        "ror    $0x9,%11;"
+        "xor    %4,%10;"
+        "mov    %5,%12;"
+        "ror    $0x5,%10;"
+        "psrlq  $0x11,%%xmm2;"
+        "xor    %7,%11;"
+        "xor    %6,%12;"
+        "psrlq  $0x13,%%xmm3;"
+        "xor    %4,%10;"
+        "and    %4,%12;"
+        "ror    $0xb,%11;"
+        "psrld  $0xa,%%xmm6;"
+        "xor    %7,%11;"
+        "ror    $0x6,%10;"
+        "xor    %6,%12;"
+        "pxor   %%xmm3,%%xmm2;"
+        "ror    $0x2,%11;"
+        "add    %10,%12;"
+        "add    12+%16,%12;"
+        "pxor   %%xmm2,%%xmm6;"
+        "mov    %7,%10;"
+        "add    %12,%k2;"
+        "mov    %7,%12;"
+        "pshufb %%xmm11,%%xmm6;"
+        "or     %9,%10;"
+        "add    %k2,%3;"
+        "and    %9,%12;"
+        "paddd  %%xmm0,%%xmm6;"
+        "and    %8,%10;"
+        "add    %11,%k2;"
+        "or     %12,%10;"
+        "add    %10,%k2;"
+        "movdqa 0x30(%13),%%xmm9;"
+        "paddd  %%xmm7,%%xmm9;"
+        "movdqa %%xmm9,%16;"
+        "add    $0x40,%13;"
+        "movdqa %%xmm6,%%xmm0;"
+        "mov    %3,%10;"
+        "ror    $0xe,%10;"
+        "mov    %k2,%11;"
+        "palignr $0x4,%%xmm5,%%xmm0;"
+        "ror    $0x9,%11;"
+        "xor    %3,%10;"
+        "mov    %4,%12;"
+        "ror    $0x5,%10;"
+        "movdqa %%xmm4,%%xmm1;"
+        "xor    %k2,%11;"
+        "xor    %5,%12;"
+        "paddd  %%xmm7,%%xmm0;"
+        "xor    %3,%10;"
+        "and    %3,%12;"
+        "ror    $0xb,%11;"
+        "palignr $0x4,%%xmm7,%%xmm1;"
+        "xor    %k2,%11;"
+        "ror    $0x6,%10;"
+        "xor    %5,%12;"
+        "movdqa %%xmm1,%%xmm2;"
+        "ror    $0x2,%11;"
+        "add    %10,%12;"
+        "add    %16,%12;"
+        "movdqa %%xmm1,%%xmm3;"
+        "mov    %k2,%10;"
+        "add    %12,%6;"
+        "mov    %k2,%12;"
+        "pslld  $0x19,%%xmm1;"
+        "or     %8,%10;"
+        "add    %6,%9;"
+        "and    %8,%12;"
+        "psrld  $0x7,%%xmm2;"
+        "and    %7,%10;"
+        "add    %11,%6;"
+        "por    %%xmm2,%%xmm1;"
+        "or     %12,%10;"
+        "add    %10,%6;"
+        "movdqa %%xmm3,%%xmm2;"
+        "mov    %9,%10;"
+        "mov    %6,%11;"
+        "movdqa %%xmm3,%%xmm8;"
+        "ror    $0xe,%10;"
+        "xor    %9,%10;"
+        "mov    %3,%12;"
+        "ror    $0x9,%11;"
+        "pslld  $0xe,%%xmm3;"
+        "xor    %6,%11;"
+        "ror    $0x5,%10;"
+        "xor    %4,%12;"
+        "psrld  $0x12,%%xmm2;"
+        "ror    $0xb,%11;"
+        "xor    %9,%10;"
+        "and    %9,%12;"
+        "ror    $0x6,%10;"
+        "pxor   %%xmm3,%%xmm1;"
+        "xor    %6,%11;"
+        "xor    %4,%12;"
+        "psrld  $0x3,%%xmm8;"
+        "add    %10,%12;"
+        "add    4+%16,%12;"
+        "ror    $0x2,%11;"
+        "pxor   %%xmm2,%%xmm1;"
+        "mov    %6,%10;"
+        "add    %12,%5;"
+        "mov    %6,%12;"
+        "pxor   %%xmm8,%%xmm1;"
+        "or     %7,%10;"
+        "add    %5,%8;"
+        "and    %7,%12;"
+        "pshufd $0xfa,%%xmm6,%%xmm2;"
+        "and    %k2,%10;"
+        "add    %11,%5;"
+        "paddd  %%xmm1,%%xmm0;"
+        "or     %12,%10;"
+        "add    %10,%5;"
+        "movdqa %%xmm2,%%xmm3;"
+        "mov    %8,%10;"
+        "mov    %5,%11;"
+        "ror    $0xe,%10;"
+        "movdqa %%xmm2,%%xmm8;"
+        "xor    %8,%10;"
+        "ror    $0x9,%11;"
+        "mov    %9,%12;"
+        "xor    %5,%11;"
+        "ror    $0x5,%10;"
+        "psrlq  $0x11,%%xmm2;"
+        "xor    %3,%12;"
+        "psrlq  $0x13,%%xmm3;"
+        "xor    %8,%10;"
+        "and    %8,%12;"
+        "psrld  $0xa,%%xmm8;"
+        "ror    $0xb,%11;"
+        "xor    %5,%11;"
+        "xor    %3,%12;"
+        "ror    $0x6,%10;"
+        "pxor   %%xmm3,%%xmm2;"
+        "add    %10,%12;"
+        "ror    $0x2,%11;"
+        "add    8+%16,%12;"
+        "pxor   %%xmm2,%%xmm8;"
+        "mov    %5,%10;"
+        "add    %12,%4;"
+        "mov    %5,%12;"
+        "pshufb %%xmm10,%%xmm8;"
+        "or     %k2,%10;"
+        "add    %4,%7;"
+        "and    %k2,%12;"
+        "paddd  %%xmm8,%%xmm0;"
+        "and    %6,%10;"
+        "add    %11,%4;"
+        "pshufd $0x50,%%xmm0,%%xmm2;"
+        "or     %12,%10;"
+        "add    %10,%4;"
+        "movdqa %%xmm2,%%xmm3;"
+        "mov    %7,%10;"
+        "ror    $0xe,%10;"
+        "mov    %4,%11;"
+        "movdqa %%xmm2,%%xmm7;"
+        "ror    $0x9,%11;"
+        "xor    %7,%10;"
+        "mov    %8,%12;"
+        "ror    $0x5,%10;"
+        "psrlq  $0x11,%%xmm2;"
+        "xor    %4,%11;"
+        "xor    %9,%12;"
+        "psrlq  $0x13,%%xmm3;"
+        "xor    %7,%10;"
+        "and    %7,%12;"
+        "ror    $0xb,%11;"
+        "psrld  $0xa,%%xmm7;"
+        "xor    %4,%11;"
+        "ror    $0x6,%10;"
+        "xor    %9,%12;"
+        "pxor   %%xmm3,%%xmm2;"
+        "ror    $0x2,%11;"
+        "add    %10,%12;"
+        "add    12+%16,%12;"
+        "pxor   %%xmm2,%%xmm7;"
+        "mov    %4,%10;"
+        "add    %12,%3;"
+        "mov    %4,%12;"
+        "pshufb %%xmm11,%%xmm7;"
+        "or     %6,%10;"
+        "add    %3,%k2;"
+        "and    %6,%12;"
+        "paddd  %%xmm0,%%xmm7;"
+        "and    %5,%10;"
+        "add    %11,%3;"
+        "or     %12,%10;"
+        "add    %10,%3;"
+        "sub    $0x1,%1;"
+        "jne    Lloop1_%=;"
+        "mov    $0x2,%1;"
+
+        "Lloop2_%=:"
+        "paddd  0x0(%13),%%xmm4;"
+        "movdqa %%xmm4,%16;"
+        "mov    %k2,%10;"
+        "ror    $0xe,%10;"
+        "mov    %3,%11;"
+        "xor    %k2,%10;"
+        "ror    $0x9,%11;"
+        "mov    %7,%12;"
+        "xor    %3,%11;"
+        "ror    $0x5,%10;"
+        "xor    %8,%12;"
+        "xor    %k2,%10;"
+        "ror    $0xb,%11;"
+        "and    %k2,%12;"
+        "xor    %3,%11;"
+        "ror    $0x6,%10;"
+        "xor    %8,%12;"
+        "add    %10,%12;"
+        "ror    $0x2,%11;"
+        "add    %16,%12;"
+        "mov    %3,%10;"
+        "add    %12,%9;"
+        "mov    %3,%12;"
+        "or     %5,%10;"
+        "add    %9,%6;"
+        "and    %5,%12;"
+        "and    %4,%10;"
+        "add    %11,%9;"
+        "or     %12,%10;"
+        "add    %10,%9;"
+        "mov    %6,%10;"
+        "ror    $0xe,%10;"
+        "mov    %9,%11;"
+        "xor    %6,%10;"
+        "ror    $0x9,%11;"
+        "mov    %k2,%12;"
+        "xor    %9,%11;"
+        "ror    $0x5,%10;"
+        "xor    %7,%12;"
+        "xor    %6,%10;"
+        "ror    $0xb,%11;"
+        "and    %6,%12;"
+        "xor    %9,%11;"
+        "ror    $0x6,%10;"
+        "xor    %7,%12;"
+        "add    %10,%12;"
+        "ror    $0x2,%11;"
+        "add    4+%16,%12;"
+        "mov    %9,%10;"
+        "add    %12,%8;"
+        "mov    %9,%12;"
+        "or     %4,%10;"
+        "add    %8,%5;"
+        "and    %4,%12;"
+        "and    %3,%10;"
+        "add    %11,%8;"
+        "or     %12,%10;"
+        "add    %10,%8;"
+        "mov    %5,%10;"
+        "ror    $0xe,%10;"
+        "mov    %8,%11;"
+        "xor    %5,%10;"
+        "ror    $0x9,%11;"
+        "mov    %6,%12;"
+        "xor    %8,%11;"
+        "ror    $0x5,%10;"
+        "xor    %k2,%12;"
+        "xor    %5,%10;"
+        "ror    $0xb,%11;"
+        "and    %5,%12;"
+        "xor    %8,%11;"
+        "ror    $0x6,%10;"
+        "xor    %k2,%12;"
+        "add    %10,%12;"
+        "ror    $0x2,%11;"
+        "add    8+%16,%12;"
+        "mov    %8,%10;"
+        "add    %12,%7;"
+        "mov    %8,%12;"
+        "or     %3,%10;"
+        "add    %7,%4;"
+        "and    %3,%12;"
+        "and    %9,%10;"
+        "add    %11,%7;"
+        "or     %12,%10;"
+        "add    %10,%7;"
+        "mov    %4,%10;"
+        "ror    $0xe,%10;"
+        "mov    %7,%11;"
+        "xor    %4,%10;"
+        "ror    $0x9,%11;"
+        "mov    %5,%12;"
+        "xor    %7,%11;"
+        "ror    $0x5,%10;"
+        "xor    %6,%12;"
+        "xor    %4,%10;"
+        "ror    $0xb,%11;"
+        "and    %4,%12;"
+        "xor    %7,%11;"
+        "ror    $0x6,%10;"
+        "xor    %6,%12;"
+        "add    %10,%12;"
+        "ror    $0x2,%11;"
+        "add    12+%16,%12;"
+        "mov    %7,%10;"
+        "add    %12,%k2;"
+        "mov    %7,%12;"
+        "or     %9,%10;"
+        "add    %k2,%3;"
+        "and    %9,%12;"
+        "and    %8,%10;"
+        "add    %11,%k2;"
+        "or     %12,%10;"
+        "add    %10,%k2;"
+        "paddd  0x10(%13),%%xmm5;"
+        "movdqa %%xmm5,%16;"
+        "add    $0x20,%13;"
+        "mov    %3,%10;"
+        "ror    $0xe,%10;"
+        "mov    %k2,%11;"
+        "xor    %3,%10;"
+        "ror    $0x9,%11;"
+        "mov    %4,%12;"
+        "xor    %k2,%11;"
+        "ror    $0x5,%10;"
+        "xor    %5,%12;"
+        "xor    %3,%10;"
+        "ror    $0xb,%11;"
+        "and    %3,%12;"
+        "xor    %k2,%11;"
+        "ror    $0x6,%10;"
+        "xor    %5,%12;"
+        "add    %10,%12;"
+        "ror    $0x2,%11;"
+        "add    %16,%12;"
+        "mov    %k2,%10;"
+        "add    %12,%6;"
+        "mov    %k2,%12;"
+        "or     %8,%10;"
+        "add    %6,%9;"
+        "and    %8,%12;"
+        "and    %7,%10;"
+        "add    %11,%6;"
+        "or     %12,%10;"
+        "add    %10,%6;"
+        "mov    %9,%10;"
+        "ror    $0xe,%10;"
+        "mov    %6,%11;"
+        "xor    %9,%10;"
+        "ror    $0x9,%11;"
+        "mov    %3,%12;"
+        "xor    %6,%11;"
+        "ror    $0x5,%10;"
+        "xor    %4,%12;"
+        "xor    %9,%10;"
+        "ror    $0xb,%11;"
+        "and    %9,%12;"
+        "xor    %6,%11;"
+        "ror    $0x6,%10;"
+        "xor    %4,%12;"
+        "add    %10,%12;"
+        "ror    $0x2,%11;"
+        "add    4+%16,%12;"
+        "mov    %6,%10;"
+        "add    %12,%5;"
+        "mov    %6,%12;"
+        "or     %7,%10;"
+        "add    %5,%8;"
+        "and    %7,%12;"
+        "and    %k2,%10;"
+        "add    %11,%5;"
+        "or     %12,%10;"
+        "add    %10,%5;"
+        "mov    %8,%10;"
+        "ror    $0xe,%10;"
+        "mov    %5,%11;"
+        "xor    %8,%10;"
+        "ror    $0x9,%11;"
+        "mov    %9,%12;"
+        "xor    %5,%11;"
+        "ror    $0x5,%10;"
+        "xor    %3,%12;"
+        "xor    %8,%10;"
+        "ror    $0xb,%11;"
+        "and    %8,%12;"
+        "xor    %5,%11;"
+        "ror    $0x6,%10;"
+        "xor    %3,%12;"
+        "add    %10,%12;"
+        "ror    $0x2,%11;"
+        "add    8+%16,%12;"
+        "mov    %5,%10;"
+        "add    %12,%4;"
+        "mov    %5,%12;"
+        "or     %k2,%10;"
+        "add    %4,%7;"
+        "and    %k2,%12;"
+        "and    %6,%10;"
+        "add    %11,%4;"
+        "or     %12,%10;"
+        "add    %10,%4;"
+        "mov    %7,%10;"
+        "ror    $0xe,%10;"
+        "mov    %4,%11;"
+        "xor    %7,%10;"
+        "ror    $0x9,%11;"
+        "mov    %8,%12;"
+        "xor    %4,%11;"
+        "ror    $0x5,%10;"
+        "xor    %9,%12;"
+        "xor    %7,%10;"
+        "ror    $0xb,%11;"
+        "and    %7,%12;"
+        "xor    %4,%11;"
+        "ror    $0x6,%10;"
+        "xor    %9,%12;"
+        "add    %10,%12;"
+        "ror    $0x2,%11;"
+        "add    12+%16,%12;"
+        "mov    %4,%10;"
+        "add    %12,%3;"
+        "mov    %4,%12;"
+        "or     %6,%10;"
+        "add    %3,%k2;"
+        "and    %6,%12;"
+        "and    %5,%10;"
+        "add    %11,%3;"
+        "or     %12,%10;"
+        "add    %10,%3;"
+        "movdqa %%xmm6,%%xmm4;"
+        "movdqa %%xmm7,%%xmm5;"
+        "sub    $0x1,%1;"
+        "jne    Lloop2_%=;"
+        "add    (%0),%3;"
+        "mov    %3,(%0);"
+        "add    0x4(%0),%4;"
+        "mov    %4,0x4(%0);"
+        "add    0x8(%0),%5;"
+        "mov    %5,0x8(%0);"
+        "add    0xc(%0),%6;"
+        "mov    %6,0xc(%0);"
+        "add    0x10(%0),%k2;"
+        "mov    %k2,0x10(%0);"
+        "add    0x14(%0),%7;"
+        "mov    %7,0x14(%0);"
+        "add    0x18(%0),%8;"
+        "mov    %8,0x18(%0);"
+        "add    0x1c(%0),%9;"
+        "mov    %9,0x1c(%0);"
+        "mov    %15,%1;"
+        "add    $0x40,%1;"
+        "cmp    %14,%1;"
+        "jne    Lloop0_%=;"
+
+        "Ldone_hash_%=:"
+
+        : "+r"(s), "+r"(chunk), "+r"(blocks), "=r"(a), "=r"(b), "=r"(c), "=r"(d), /* e = chunk */ "=r"(f), "=r"(g), "=r"(h), "=r"(y0), "=r"(y1), "=r"(y2), "=r"(tbl), "+m"(inp_end), "+m"(inp), "+m"(xfer)
+        : "m"(K256), "m"(FLIP_MASK), "m"(SHUF_00BA), "m"(SHUF_DC00)
+        : "cc", "memory", "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7", "xmm8", "xmm9", "xmm10", "xmm11", "xmm12"
+   );
+}
+}
+
+/*
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Copyright (c) 2012, Intel Corporation 
+; 
+; All rights reserved. 
+; 
+; Redistribution and use in source and binary forms, with or without
+; modification, are permitted provided that the following conditions are
+; met: 
+; 
+; * Redistributions of source code must retain the above copyright
+;   notice, this list of conditions and the following disclaimer.  
+; 
+; * Redistributions in binary form must reproduce the above copyright
+;   notice, this list of conditions and the following disclaimer in the
+;   documentation and/or other materials provided with the
+;   distribution. 
+; 
+; * Neither the name of the Intel Corporation nor the names of its
+;   contributors may be used to endorse or promote products derived from
+;   this software without specific prior written permission. 
+; 
+; 
+; THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY
+; EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+; PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION OR
+; CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+; EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+; PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+; LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; Example YASM command lines:
+; Windows:  yasm -Xvc -f x64 -rnasm -pnasm -o sha256_sse4.obj -g cv8 sha256_sse4.asm
+; Linux:    yasm -f x64 -f elf64 -X gnu -g dwarf2 -D LINUX -o sha256_sse4.o sha256_sse4.asm
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; This code is described in an Intel White-Paper:
+; "Fast SHA-256 Implementations on Intel Architecture Processors"
+;
+; To find it, surf to https://www.intel.com/p/en_US/embedded
+; and search for that title.
+; The paper is expected to be released roughly at the end of April, 2012
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; This code schedules 1 blocks at a time, with 4 lanes per block
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%define	MOVDQ movdqu ;; assume buffers not aligned 
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Define Macros
+
+; addm [mem], reg
+; Add reg to mem using reg-mem add and store
+%macro addm 2
+    add	%2, %1
+    mov	%1, %2
+%endm
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; COPY_XMM_AND_BSWAP xmm, [mem], byte_flip_mask
+; Load xmm with mem and byte swap each dword
+%macro COPY_XMM_AND_BSWAP 3
+    MOVDQ %1, %2
+    pshufb %1, %3
+%endmacro
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+%define X0 xmm4
+%define X1 xmm5
+%define X2 xmm6
+%define X3 xmm7
+
+%define XTMP0 xmm0
+%define XTMP1 xmm1
+%define XTMP2 xmm2
+%define XTMP3 xmm3
+%define XTMP4 xmm8
+%define XFER  xmm9
+
+%define SHUF_00BA	xmm10 ; shuffle xBxA -> 00BA
+%define SHUF_DC00	xmm11 ; shuffle xDxC -> DC00
+%define BYTE_FLIP_MASK	xmm12
+    
+%ifdef LINUX
+%define NUM_BLKS rdx	; 3rd arg
+%define CTX	rsi	; 2nd arg
+%define INP	rdi	; 1st arg
+
+%define SRND	rdi	; clobbers INP
+%define c	ecx
+%define d 	r8d
+%define e 	edx
+%else
+%define NUM_BLKS r8	; 3rd arg
+%define CTX	rdx 	; 2nd arg
+%define INP	rcx 	; 1st arg
+
+%define SRND	rcx	; clobbers INP
+%define c 	edi 
+%define d	esi 
+%define e 	r8d
+    
+%endif
+%define TBL	rbp
+%define a eax
+%define b ebx
+
+%define f r9d
+%define g r10d
+%define h r11d
+
+%define y0 r13d
+%define y1 r14d
+%define y2 r15d
+
+
+
+_INP_END_SIZE	equ 8
+_INP_SIZE	equ 8
+_XFER_SIZE	equ 8
+%ifdef LINUX
+_XMM_SAVE_SIZE	equ 0
+%else
+_XMM_SAVE_SIZE	equ 7*16
+%endif
+; STACK_SIZE plus pushes must be an odd multiple of 8
+_ALIGN_SIZE	equ 8
+
+_INP_END	equ 0
+_INP		equ _INP_END  + _INP_END_SIZE
+_XFER		equ _INP      + _INP_SIZE
+_XMM_SAVE	equ _XFER     + _XFER_SIZE + _ALIGN_SIZE
+STACK_SIZE	equ _XMM_SAVE + _XMM_SAVE_SIZE
+
+; rotate_Xs
+; Rotate values of symbols X0...X3
+%macro rotate_Xs 0
+%xdefine X_ X0
+%xdefine X0 X1
+%xdefine X1 X2
+%xdefine X2 X3
+%xdefine X3 X_
+%endm
+
+; ROTATE_ARGS
+; Rotate values of symbols a...h
+%macro ROTATE_ARGS 0
+%xdefine TMP_ h
+%xdefine h g
+%xdefine g f
+%xdefine f e
+%xdefine e d
+%xdefine d c
+%xdefine c b
+%xdefine b a
+%xdefine a TMP_
+%endm
+
+%macro FOUR_ROUNDS_AND_SCHED 0
+	;; compute s0 four at a time and s1 two at a time
+	;; compute W[-16] + W[-7] 4 at a time
+	movdqa	XTMP0, X3
+    mov	y0, e		; y0 = e
+    ror	y0, (25-11)	; y0 = e >> (25-11)
+    mov	y1, a		; y1 = a
+	palignr	XTMP0, X2, 4	; XTMP0 = W[-7]
+    ror	y1, (22-13)	; y1 = a >> (22-13)
+    xor	y0, e		; y0 = e ^ (e >> (25-11))
+    mov	y2, f		; y2 = f
+    ror	y0, (11-6)	; y0 = (e >> (11-6)) ^ (e >> (25-6))
+	movdqa	XTMP1, X1
+    xor	y1, a		; y1 = a ^ (a >> (22-13)
+    xor	y2, g		; y2 = f^g
+	paddd	XTMP0, X0	; XTMP0 = W[-7] + W[-16]
+    xor	y0, e		; y0 = e ^ (e >> (11-6)) ^ (e >> (25-6))
+    and	y2, e		; y2 = (f^g)&e
+    ror	y1, (13-2)	; y1 = (a >> (13-2)) ^ (a >> (22-2))
+	;; compute s0
+	palignr	XTMP1, X0, 4	; XTMP1 = W[-15]
+    xor	y1, a		; y1 = a ^ (a >> (13-2)) ^ (a >> (22-2))
+    ror	y0, 6		; y0 = S1 = (e>>6) & (e>>11) ^ (e>>25)
+    xor	y2, g		; y2 = CH = ((f^g)&e)^g
+	movdqa	XTMP2, XTMP1	; XTMP2 = W[-15]
+    ror	y1, 2		; y1 = S0 = (a>>2) ^ (a>>13) ^ (a>>22)
+    add	y2, y0		; y2 = S1 + CH
+    add	y2, [rsp + _XFER + 0*4]	; y2 = k + w + S1 + CH
+	movdqa	XTMP3, XTMP1	; XTMP3 = W[-15]
+    mov	y0, a		; y0 = a
+    add	h, y2		; h = h + S1 + CH + k + w
+    mov	y2, a		; y2 = a
+	pslld	XTMP1, (32-7)
+    or	y0, c		; y0 = a|c
+    add	d, h		; d = d + h + S1 + CH + k + w
+    and	y2, c		; y2 = a&c
+	psrld	XTMP2, 7
+    and	y0, b		; y0 = (a|c)&b
+    add	h, y1		; h = h + S1 + CH + k + w + S0
+	por	XTMP1, XTMP2	; XTMP1 = W[-15] ror 7
+    or	y0, y2		; y0 = MAJ = (a|c)&b)|(a&c)
+    add	h, y0		; h = h + S1 + CH + k + w + S0 + MAJ
+
+ROTATE_ARGS
+	movdqa	XTMP2, XTMP3	; XTMP2 = W[-15]
+    mov	y0, e		; y0 = e
+    mov	y1, a		; y1 = a
+	movdqa	XTMP4, XTMP3	; XTMP4 = W[-15]
+    ror	y0, (25-11)	; y0 = e >> (25-11)
+    xor	y0, e		; y0 = e ^ (e >> (25-11))
+    mov	y2, f		; y2 = f
+    ror	y1, (22-13)	; y1 = a >> (22-13)
+	pslld	XTMP3, (32-18)
+    xor	y1, a		; y1 = a ^ (a >> (22-13)
+    ror	y0, (11-6)	; y0 = (e >> (11-6)) ^ (e >> (25-6))
+    xor	y2, g		; y2 = f^g
+	psrld	XTMP2, 18
+    ror	y1, (13-2)	; y1 = (a >> (13-2)) ^ (a >> (22-2))
+    xor	y0, e		; y0 = e ^ (e >> (11-6)) ^ (e >> (25-6))
+    and	y2, e		; y2 = (f^g)&e
+    ror	y0, 6		; y0 = S1 = (e>>6) & (e>>11) ^ (e>>25)
+	pxor	XTMP1, XTMP3
+    xor	y1, a		; y1 = a ^ (a >> (13-2)) ^ (a >> (22-2))
+    xor	y2, g		; y2 = CH = ((f^g)&e)^g
+	psrld	XTMP4, 3	; XTMP4 = W[-15] >> 3
+    add	y2, y0		; y2 = S1 + CH
+    add	y2, [rsp + _XFER + 1*4]	; y2 = k + w + S1 + CH
+    ror	y1, 2		; y1 = S0 = (a>>2) ^ (a>>13) ^ (a>>22)
+	pxor	XTMP1, XTMP2	; XTMP1 = W[-15] ror 7 ^ W[-15] ror 18
+    mov	y0, a		; y0 = a
+    add	h, y2		; h = h + S1 + CH + k + w
+    mov	y2, a		; y2 = a
+	pxor	XTMP1, XTMP4	; XTMP1 = s0
+    or	y0, c		; y0 = a|c
+    add	d, h		; d = d + h + S1 + CH + k + w
+    and	y2, c		; y2 = a&c
+	;; compute low s1
+	pshufd	XTMP2, X3, 11111010b	; XTMP2 = W[-2] {BBAA}
+    and	y0, b		; y0 = (a|c)&b
+    add	h, y1		; h = h + S1 + CH + k + w + S0
+	paddd	XTMP0, XTMP1	; XTMP0 = W[-16] + W[-7] + s0
+    or	y0, y2		; y0 = MAJ = (a|c)&b)|(a&c)
+    add	h, y0		; h = h + S1 + CH + k + w + S0 + MAJ
+
+ROTATE_ARGS
+	movdqa	XTMP3, XTMP2	; XTMP3 = W[-2] {BBAA}
+    mov	y0, e		; y0 = e
+    mov	y1, a		; y1 = a
+    ror	y0, (25-11)	; y0 = e >> (25-11)
+	movdqa	XTMP4, XTMP2	; XTMP4 = W[-2] {BBAA}
+    xor	y0, e		; y0 = e ^ (e >> (25-11))
+    ror	y1, (22-13)	; y1 = a >> (22-13)
+    mov	y2, f		; y2 = f
+    xor	y1, a		; y1 = a ^ (a >> (22-13)
+    ror	y0, (11-6)	; y0 = (e >> (11-6)) ^ (e >> (25-6))
+	psrlq	XTMP2, 17	; XTMP2 = W[-2] ror 17 {xBxA}
+    xor	y2, g		; y2 = f^g
+	psrlq	XTMP3, 19	; XTMP3 = W[-2] ror 19 {xBxA}
+    xor	y0, e		; y0 = e ^ (e >> (11-6)) ^ (e >> (25-6))
+    and	y2, e		; y2 = (f^g)&e
+	psrld	XTMP4, 10	; XTMP4 = W[-2] >> 10 {BBAA}
+    ror	y1, (13-2)	; y1 = (a >> (13-2)) ^ (a >> (22-2))
+    xor	y1, a		; y1 = a ^ (a >> (13-2)) ^ (a >> (22-2))
+    xor	y2, g		; y2 = CH = ((f^g)&e)^g
+    ror	y0, 6		; y0 = S1 = (e>>6) & (e>>11) ^ (e>>25)
+	pxor	XTMP2, XTMP3
+    add	y2, y0		; y2 = S1 + CH
+    ror	y1, 2		; y1 = S0 = (a>>2) ^ (a>>13) ^ (a>>22)
+    add	y2, [rsp + _XFER + 2*4]	; y2 = k + w + S1 + CH
+	pxor	XTMP4, XTMP2	; XTMP4 = s1 {xBxA}
+    mov	y0, a		; y0 = a
+    add	h, y2		; h = h + S1 + CH + k + w
+    mov	y2, a		; y2 = a
+	pshufb	XTMP4, SHUF_00BA	; XTMP4 = s1 {00BA}
+    or	y0, c		; y0 = a|c
+    add	d, h		; d = d + h + S1 + CH + k + w
+    and	y2, c		; y2 = a&c
+	paddd	XTMP0, XTMP4	; XTMP0 = {..., ..., W[1], W[0]}
+    and	y0, b		; y0 = (a|c)&b
+    add	h, y1		; h = h + S1 + CH + k + w + S0
+	;; compute high s1
+	pshufd	XTMP2, XTMP0, 01010000b	; XTMP2 = W[-2] {DDCC}
+    or	y0, y2		; y0 = MAJ = (a|c)&b)|(a&c)
+    add	h, y0		; h = h + S1 + CH + k + w + S0 + MAJ
+
+ROTATE_ARGS
+	movdqa	XTMP3, XTMP2	; XTMP3 = W[-2] {DDCC}
+    mov	y0, e		; y0 = e
+    ror	y0, (25-11)	; y0 = e >> (25-11)
+    mov	y1, a		; y1 = a
+	movdqa	X0,    XTMP2	; X0    = W[-2] {DDCC}
+    ror	y1, (22-13)	; y1 = a >> (22-13)
+    xor	y0, e		; y0 = e ^ (e >> (25-11))
+    mov	y2, f		; y2 = f
+    ror	y0, (11-6)	; y0 = (e >> (11-6)) ^ (e >> (25-6))
+	psrlq	XTMP2, 17	; XTMP2 = W[-2] ror 17 {xDxC}
+    xor	y1, a		; y1 = a ^ (a >> (22-13)
+    xor	y2, g		; y2 = f^g
+	psrlq	XTMP3, 19	; XTMP3 = W[-2] ror 19 {xDxC}
+    xor	y0, e		; y0 = e ^ (e >> (11-6)) ^ (e >> (25-6))
+    and	y2, e		; y2 = (f^g)&e
+    ror	y1, (13-2)	; y1 = (a >> (13-2)) ^ (a >> (22-2))
+	psrld	X0,    10	; X0 = W[-2] >> 10 {DDCC}
+    xor	y1, a		; y1 = a ^ (a >> (13-2)) ^ (a >> (22-2))
+    ror	y0, 6		; y0 = S1 = (e>>6) & (e>>11) ^ (e>>25)
+    xor	y2, g		; y2 = CH = ((f^g)&e)^g
+	pxor	XTMP2, XTMP3
+    ror	y1, 2		; y1 = S0 = (a>>2) ^ (a>>13) ^ (a>>22)
+    add	y2, y0		; y2 = S1 + CH
+    add	y2, [rsp + _XFER + 3*4]	; y2 = k + w + S1 + CH
+	pxor	X0, XTMP2	; X0 = s1 {xDxC}
+    mov	y0, a		; y0 = a
+    add	h, y2		; h = h + S1 + CH + k + w
+    mov	y2, a		; y2 = a
+	pshufb	X0, SHUF_DC00	; X0 = s1 {DC00}
+    or	y0, c		; y0 = a|c
+    add	d, h		; d = d + h + S1 + CH + k + w
+    and	y2, c		; y2 = a&c
+	paddd	X0, XTMP0	; X0 = {W[3], W[2], W[1], W[0]}
+    and	y0, b		; y0 = (a|c)&b
+    add	h, y1		; h = h + S1 + CH + k + w + S0
+    or	y0, y2		; y0 = MAJ = (a|c)&b)|(a&c)
+    add	h, y0		; h = h + S1 + CH + k + w + S0 + MAJ
+
+ROTATE_ARGS
+rotate_Xs
+%endm
+
+;; input is [rsp + _XFER + %1 * 4]
+%macro DO_ROUND 1
+    mov	y0, e		; y0 = e
+    ror	y0, (25-11)	; y0 = e >> (25-11)
+    mov	y1, a		; y1 = a
+    xor	y0, e		; y0 = e ^ (e >> (25-11))
+    ror	y1, (22-13)	; y1 = a >> (22-13)
+    mov	y2, f		; y2 = f
+    xor	y1, a		; y1 = a ^ (a >> (22-13)
+    ror	y0, (11-6)	; y0 = (e >> (11-6)) ^ (e >> (25-6))
+    xor	y2, g		; y2 = f^g
+    xor	y0, e		; y0 = e ^ (e >> (11-6)) ^ (e >> (25-6))
+    ror	y1, (13-2)	; y1 = (a >> (13-2)) ^ (a >> (22-2))
+    and	y2, e		; y2 = (f^g)&e
+    xor	y1, a		; y1 = a ^ (a >> (13-2)) ^ (a >> (22-2))
+    ror	y0, 6		; y0 = S1 = (e>>6) & (e>>11) ^ (e>>25)
+    xor	y2, g		; y2 = CH = ((f^g)&e)^g
+    add	y2, y0		; y2 = S1 + CH
+    ror	y1, 2		; y1 = S0 = (a>>2) ^ (a>>13) ^ (a>>22)
+    add	y2, [rsp + _XFER + %1 * 4]	; y2 = k + w + S1 + CH
+    mov	y0, a		; y0 = a
+    add	h, y2		; h = h + S1 + CH + k + w
+    mov	y2, a		; y2 = a
+    or	y0, c		; y0 = a|c
+    add	d, h		; d = d + h + S1 + CH + k + w
+    and	y2, c		; y2 = a&c
+    and	y0, b		; y0 = (a|c)&b
+    add	h, y1		; h = h + S1 + CH + k + w + S0
+    or	y0, y2		; y0 = MAJ = (a|c)&b)|(a&c)
+    add	h, y0		; h = h + S1 + CH + k + w + S0 + MAJ
+    ROTATE_ARGS
+%endm
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; void sha256_sse4(void *input_data, UINT32 digest[8], UINT64 num_blks)
+;; arg 1 : pointer to input data
+;; arg 2 : pointer to digest
+;; arg 3 : Num blocks
+section .text
+global sha256_sse4
+align 32
+sha256_sse4:
+    push	rbx
+%ifndef LINUX
+    push	rsi
+    push	rdi
+%endif
+    push	rbp
+    push	r13
+    push	r14
+    push	r15
+
+    sub	rsp,STACK_SIZE
+%ifndef LINUX
+    movdqa	[rsp + _XMM_SAVE + 0*16],xmm6	
+    movdqa	[rsp + _XMM_SAVE + 1*16],xmm7
+    movdqa	[rsp + _XMM_SAVE + 2*16],xmm8	
+    movdqa	[rsp + _XMM_SAVE + 3*16],xmm9	
+    movdqa	[rsp + _XMM_SAVE + 4*16],xmm10
+    movdqa	[rsp + _XMM_SAVE + 5*16],xmm11
+    movdqa	[rsp + _XMM_SAVE + 6*16],xmm12
+%endif
+
+    shl	NUM_BLKS, 6	; convert to bytes
+    jz	done_hash
+    add	NUM_BLKS, INP	; pointer to end of data
+    mov	[rsp + _INP_END], NUM_BLKS
+
+    ;; load initial digest
+    mov	a,[4*0 + CTX]
+    mov	b,[4*1 + CTX]
+    mov	c,[4*2 + CTX]
+    mov	d,[4*3 + CTX]
+    mov	e,[4*4 + CTX]
+    mov	f,[4*5 + CTX]
+    mov	g,[4*6 + CTX]
+    mov	h,[4*7 + CTX]
+
+    movdqa	BYTE_FLIP_MASK, [PSHUFFLE_BYTE_FLIP_MASK wrt rip]
+    movdqa	SHUF_00BA, [_SHUF_00BA wrt rip]
+    movdqa	SHUF_DC00, [_SHUF_DC00 wrt rip]
+
+loop0:
+    lea	TBL,[K256 wrt rip]
+
+    ;; byte swap first 16 dwords
+    COPY_XMM_AND_BSWAP	X0, [INP + 0*16], BYTE_FLIP_MASK
+    COPY_XMM_AND_BSWAP	X1, [INP + 1*16], BYTE_FLIP_MASK
+    COPY_XMM_AND_BSWAP	X2, [INP + 2*16], BYTE_FLIP_MASK
+    COPY_XMM_AND_BSWAP	X3, [INP + 3*16], BYTE_FLIP_MASK
+    
+    mov	[rsp + _INP], INP
+
+    ;; schedule 48 input dwords, by doing 3 rounds of 16 each
+    mov	SRND, 3
+align 16
+loop1:
+    movdqa	XFER, [TBL + 0*16]
+    paddd	XFER, X0
+    movdqa	[rsp + _XFER], XFER
+    FOUR_ROUNDS_AND_SCHED
+
+    movdqa	XFER, [TBL + 1*16]
+    paddd	XFER, X0
+    movdqa	[rsp + _XFER], XFER
+    FOUR_ROUNDS_AND_SCHED
+
+    movdqa	XFER, [TBL + 2*16]
+    paddd	XFER, X0
+    movdqa	[rsp + _XFER], XFER
+    FOUR_ROUNDS_AND_SCHED
+
+    movdqa	XFER, [TBL + 3*16]
+    paddd	XFER, X0
+    movdqa	[rsp + _XFER], XFER
+    add	TBL, 4*16
+    FOUR_ROUNDS_AND_SCHED
+
+    sub	SRND, 1
+    jne	loop1
+
+    mov	SRND, 2
+loop2:
+    paddd	X0, [TBL + 0*16]
+    movdqa	[rsp + _XFER], X0
+    DO_ROUND	0
+    DO_ROUND	1
+    DO_ROUND	2
+    DO_ROUND	3
+    paddd	X1, [TBL + 1*16]
+    movdqa	[rsp + _XFER], X1
+    add	TBL, 2*16
+    DO_ROUND	0
+    DO_ROUND	1
+    DO_ROUND	2
+    DO_ROUND	3
+
+    movdqa	X0, X2
+    movdqa	X1, X3
+
+    sub	SRND, 1
+    jne	loop2
+
+    addm	[4*0 + CTX],a
+    addm	[4*1 + CTX],b
+    addm	[4*2 + CTX],c
+    addm	[4*3 + CTX],d
+    addm	[4*4 + CTX],e
+    addm	[4*5 + CTX],f
+    addm	[4*6 + CTX],g
+    addm	[4*7 + CTX],h
+
+    mov	INP, [rsp + _INP]
+    add	INP, 64
+    cmp	INP, [rsp + _INP_END]
+    jne	loop0
+
+done_hash:
+%ifndef LINUX
+    movdqa	xmm6,[rsp + _XMM_SAVE + 0*16]
+    movdqa	xmm7,[rsp + _XMM_SAVE + 1*16]
+    movdqa	xmm8,[rsp + _XMM_SAVE + 2*16]
+    movdqa	xmm9,[rsp + _XMM_SAVE + 3*16]
+    movdqa	xmm10,[rsp + _XMM_SAVE + 4*16]
+    movdqa	xmm11,[rsp + _XMM_SAVE + 5*16]
+    movdqa	xmm12,[rsp + _XMM_SAVE + 6*16]
+%endif
+
+    add	rsp, STACK_SIZE
+
+    pop	r15
+    pop	r14
+    pop	r13
+    pop	rbp
+%ifndef LINUX
+    pop	rdi
+    pop	rsi
+%endif
+    pop	rbx
+
+    ret	
+    
+
+section .data
+align 64
+K256:
+    dd	0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5
+    dd	0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5
+    dd	0xd807aa98,0x12835b01,0x243185be,0x550c7dc3
+    dd	0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174
+    dd	0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc
+    dd	0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da
+    dd	0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7
+    dd	0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967
+    dd	0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13
+    dd	0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85
+    dd	0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3
+    dd	0xd192e819,0xd6990624,0xf40e3585,0x106aa070
+    dd	0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5
+    dd	0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3
+    dd	0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208
+    dd	0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+
+PSHUFFLE_BYTE_FLIP_MASK: ddq 0x0c0d0e0f08090a0b0405060700010203
+
+; shuffle xBxA -> 00BA
+_SHUF_00BA:              ddq 0xFFFFFFFFFFFFFFFF0b0a090803020100
+
+; shuffle xDxC -> DC00
+_SHUF_DC00:              ddq 0x0b0a090803020100FFFFFFFFFFFFFFFF
+*/
+
+#endif

--- a/modules/rustbitcoin/module.cpp
+++ b/modules/rustbitcoin/module.cpp
@@ -67,5 +67,14 @@ namespace bitcoinfuzz
             }
             return result; // Return the count, or handle as needed
         }
+        
+        std::optional<std::string> Rustbitcoin::parse_p2p_message(std::span<const uint8_t> buffer) const
+        {
+            auto message{rust_bitcoin_parse_p2p_message(buffer.data(), buffer.size())};
+            if (message == nullptr) return std::nullopt;
+            std::string result(message);
+            free_c_string(message);
+            return result;
+        }
     }
 }

--- a/modules/rustbitcoin/module.h
+++ b/modules/rustbitcoin/module.h
@@ -20,6 +20,7 @@ namespace bitcoinfuzz
             std::optional<std::string> psbt_parse(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> addrv2_parse(std::span<const uint8_t> buffer) const override;
             std::optional<int> cmpctblocks_parse(std::span<const uint8_t> buffer) const override;
+            std::optional<std::string> parse_p2p_message(std::span<const uint8_t> buffer) const override;
             ~Rustbitcoin() noexcept override = default;
         };
 

--- a/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
+++ b/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
@@ -8,3 +8,4 @@ extern "C" char* rust_bitcoin_psbt_parse(const uint8_t *data, size_t len);
 extern "C" char* rust_bitcoin_addrv2(const uint8_t *data, size_t len);
 extern "C" int32_t rust_bitcoin_cmpctblocks_parse(const uint8_t *data, size_t len);
 extern "C" void free_c_string(char* ptr);
+extern "C" char* rust_bitcoin_parse_p2p_message(const uint8_t *data, size_t len);

--- a/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
+++ b/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
@@ -1,3 +1,4 @@
+use bitcoin::absolute::Decodable;
 use bitcoin::address::Address;
 use bitcoin::bip152::HeaderAndShortIds;
 use bitcoin::block::BlockUncheckedExt;
@@ -5,7 +6,8 @@ use bitcoin::consensus::{deserialize_partial, encode, serialize};
 use bitcoin::script::{ScriptBuf, ScriptExt};
 use bitcoin::Block;
 use p2p::address::AddrV2;
-use p2p::message::AddrV2Payload;
+use p2p::message::{AddrV2Payload, RawNetworkMessage};
+use p2p::Magic;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::os::raw::c_char;
@@ -52,7 +54,10 @@ pub unsafe extern "C" fn rust_bitcoin_des_block(
             if err.to_string().starts_with("unsupported SegWit version") {
                 return str_to_c_string("skip error");
             }
-            if err.to_string().starts_with("parse failed: amount is greater than Amount::MAX_MONEY") {
+            if err
+                .to_string()
+                .starts_with("parse failed: amount is greater than Amount::MAX_MONEY")
+            {
                 return str_to_c_string("skip error");
             }
             return str_to_c_string("0");
@@ -78,6 +83,30 @@ pub unsafe extern "C" fn rust_bitcoin_script(data: *const u8, len: usize) -> *mu
             final_res.push_str(if s.0.is_push_only() { "1" } else { "0" });
             str_to_c_string(&final_res)
         }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_bitcoin_parse_p2p_message(
+    data: *const u8,
+    len: usize,
+) -> *mut c_char {
+    let mut data_slice = slice::from_raw_parts(data, len);
+
+    let message = match RawNetworkMessage::consensus_decode(&mut data_slice) {
+        Ok(m) => m,
+        Err(encode::Error::Parse(encode::ParseError::UnsupportedSegwitFlag(_))) => {
+            return std::ptr::null_mut()
+        }
+        Err(_) => return str_to_c_string("0"),
+    };
+    if message.magic() != &Magic::BITCOIN {
+        return str_to_c_string("0");
+    }
+    let cmd = message.cmd();
+    match cmd {
+        "unknown" => str_to_c_string("0"),
+        _ => str_to_c_string(cmd),
     }
 }
 


### PR DESCRIPTION
Add a new target parse_p2p_message for differential fuzzing of Bitcoin v1 P2P messages

### Changes
- Add btcd suport for the target
- Add rust-bitcoin suport for the target
- Add custom mutator to create valid checksums