### PR TITLE
feat: compile dependencies with coverage sanitizers

### DIFF
--- a/modules/ldk/Makefile
+++ b/modules/ldk/Makefile
@@ -5,12 +5,7 @@ CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer -std=c++20 -I ../../include
 LDK_LIB_PATH := ./ldk_lib/target/release/libldk_lib.a
 
 cargo:
-	cd ldk_lib && RUSTFLAGS="-Z sanitizer=address" cargo rustc --release -- -C passes='sancov-module' \
-    -C llvm-args=-sanitizer-coverage-inline-8bit-counters \
-    -C llvm-args=-sanitizer-coverage-trace-compares \
-    -C llvm-args=-sanitizer-coverage-pc-table \
-    -C llvm-args=-sanitizer-coverage-level=4 \
-    -C llvm-args=-simplifycfg-branch-fold-threshold=0
+	cd ldk_lib && cargo +nightly build --release
 
 module.a: module.o $(LDK_LIB_PATH)
 	bash ../../merge.sh module.a $(LDK_LIB_PATH) module.o

--- a/modules/ldk/ldk_lib/.cargo/config.toml
+++ b/modules/ldk/ldk_lib/.cargo/config.toml
@@ -1,0 +1,10 @@
+[build]
+rustflags = [
+    "-Z", "sanitizer=address",
+    "-C", "passes=sancov-module",
+    "-C", "llvm-args=-sanitizer-coverage-inline-8bit-counters",
+    "-C", "llvm-args=-sanitizer-coverage-trace-compares",
+    "-C", "llvm-args=-sanitizer-coverage-pc-table",
+    "-C", "llvm-args=-sanitizer-coverage-level=4",
+    "-C", "llvm-args=-simplifycfg-branch-fold-threshold=0"
+]

--- a/modules/rustbitcoin/Makefile
+++ b/modules/rustbitcoin/Makefile
@@ -6,12 +6,7 @@ CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer -std=c++20 -I ../../include
 RUST_LIB_PATH := ./rust_bitcoin_lib/target/release/librust_bitcoin_lib.a
 
 cargo:
-	cd rust_bitcoin_lib && RUSTFLAGS="-Z sanitizer=address" cargo rustc --release -- -C passes='sancov-module' \
-    -C llvm-args=-sanitizer-coverage-inline-8bit-counters \
-    -C llvm-args=-sanitizer-coverage-trace-compares \
-    -C llvm-args=-sanitizer-coverage-pc-table \
-    -C llvm-args=-sanitizer-coverage-level=4 \
-    -C llvm-args=-simplifycfg-branch-fold-threshold=0 \
+	cd rust_bitcoin_lib && cargo +nightly build --release
 
 module.a: module.o $(RUST_LIB_PATH)
 	bash ../../merge.sh module.a $(RUST_LIB_PATH) module.o

--- a/modules/rustbitcoin/rust_bitcoin_lib/.cargo/config.toml
+++ b/modules/rustbitcoin/rust_bitcoin_lib/.cargo/config.toml
@@ -1,0 +1,10 @@
+[build]
+rustflags = [
+    "-Z", "sanitizer=address",
+    "-C", "passes=sancov-module",
+    "-C", "llvm-args=-sanitizer-coverage-inline-8bit-counters",
+    "-C", "llvm-args=-sanitizer-coverage-trace-compares",
+    "-C", "llvm-args=-sanitizer-coverage-pc-table",
+    "-C", "llvm-args=-sanitizer-coverage-level=4",
+    "-C", "llvm-args=-simplifycfg-branch-fold-threshold=0"
+]

--- a/modules/rustminiscript/Makefile
+++ b/modules/rustminiscript/Makefile
@@ -6,12 +6,7 @@ CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer -std=c++20 -I ../../include
 RUST_MINISCRIPT_LIB_PATH := ./rust_miniscript_lib/target/release/librust_miniscript_lib.a
 
 cargo:
-	cd rust_miniscript_lib && RUSTFLAGS="-Z sanitizer=address" cargo rustc --release -- -C passes='sancov-module' \
-    -C llvm-args=-sanitizer-coverage-inline-8bit-counters \
-    -C llvm-args=-sanitizer-coverage-trace-compares \
-    -C llvm-args=-sanitizer-coverage-pc-table \
-    -C llvm-args=-sanitizer-coverage-level=4 \
-    -C llvm-args=-simplifycfg-branch-fold-threshold=0
+	cd rust_miniscript_lib && cargo +nightly build --release
 
 module.a: module.o $(RUST_MINISCRIPT_LIB_PATH)
 	bash ../../merge.sh module.a $(RUST_MINISCRIPT_LIB_PATH) module.o

--- a/modules/rustminiscript/rust_miniscript_lib/.cargo/config.toml
+++ b/modules/rustminiscript/rust_miniscript_lib/.cargo/config.toml
@@ -1,0 +1,10 @@
+[build]
+rustflags = [
+    "-Z", "sanitizer=address",
+    "-C", "passes=sancov-module",
+    "-C", "llvm-args=-sanitizer-coverage-inline-8bit-counters",
+    "-C", "llvm-args=-sanitizer-coverage-trace-compares",
+    "-C", "llvm-args=-sanitizer-coverage-pc-table",
+    "-C", "llvm-args=-sanitizer-coverage-level=4",
+    "-C", "llvm-args=-simplifycfg-branch-fold-threshold=0"
+]


### PR DESCRIPTION
Previously, the `cargo rustc --release -- <flags>` approach only applied coverage instrumentation flags to the root crate, while `RUSTFLAGS` only provided `AddressSanitizer` to dependencies, resulting in just addresses sanitizer being applied to dependencies crate. This pr moves all instrumentation flags to `.cargo/config.toml `files, ensuring that dependencies like `lightning`, `bitcoin`, and `miniscript` receive complete sanitizer coverage instrumentation (SanitizerCoverage, inline counters, trace compares, PC table) alongside `AddressSanitizer`, significantly improving fuzzing effectiveness across the entire dependency tree.