### PR TITLE
Add feature field to the `deserialize_invoice` target

### DIFF
--- a/modules/clightning/module.cpp
+++ b/modules/clightning/module.cpp
@@ -139,6 +139,11 @@ std::optional<std::string> clightning_des_invoice(const std::string& input) {
 
     result << ";MIN_CLTV=" << invoice->min_final_cltv_expiry;
 
+    result << ";FEATURES=";
+    if (invoice->features) {
+        result << hex_encode(invoice->features, tal_bytelen(invoice->features));
+    }
+
     clean_tmpctx();
     return result.str();
 }

--- a/modules/clightning/module.cpp
+++ b/modules/clightning/module.cpp
@@ -101,9 +101,7 @@ std::optional<std::string> clightning_des_invoice(const std::string& input) {
     // logic used in LND to ensure the same overflow characteristics.
     result << ";EXPIRY=" << (invoice->expiry * 1000000000) / 1000000000;
 
-    result << ";MIN_FINAL_CLTV_EXPIRY_DELTA=" << invoice->min_final_cltv_expiry;
     result << ";TIMESTAMP=" << invoice->timestamp;
-
 
     result << ";FALLBACK_ADDRESS=";
     if (invoice->fallbacks) {

--- a/modules/ldk/ldk_lib/src/lib.rs
+++ b/modules/ldk/ldk_lib/src/lib.rs
@@ -127,6 +127,13 @@ pub unsafe extern "C" fn ldk_des_invoice(input: *const std::os::raw::c_char) -> 
             result.push_str(";MIN_CLTV=");
             result.push_str(&invoice.min_final_cltv_expiry_delta().to_string());
 
+            result.push_str(";FEATURES=");
+            if invoice.features().is_some() {
+                let mut flags = invoice.features().unwrap().le_flags().to_vec();
+                flags.reverse();
+                result.push_str(&flags.to_hex_string(Case::Lower));
+            }
+
             str_to_c_string(&result)
         }
         // Handle invoices without payment secrets by returning null

--- a/modules/ldk/ldk_lib/src/lib.rs
+++ b/modules/ldk/ldk_lib/src/lib.rs
@@ -77,8 +77,6 @@ pub unsafe extern "C" fn ldk_des_invoice(input: *const std::os::raw::c_char) -> 
                     .as_str(),
             );
 
-            result.push_str(";MIN_FINAL_CLTV_EXPIRY_DELTA=");
-            result.push_str(&invoice.min_final_cltv_expiry_delta().to_string());
 
             result.push_str(";TIMESTAMP=");
             result.push_str(

--- a/modules/lnd/lnd_wrapper/wrapper.go
+++ b/modules/lnd/lnd_wrapper/wrapper.go
@@ -87,9 +87,6 @@ func LndDeserializeInvoice(cInvoiceStr *C.char) *C.char {
 	sb.WriteString(";EXPIRY=")
 	sb.WriteString(fmt.Sprintf("%d", uint64(invoice.Expiry().Nanoseconds())/1000000000))
 
-	sb.WriteString(";MIN_FINAL_CLTV_EXPIRY_DELTA=")
-	sb.WriteString(fmt.Sprintf("%d", invoice.MinFinalCLTVExpiry()))
-
 	sb.WriteString(";TIMESTAMP=")
 	sb.WriteString(fmt.Sprintf("%d", invoice.Timestamp.Unix()))
 

--- a/modules/lnd/lnd_wrapper/wrapper.go
+++ b/modules/lnd/lnd_wrapper/wrapper.go
@@ -7,6 +7,7 @@ package main
 import "C"
 
 import (
+	"bytes"
 	"fmt"
 	"runtime"
 	"strings"
@@ -122,6 +123,12 @@ func LndDeserializeInvoice(cInvoiceStr *C.char) *C.char {
 
 	sb.WriteString(";MIN_CLTV=")
 	sb.WriteString(fmt.Sprintf("%d", invoice.MinFinalCLTVExpiry()))
+
+	sb.WriteString(";FEATURES=")
+	var buf bytes.Buffer
+	if err := invoice.Features.RawFeatureVector.EncodeBase256(&buf); err == nil {
+		sb.WriteString(fmt.Sprintf("%x", buf.Bytes()))
+	}
 
 	return C.CString(sb.String())
 }


### PR DESCRIPTION
- Add the feature field to the formatted result in `deserialize_invoice` target.
- Remove duplicated field `MIN_FINAL_CLTV_EXPIRY_DELTA` field from the formatted result.