### PR TITLE
address_parse: bypass unknown type

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -196,7 +196,7 @@ namespace bitcoinfuzz
         for(auto module: modules)
         {
             std::optional<std::string> res{module.second->address_parse(address)};
-            if(!res.has_value()) continue;
+            if(!res.has_value() || res->starts_with("UNK:")) continue;
 
             if (last_response.has_value()) {
                 if (*res != *last_response) {
@@ -204,9 +204,8 @@ namespace bitcoinfuzz
                     std::cout << "MISMATCH DETECTED between " << last_module_name << " and " << module.first << "!" << "\n";
                     std::cout << "  " << last_module_name << ": " << *last_response << "\n";
                     std::cout << "  " << module.first << ": " << *res << "\n";
+                    assert(*res == *last_response);
                 }
-
-                assert(*res == *last_response);
             }
             last_response = *res;
             last_module_name = module.first;
@@ -285,7 +284,7 @@ namespace bitcoinfuzz
             last_module_name = module.first;
         }
     }
-    
+
     void Driver::OfferDeserializationTarget(std::span<const uint8_t> buffer) const
     {
         FuzzedDataProvider provider(buffer.data(), buffer.size());


### PR DESCRIPTION
Let's ignore the `UNK:` address type for now due to #247.