### PR TITLE
feat: update clightning to latest commit master

### DIFF
--- a/modules/clightning/module.cpp
+++ b/modules/clightning/module.cpp
@@ -40,13 +40,20 @@ std::string hex_encode(const unsigned char* data, size_t len) {
     return oss.str();
 }
 
-std::string clightning_des_invoice(const std::string& input) {
+std::optional<std::string> clightning_des_invoice(const std::string& input) {
     char* fail = nullptr;
     const struct chainparams* params = chainparams_for_network("bitcoin");
 
     struct bolt11 *invoice = bolt11_decode(tmpctx, input.c_str(), nullptr, nullptr, params, &fail);
 
     if (!invoice) {
+        // Handle invoices without payment secrets by returning null
+        // This is needed because LND don't require payment secrets,
+        // and we need to maintain compatibility with that implementation
+        if (strcmp(fail, "Missing required payment secret (s field)") == 0) {
+            clean_tmpctx();
+            return std::nullopt;
+        }
         clean_tmpctx();
         return "";
     }


### PR DESCRIPTION
This pr update the clightning git submodule to the latest commit 266a5f9e856cddaecb17a36c6f09bff7900bd458

Clightning now requires payment secret and have made more changes in their bolt11 parsing.

see https://github.com/ElementsProject/lightning/pull/8377 for more details