### PR TITLE
feat: log loaded modules at startup for better visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target/
 Cargo.lock
 .vscode
 bitcoinfuzz
+!bitcoinfuzz/
 bin/
 obj/
 *.dylib

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ CXX := clang++
 BASE_CXXFLAGS := -fsanitize=address,fuzzer -Wall -Wextra -std=c++20 -I include -I .
 MODULES := $(wildcard modules/*/module.a)
 UNAME_S := $(shell uname -s)
+BITCOINFUZZ_SRC := basemodule modulelogger
+BITCOINFUZZ_OBJS := $(addprefix include/bitcoinfuzz/, $(addsuffix .o, $(BITCOINFUZZ_SRC)))
+
 
 ifeq ($(UNAME_S), Darwin)
 	LDFLAGS = -framework CoreFoundation -Wl,-ld_classic
@@ -32,20 +35,20 @@ ifneq ($(findstring -DECLAIR,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
 	else
 		JAVA_HOME ?= $(shell dirname $$(dirname $$(readlink -f $$(which javac))))
 	endif
-	
+
   JAVA_CXXFLAGS := -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(shell uname -s | tr '[:upper:]' '[:lower:]') -L$(JAVA_HOME)/lib/server -ljvm -Wl,-rpath,$(JAVA_HOME)/lib/server
 endif
 
 CXXFLAGS := $(BASE_CXXFLAGS) $(JAVA_CXXFLAGS) $(CXXFLAGS) $(PYTHON_LDFLAGS)
 
-bitcoinfuzz: main.cpp driver.o include/bitcoinfuzz/basemodule.o
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp $(MODULES) driver.o include/bitcoinfuzz/basemodule.o $(NBITCOIN_DYLIB) -o bitcoinfuzz $(PYTHON_LDFLAGS) $(SODIUM_LDLIBS)
+bitcoinfuzz: main.cpp driver.o $(BITCOINFUZZ_OBJS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp $(MODULES) driver.o $(BITCOINFUZZ_OBJS) $(NBITCOIN_DYLIB) -o bitcoinfuzz $(PYTHON_LDFLAGS) $(SODIUM_LDLIBS)
 
 driver.o: driver.cpp driver.h
 	$(CXX) $(CXXFLAGS) -c driver.cpp -o driver.o
 
-include/bitcoinfuzz/basemodule.o: include/bitcoinfuzz/basemodule.cpp include/bitcoinfuzz/basemodule.h
-	$(CXX) $(CXXFLAGS) -c include/bitcoinfuzz/basemodule.cpp -o include/bitcoinfuzz/basemodule.o
+include/bitcoinfuzz/%.o: include/bitcoinfuzz/%.cpp include/bitcoinfuzz/%.h
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 clean:
 	rm -rf *.o module.a bitcoinfuzz include/bitcoinfuzz/*.o $(MODULES)

--- a/driver.cpp
+++ b/driver.cpp
@@ -14,6 +14,7 @@ namespace bitcoinfuzz
     void Driver::LoadModule(std::shared_ptr<BaseModule> module)
     {
         modules[module->name] = module;
+        module_logger.addModule(module->name);
     }
 
     void Driver::ScriptTarget(std::span<const uint8_t> buffer) const

--- a/driver.h
+++ b/driver.h
@@ -9,15 +9,18 @@
 #include <utility>
 
 #include <bitcoinfuzz/basemodule.h>
+#include <bitcoinfuzz/modulelogger.h>
 
 namespace bitcoinfuzz
 {
     class Driver
     {
     private:
+        ModuleLogger& module_logger;
         std::map<std::string, std::shared_ptr<BaseModule>> modules;
 
     public:
+        Driver(ModuleLogger& logger) : module_logger(logger) {}
         void LoadModule(std::shared_ptr<BaseModule> module);
         void ScriptTarget(std::span<const uint8_t>) const;
         void ScriptEvalTarget(std::span<const uint8_t> buffer) const;

--- a/include/bitcoinfuzz/modulelogger.cpp
+++ b/include/bitcoinfuzz/modulelogger.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <vector>
+#include <string>
+#include "modulelogger.h"
+
+namespace bitcoinfuzz
+{
+    void ModuleLogger::addModule(const std::string& module_name) {
+        if (logged) return;
+        loaded_modules.push_back(module_name);
+    }
+
+    void ModuleLogger::addCustomMutator(const std::string& mutator_name) {
+        if (logged) return;
+        custom_mutators.push_back(mutator_name);
+    }
+
+    void ModuleLogger::logModules() {
+        if (logged) return;
+        logged = true;
+
+        std::cout << "=== BitcoinFuzz Module Activation Log ===" << std::endl;
+        std::cout << "Target: " << (std::getenv("FUZZ") ? std::getenv("FUZZ") : "default") << std::endl;
+
+        if (!loaded_modules.empty()) {
+            std::cout << "Loaded Modules (" << loaded_modules.size() << "):" << std::endl;
+            for (size_t i = 0; i < loaded_modules.size(); ++i) {
+                std::cout << "  [" << (i + 1) << "] " << loaded_modules[i] << std::endl;
+            }
+        } else {
+            std::cout << "No modules loaded!" << std::endl;
+        }
+
+        if (!custom_mutators.empty()) {
+            std::cout << "Active Custom Mutators:" << std::endl;
+            for (const auto& mutator : custom_mutators) {
+                std::cout << "  - " << mutator << std::endl;
+            }
+        }
+
+        std::cout << "=========================================" << std::endl;
+    }
+}

--- a/include/bitcoinfuzz/modulelogger.h
+++ b/include/bitcoinfuzz/modulelogger.h
@@ -1,0 +1,16 @@
+#include <vector>
+#include <string>
+
+namespace bitcoinfuzz {
+    class ModuleLogger {
+    private:
+        std::vector<std::string> loaded_modules;
+        std::vector<std::string> custom_mutators;
+        bool logged = false;
+    
+    public:
+        void addModule(const std::string& module_name);
+        void addCustomMutator(const std::string& mutator_name);
+        void logModules();
+    };
+}

--- a/main.cpp
+++ b/main.cpp
@@ -55,6 +55,8 @@
 
 std::shared_ptr<bitcoinfuzz::Driver> driver = nullptr;
 
+static bitcoinfuzz::ModuleLogger module_logger;
+
 #ifdef CUSTOM_MUTATOR_BOLT12_OFFER
 constexpr std::string_view bech32_hrp = "lno";
 constexpr std::string_view dummy_initial_input = "lno1";
@@ -119,7 +121,7 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t *fuzz_data, size_t size,
     for (uint8_t& val : decoded_data) {
         val &= 0x1F;
     }
-    
+
     // Encode the mutated input
     std::string encoded_data = bech32::EncodeNoChecksum(bech32_hrp, decoded_data);
 
@@ -149,7 +151,7 @@ extern "C" size_t LLVMFuzzerCustomCrossOver(const uint8_t *in1, size_t in1_size,
     bech32::DecodeResult decoded_result2 = bech32::DecodeNoChecksum(input2_str, bech32::CharLimit::CUSTOM_MUTATOR);
 
     // Perform cross-over on decoded data
-    std::vector<uint8_t> crossed_data = cross_over(decoded_result1.data, decoded_result2.data, 
+    std::vector<uint8_t> crossed_data = cross_over(decoded_result1.data, decoded_result2.data,
                                                     max_out_size, seed);
 
     // Encode the crossed-over data
@@ -195,7 +197,7 @@ static void bitcoin_double_sha256(const uint8_t* data, size_t len, uint8_t* hash
     hasher.Write(data, len);
     unsigned char first_hash[CSHA256::OUTPUT_SIZE];
     hasher.Finalize(first_hash);
-    
+
     hasher.Reset();
     hasher.Write(first_hash, CSHA256::OUTPUT_SIZE);
     hasher.Finalize(hash);
@@ -206,20 +208,20 @@ static void fix_bitcoin_checksum(uint8_t* data, size_t size) {
     if (size < BITCOIN_HEADER_SIZE) {
         return;
     }
-    
+
     uint32_t payload_length;
     memcpy(&payload_length, data + PAYLOAD_LENGTH_OFFSET, 4);
-    
+
     // Validate that we have the complete message
     if (size < BITCOIN_HEADER_SIZE + payload_length) {
         return;
     }
-    
+
     // Calculate checksum for the payload
     const uint8_t* payload = data + BITCOIN_HEADER_SIZE;
     uint8_t calculated_checksum[32];
     bitcoin_double_sha256(payload, payload_length, calculated_checksum);
-    
+
     // Update checksum in header (first 4 bytes of hash)
     memcpy(data + CHECKSUM_OFFSET, calculated_checksum, 4);
 }
@@ -228,10 +230,10 @@ size_t LLVMFuzzerCustomMutator(uint8_t *fuzz_data, size_t size, size_t max_size,
                                unsigned int seed) {
     // First, mutate the data using LibFuzzer's default mutator
     size_t new_size = LLVMFuzzerMutate(fuzz_data, size, max_size);
-    
+
     // Then fix the checksum if the data looks like it could be a Bitcoin message
     fix_bitcoin_checksum(fuzz_data, new_size);
-    
+
     return new_size;
 }
 #endif
@@ -438,7 +440,7 @@ size_t LLVMFuzzerCustomCrossOver(const uint8_t *in1, size_t in1_size, const uint
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
   const char* target = std::getenv("FUZZ");
-  driver = std::make_shared<bitcoinfuzz::Driver>();
+  driver = std::make_shared<bitcoinfuzz::Driver>(module_logger);
 #ifdef BITCOIN_CORE
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::Bitcoin>());
 #endif
@@ -473,6 +475,19 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::Eclair>());
 #endif
 
+#ifdef CUSTOM_MUTATOR_BOLT11
+  module_logger.addCustomMutator("BOLT11 Bech32 Custom Mutator");
+#endif
+
+#ifdef CUSTOM_MUTATOR_BOLT12_OFFER
+  module_logger.addCustomMutator("BOLT12 Offer/Invoice Custom Mutator");
+#endif
+
+#ifdef CUSTOM_MUTATOR_P2P_MESSAGE
+  module_logger.addCustomMutator("Bitcoin P2P Message Custom Mutator");
+#endif
+
+  module_logger.logModules();
   driver->Run(Data, Size, target);
   return 0;
 }


### PR DESCRIPTION
The idea is to provide feedback to the user about which modules have been loaded. Typos or configuration mistakes can sometimes cause the fuzzer to run without loading any modules at all. By logging the loaded modules at startup, the user can immediately see what’s going on and catch issues early.

```
ASAN_OPTIONS=detect_leaks=0 FUZZ=deserialize_invoice ./bitcoinfuzz ./test
INFO: found LLVMFuzzerCustomMutator (0x5558c3cb58f0). Disabling -len_control by default.
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 216874574
INFO: Loaded 2 modules   (36563 inline 8-bit counters): 3376 [0x5558c4ad8310, 0x5558c4ad9040), 33187 [0x5558c5534c30, 0x5558c553cdd3), 
INFO: Loaded 2 PC tables (36563 PCs): 3376 [0x5558c4ad9040,0x5558c4ae6340), 33187 [0x10c000088000,0x10c000109a30), 
./bitcoinfuzz: Running 1 inputs 1 time(s) each.
Running: ./test
=== BitcoinFuzz Module Activation Log ===
Target: deserialize_invoice
Loaded Modules (3):
  [1] LND
  [2] LDK
  [3] Eclair
Active Custom Mutators:
  - BOLT11 Bech32 Custom Mutator
=========================================
```