### PR TITLE
fix: accept any chain in offer clightning

### DIFF
--- a/modules/clightning/module.cpp
+++ b/modules/clightning/module.cpp
@@ -148,12 +148,11 @@ std::optional<std::string> clightning_des_invoice(const std::string& input) {
 
 std::string clightning_des_offer(const std::string_view input) {
     char* fail = nullptr;
-    const struct chainparams* params = chainparams_for_network("bitcoin");
 
     // Get the truncated length of the string (in case it contains null bytes)
     size_t c_string_len = strnlen(input.data(), input.size());
 
-    struct tlv_offer *offer = offer_decode(tmpctx, input.data(), c_string_len, nullptr, params, &fail);
+    struct tlv_offer *offer = offer_decode(tmpctx, input.data(), c_string_len, /*our_features=*/nullptr, /*must_be_chain=*/nullptr, &fail);
     if (!offer) {
         clean_tmpctx();
         return "";


### PR DESCRIPTION
Remove the requirement of just accepting only the Bitcoin chain. This was making the fuzzer crash when receiving different chains, since rust-lightning isn't requiring a Bitcoin chain.