### PR TITLE
  Return block hash on successful deserialization (#97)

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -30,11 +30,11 @@ namespace bitcoinfuzz
 
     void Driver::BlockDeserializationTarget(std::span<const uint8_t> buffer) const
     {
-        std::optional<std::vector<bool>> last_response{std::nullopt};
+        std::optional<std::string> last_response{std::nullopt};
         for (auto& module : modules)
         {
-            std::optional<std::vector<bool>> res{module.second->deserialize_block(buffer)};
-            if (!res.has_value() || res->empty()) continue;
+            std::optional<std::string> res{module.second->deserialize_block(buffer)};
+            if (!res.has_value()) continue;
             if (last_response.has_value()) assert(*res == *last_response);
             last_response = res.value();
         }

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -13,7 +13,7 @@ namespace bitcoinfuzz
         return std::nullopt;
     }
 
-    std::optional<std::vector<bool>> BaseModule::deserialize_block(std::span<const uint8_t> buffer) const
+    std::optional<std::string> BaseModule::deserialize_block(std::span<const uint8_t> buffer) const
     {
         return std::nullopt;
     }

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -18,7 +18,7 @@ namespace bitcoinfuzz
         BaseModule(const std::string &name) : name(name) {}
 
         virtual std::optional<std::string> script_parse(std::span<const uint8_t> buffer) const;
-        virtual std::optional<std::vector<bool>> deserialize_block(std::span<const uint8_t> buffer) const;
+        virtual std::optional<std::string> deserialize_block(std::span<const uint8_t> buffer) const;
         virtual std::optional<bool> script_eval(const std::vector<uint8_t>& input_data, unsigned int flags, size_t version) const;
         virtual std::optional<bool> descriptor_parse(std::string str) const;
         virtual std::optional<bool> miniscript_parse(std::string str) const;

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -284,22 +284,22 @@ std::optional<bool> Bitcoin::miniscript_parse(std::string str) const
     return false;
 }
 
-std::optional<std::vector<bool>> Bitcoin::deserialize_block(std::span<const uint8_t> buffer) const
+std::optional<std::string> Bitcoin::deserialize_block(std::span<const uint8_t> buffer) const
 {
     DataStream ds{buffer};
     CBlock block;
-    std::vector<bool> res{};
     try {
         ds >> TX_WITH_WITNESS(block);
     } catch (const std::ios_base::failure&) {
-        return res;
+        return std::nullopt;
     }
     if (block.vtx.empty()) {
-        res.push_back(false);
-    } else {
-        res.push_back(!IsBlockMutated(block, true));
+        return "0";
     }
-    return res;
+    if (IsBlockMutated(block, true)) {
+        return "0";
+    }
+    return block.GetHash().ToString();
 }
 
 std::optional<std::string> Bitcoin::script_asm(std::span<const uint8_t> buffer) const

--- a/modules/bitcoin/module.h
+++ b/modules/bitcoin/module.h
@@ -15,7 +15,7 @@ namespace bitcoinfuzz
         public:
             Bitcoin(void);
             std::optional<std::string> script_parse(std::span<const uint8_t> buffer) const override;
-            std::optional<std::vector<bool>> deserialize_block(std::span<const uint8_t> buffer) const override;
+            std::optional<std::string> deserialize_block(std::span<const uint8_t> buffer) const override;
             std::optional<bool> script_eval(const std::vector<uint8_t>& input_data, unsigned int flags, size_t version) const override;
             std::optional<bool> descriptor_parse(std::string str) const override;
             std::optional<bool> miniscript_parse(std::string str) const override;

--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -133,7 +133,7 @@ func BTCDDesBlock(scriptData C.ByteArray) *C.char {
 		return C.CString("0")
 	}
 
-	return C.CString("true")
+	return C.CString(block.Hash().String())
 }
 
 //export BTCDFreeString

--- a/modules/btcd/module.cpp
+++ b/modules/btcd/module.cpp
@@ -31,7 +31,7 @@ namespace bitcoinfuzz
             return res;
         }
 
-        std::optional<std::vector<bool>> Btcd::deserialize_block(std::span<const uint8_t> buffer) const
+        std::optional<std::string> Btcd::deserialize_block(std::span<const uint8_t> buffer) const
         {
             ByteArray script_data{
                 .data = reinterpret_cast<char *>(const_cast<uint8_t *>(buffer.data())),
@@ -40,8 +40,10 @@ namespace bitcoinfuzz
             auto pointer{BTCDDesBlock(script_data)};
             std::string result(pointer);
             BTCDFreeString(pointer);
-            std::vector<bool> final_result{"true" == result};
-            return final_result;
+            if (result == "unsupported segwit version") {
+                return std::nullopt;
+            }
+            return result;
         }
 
         std::optional<std::string> Btcd::addrv2_parse(std::span<const uint8_t> buffer) const

--- a/modules/btcd/module.h
+++ b/modules/btcd/module.h
@@ -15,7 +15,7 @@ namespace bitcoinfuzz
             Btcd(void);
             std::optional<bool> script_eval(const std::vector<uint8_t>& input_data, unsigned int flags, size_t version) const override;
             std::optional<std::string> script_asm(std::span<const uint8_t> buffer) const override;
-            std::optional<std::vector<bool>> deserialize_block(std::span<const uint8_t> buffer) const override;
+            std::optional<std::string> deserialize_block(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> address_parse(std::string str) const override;
             std::optional<std::string> psbt_parse(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> addrv2_parse(std::span<const uint8_t> buffer) const override;

--- a/modules/rustbitcoin/module.cpp
+++ b/modules/rustbitcoin/module.cpp
@@ -17,7 +17,7 @@ namespace bitcoinfuzz
             return result;
         }
 
-        std::optional<std::vector<bool>> Rustbitcoin::deserialize_block(std::span<const uint8_t> buffer) const
+        std::optional<std::string> Rustbitcoin::deserialize_block(std::span<const uint8_t> buffer) const
         {
             auto pointer{rust_bitcoin_des_block(buffer.data(), buffer.size())};
             std::string result(pointer);
@@ -25,8 +25,7 @@ namespace bitcoinfuzz
             if (result == "unsupported segwit version") {
                 return std::nullopt;
             }
-            std::vector<bool> final_result{"true" == result};
-            return final_result;
+            return result;
         }
 
         std::optional<std::string> Rustbitcoin::address_parse(std::string str) const

--- a/modules/rustbitcoin/module.h
+++ b/modules/rustbitcoin/module.h
@@ -15,7 +15,7 @@ namespace bitcoinfuzz
         public:
             Rustbitcoin(void);
             std::optional<std::string> script_parse(std::span<const uint8_t> buffer) const override;
-            std::optional<std::vector<bool>> deserialize_block(std::span<const uint8_t> buffer) const override;
+            std::optional<std::string> deserialize_block(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> address_parse(std::string str) const override;
             std::optional<std::string> psbt_parse(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> addrv2_parse(std::span<const uint8_t> buffer) const override;

--- a/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
+++ b/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
@@ -41,8 +41,13 @@ pub unsafe extern "C" fn rust_bitcoin_des_block(
 
     match res {
         Ok(res) => {
+            let block_hash = res.0.block_hash();
             let is_valid = res.0.validate().is_ok();
-            return str_to_c_string(is_valid.to_string().as_str());
+            if is_valid {
+                return str_to_c_string(&block_hash.to_string());
+            } else {
+                return str_to_c_string("0");
+            }
         }
         Err(err) => {
             if err.to_string().starts_with("unsupported segwit version") {


### PR DESCRIPTION
  Changes:
  - Modified `deserialize_block` functions to return block hash instead of boolean
  - Updated all modules (Bitcoin Core, BTCD, Rust-Bitcoin) to return hash string
  - Updated driver logic to compare hash strings

  This allows comparing block hashes between different implementations during fuzzing.
- Fixes #97