### PR TITLE
fix(eclair): use absolute path to get the eclair lib path

### DIFF
--- a/modules/eclair/Makefile
+++ b/modules/eclair/Makefile
@@ -14,6 +14,9 @@ CXXFLAGS += -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(OS_NAME)
 ROOT_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
 ECLAIR_DIR := $(ROOT_DIR)/external/eclair
 
+LIB_DIR = $(shell pwd)/lib
+CXXFLAGS += -DLIB_DIR=\"$(LIB_DIR)\"
+
 all: module.a
 
 lib: eclair.zip

--- a/modules/eclair/module.cpp
+++ b/modules/eclair/module.cpp
@@ -13,6 +13,8 @@ static JavaVM* jvm = nullptr;
 static jclass decoderClass = nullptr;
 static jmethodID decodeMethod = nullptr;
 
+constexpr const char* LIB_DIR_PATH = LIB_DIR;
+
 static std::string cached_classpath;
 
 static const std::string build_classpath() {
@@ -23,7 +25,7 @@ static const std::string build_classpath() {
     bool first = true;
     
     try {
-        for (const auto& entry : fs::directory_iterator("./modules/eclair/lib")) {
+        for (const auto& entry : fs::directory_iterator(LIB_DIR_PATH)) {
             auto ext = entry.path().extension();
             if (ext == ".jar" || ext == ".class") {
                 if (!first) cp << ":";


### PR DESCRIPTION
Get rootdir at compile time and use it to find the correct path to the eclair lib.

Closes #234