### PR TITLE
update: return length for compact blocks parse target

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <cstdint>
 #include <set>
 #include <algorithm>
 #include <unistd.h>
@@ -315,20 +316,20 @@ namespace bitcoinfuzz
 
     void Driver::CompactBlocksTarget(std::span<const uint8_t> buffer) const
     {
-        std::optional<int> last_response{std::nullopt};
+        std::optional<uint32_t> last_response{std::nullopt};
         std::string last_module_name;
 
         for (auto &module : modules)
         {
-            std::optional<int> res{module.second->cmpctblocks_parse(buffer)};
-            if (!res.has_value() || *res == -2)
+            std::optional<uint32_t> res{module.second->cmpctblocks_parse(buffer)};
+            if (!res.has_value() || *res == UINT32_MAX - 1)
                 continue;
 
             if (last_response.has_value()) {
                 if (*res != *last_response) {
                     if (!buffer.empty())
                     {
-                        for (size_t i = 0; std::min(size_t(32), buffer.size()); ++i)
+                        for (size_t i = 0; i < std::min(size_t(32), buffer.size()); ++i)
                             printf("%02x", buffer[i]);
                         if (buffer.size() > 32)
                             std::cout << "...";

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -63,7 +63,7 @@ namespace bitcoinfuzz
         return std::nullopt;
     }
 
-    std::optional<int32_t> BaseModule::cmpctblocks_parse(std::span<const uint8_t> buffer) const
+    std::optional<uint32_t> BaseModule::cmpctblocks_parse(std::span<const uint8_t> buffer) const
     {
         return std::nullopt;
     }

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -28,9 +28,8 @@ namespace bitcoinfuzz
         virtual std::optional<std::string> psbt_parse(std::span<const uint8_t> buffer) const;
         virtual std::optional<std::string> addrv2_parse(std::span<const uint8_t> buffer) const;
         virtual std::optional<std::string> deserialize_offer(std::string str) const;
-        virtual std::optional<int> cmpctblocks_parse(std::span<const uint8_t> buffer) const;
+        virtual std::optional<uint32_t> cmpctblocks_parse(std::span<const uint8_t> buffer) const;
         virtual std::optional<std::string> parse_p2p_message(std::span<const uint8_t> buffer) const;
-        
         virtual ~BaseModule() noexcept;
     };
 }

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <optional>
 #include <span>
 
@@ -456,7 +457,7 @@ std::optional<std::string> Bitcoin::psbt_parse(std::span<const uint8_t> buffer) 
     return result;
 }
 
-std::optional<int> Bitcoin::cmpctblocks_parse(std::span<const uint8_t> buffer) const
+std::optional<uint32_t> Bitcoin::cmpctblocks_parse(std::span<const uint8_t> buffer) const
 {
     DataStream ds{buffer};
     CBlockHeaderAndShortTxIDs block_header_and_short_txids;
@@ -465,18 +466,17 @@ std::optional<int> Bitcoin::cmpctblocks_parse(std::span<const uint8_t> buffer) c
         ds >> block_header_and_short_txids;
     } catch (const std::ios_base::failure& e) {
         if (std::string(e.what()).find("Superflous witness record") != std::string::npos)
-            return -2;
-        return std::nullopt;
+            return UINT32_MAX - 1;
+        return UINT32_MAX;
     }
 
     DataStream temp_ds{};
     try {
         temp_ds << block_header_and_short_txids;
-        return static_cast<int>(temp_ds.size());
+        return static_cast<uint32_t>(temp_ds.size());
     } catch (const std::exception& e) {
         return std::nullopt;
     }
-
 }
 
 } // namespace module

--- a/modules/bitcoin/module.h
+++ b/modules/bitcoin/module.h
@@ -23,7 +23,7 @@ namespace bitcoinfuzz
             std::optional<std::string> address_parse(std::string str) const override;
             std::optional<std::string> addrv2_parse(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> psbt_parse(std::span<const uint8_t> buffer) const override;
-            std::optional<int32_t> cmpctblocks_parse(std::span<const uint8_t> buffer) const override;
+            std::optional<uint32_t> cmpctblocks_parse(std::span<const uint8_t> buffer) const override;
             ~Bitcoin() noexcept override = default;
         };
 

--- a/modules/rustbitcoin/module.cpp
+++ b/modules/rustbitcoin/module.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <span>
 
 #include "module.h"
@@ -58,14 +59,16 @@ namespace bitcoinfuzz
             return result;
         }
 
-        std::optional<int> Rustbitcoin::cmpctblocks_parse(std::span<const uint8_t> buffer) const
+        std::optional<uint32_t> Rustbitcoin::cmpctblocks_parse(std::span<const uint8_t> buffer) const
         {
-            int32_t result = rust_bitcoin_cmpctblocks_parse(buffer.data(), buffer.size());
-            if (result == -1 || result == -2)
-            {
-                return result; // Return error codes as is
+            uint32_t result = rust_bitcoin_cmpctblocks_parse(buffer.data(), buffer.size());
+            if (result == UINT32_MAX) {
+                return std::nullopt;
             }
-            return result; // Return the count, or handle as needed
+            if (result == UINT32_MAX - 1) {
+                return result;
+            }
+            return result;
         }
         
         std::optional<std::string> Rustbitcoin::parse_p2p_message(std::span<const uint8_t> buffer) const

--- a/modules/rustbitcoin/module.h
+++ b/modules/rustbitcoin/module.h
@@ -19,7 +19,7 @@ namespace bitcoinfuzz
             std::optional<std::string> address_parse(std::string str) const override;
             std::optional<std::string> psbt_parse(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> addrv2_parse(std::span<const uint8_t> buffer) const override;
-            std::optional<int> cmpctblocks_parse(std::span<const uint8_t> buffer) const override;
+            std::optional<uint32_t> cmpctblocks_parse(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> parse_p2p_message(std::span<const uint8_t> buffer) const override;
             ~Rustbitcoin() noexcept override = default;
         };

--- a/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
+++ b/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
@@ -6,6 +6,6 @@ extern "C" char* rust_bitcoin_script_asm(const char* input);
 extern "C" char* rust_bitcoin_address_parse(const char* address);
 extern "C" char* rust_bitcoin_psbt_parse(const uint8_t *data, size_t len);
 extern "C" char* rust_bitcoin_addrv2(const uint8_t *data, size_t len);
-extern "C" int32_t rust_bitcoin_cmpctblocks_parse(const uint8_t *data, size_t len);
+extern "C" uint32_t rust_bitcoin_cmpctblocks_parse(const uint8_t *data, size_t len);
 extern "C" void free_c_string(char* ptr);
 extern "C" char* rust_bitcoin_parse_p2p_message(const uint8_t *data, size_t len);

--- a/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
+++ b/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
@@ -232,8 +232,13 @@ pub unsafe extern "C" fn rust_bitcoin_addrv2(data: *const u8, len: usize) -> *mu
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rust_bitcoin_cmpctblocks_parse(data: *const u8, len: usize) -> i32 {
-    // Safety: Ensure that the data pointer is valid for the given length
+pub unsafe extern "C" fn rust_bitcoin_cmpctblocks_parse(data: *const u8, len: usize) -> u32 {
+    
+    if data.is_null() || len == 0 {
+        return u32::MAX;
+    }
+    
+    // Safety: Ensure data pointer is valid for the given length
     let data_slice = slice::from_raw_parts(data, len);
 
     let res = deserialize_partial::<HeaderAndShortIds>(data_slice);
@@ -241,13 +246,14 @@ pub unsafe extern "C" fn rust_bitcoin_cmpctblocks_parse(data: *const u8, len: us
     match res {
         Ok((header_and_short_ids, _)) => {
             let serialized_data = serialize(&header_and_short_ids);
-            serialized_data.len() as i32
+            serialized_data.len() as u32
         }
         Err(err) => {
             if err.to_string().starts_with("unsupported segwit version") {
-                return -2;
+                u32::MAX - 1
+            } else {
+                u32::MAX
             }
-            return -1;
         }
     }
 }


### PR DESCRIPTION
This way we can keep the return type as `unsigned integer`, see [comment](https://github.com/bitcoinfuzz/bitcoinfuzz/pull/127#discussion_r2193125151).