### PR TITLE
fix: decode the address before passing it to DecodeString

### DIFF
--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -18,6 +18,7 @@ import (
 	"math/big"
 	"strings"
 	"unsafe"
+	"encoding/hex"
 
 	"github.com/btcsuite/btcd/addrmgr"
 	"github.com/btcsuite/btcd/blockchain"
@@ -207,7 +208,12 @@ func BTCDAddress(data C.ByteArray) *C.char {
 	addrBytes := C.GoBytes(unsafe.Pointer(data.data), data.length)
 	addrStr := string(addrBytes)
 
-	addr, err := btcutil.DecodeAddress(addrStr, &chaincfg.MainNetParams)
+	addr_decode, err := hex.DecodeString(addrStr)
+	if err != nil {
+		return C.CString("INVALID")
+	}
+
+	addr, err := btcutil.DecodeAddress(string(addr_decode), &chaincfg.MainNetParams)
 	if err != nil {
 		return C.CString("INVALID")
 	}


### PR DESCRIPTION
We need to decode the address string before passing it to the `DecodeString` method so that it can be detected as `INVALID` if it is an invalid address string.