### PR TITLE
feat: add jvmloader to initialize the JVM only 1 time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ MODULES := $(wildcard modules/*/module.a)
 UNAME_S := $(shell uname -s)
 BITCOINFUZZ_SRC := basemodule modulelogger
 BITCOINFUZZ_OBJS := $(addprefix include/bitcoinfuzz/, $(addsuffix .o, $(BITCOINFUZZ_SRC)))
+HELPERS_SRC := jvmloader
+HELPERS_OBJS := $(addprefix helpers/, $(addsuffix .o, $(HELPERS_SRC)))
 
+BITCOINFUZZ_DIR = $(shell pwd)
+CXXFLAGS += -DBITCOINFUZZ_DIR=\"$(BITCOINFUZZ_DIR)\"
 
 ifeq ($(UNAME_S), Darwin)
 	LDFLAGS = -framework CoreFoundation -Wl,-ld_classic
@@ -37,12 +41,13 @@ ifneq (,$(filter -DECLAIR -DLIGHTNING_KMP,$(BASE_CXXFLAGS) $(CXXFLAGS)))
 	endif
 
   JAVA_CXXFLAGS := -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(shell uname -s | tr '[:upper:]' '[:lower:]') -L$(JAVA_HOME)/lib/server -ljvm -Wl,-rpath,$(JAVA_HOME)/lib/server
+	JVM_LOADER := helpers/jvmloader.o
 endif
 
 CXXFLAGS := $(BASE_CXXFLAGS) $(JAVA_CXXFLAGS) $(CXXFLAGS) $(PYTHON_LDFLAGS)
 
-bitcoinfuzz: main.cpp driver.o $(BITCOINFUZZ_OBJS)
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp $(MODULES) driver.o $(BITCOINFUZZ_OBJS) $(NBITCOIN_DYLIB) -o bitcoinfuzz $(PYTHON_LDFLAGS) $(SODIUM_LDLIBS)
+bitcoinfuzz: main.cpp driver.o $(BITCOINFUZZ_OBJS) $(JVM_LOADER)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp $(MODULES) driver.o $(BITCOINFUZZ_OBJS) $(NBITCOIN_DYLIB) -o bitcoinfuzz $(PYTHON_LDFLAGS) $(SODIUM_LDLIBS) $(JVM_LOADER)
 
 driver.o: driver.cpp driver.h
 	$(CXX) $(CXXFLAGS) -c driver.cpp -o driver.o
@@ -50,8 +55,11 @@ driver.o: driver.cpp driver.h
 include/bitcoinfuzz/%.o: include/bitcoinfuzz/%.cpp include/bitcoinfuzz/%.h
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
+helpers/%.o: helpers/%.cpp helpers/%.h
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
 clean:
-	rm -rf *.o module.a bitcoinfuzz include/bitcoinfuzz/*.o $(MODULES)
+	rm -rf *.o module.a bitcoinfuzz include/bitcoinfuzz/*.o helpers/*.o $(MODULES)
 	rm -rf modules/eclair/eclair.zip modules/eclair/lib modules/eclair/eclair_extracted
 
 .PHONY: all bitcoinfuzz

--- a/helpers/jvmloader.cpp
+++ b/helpers/jvmloader.cpp
@@ -1,0 +1,85 @@
+#include "jvmloader.h"
+
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+constexpr const char* BITCOINFUZZ_PATH = BITCOINFUZZ_DIR;
+static const fs::path BITCOINFUZZ_ROOT{BITCOINFUZZ_PATH};
+
+static JvmLoader& instance() {
+    static JvmLoader inst;
+    return inst;
+}
+
+JavaVM* JvmLoader::get_jvm() {
+    return instance().jvm;
+}
+
+std::string JvmLoader::build_classpath(const std::vector<std::string>& lib_dirs) {
+    std::ostringstream cp;
+    cp << "-Djava.class.path=";
+    bool first = true;
+
+    for (const auto& lib_dir : lib_dirs) {
+        try {
+            for (const auto& entry : fs::directory_iterator(lib_dir)) {
+                if (entry.is_regular_file() && entry.path().extension() == ".jar") {
+                    if (!first) cp << ":";
+                    cp << entry.path().string();
+                    first = false;
+                }
+            }
+        } catch (const fs::filesystem_error& e) {
+            std::cerr << "Filesystem error in " << lib_dir << ": " << e.what() << std::endl;
+        }
+    }
+
+    return cp.str();
+}
+
+JvmLoader::JvmLoader() : jvm(nullptr) {
+    init();
+}
+
+JvmLoader::~JvmLoader() = default;
+
+void JvmLoader::init() {
+    if (jvm != nullptr) return;
+
+    JavaVMInitArgs vm_args;
+    JavaVMOption options[7];
+
+    std::vector<std::string> lib_dirs;
+    #ifdef LIGHTNING_KMP
+        lib_dirs.push_back((BITCOINFUZZ_ROOT / "modules" / "lightningkmp" / "lib").string());
+    #endif
+    #ifdef ECLAIR
+        lib_dirs.push_back((BITCOINFUZZ_ROOT / "modules" / "eclair" / "lib").string());
+    #endif
+    std::string classpathStr = build_classpath(lib_dirs);
+
+    options[0].optionString = const_cast<char*>(classpathStr.c_str());
+    options[1].optionString = const_cast<char*>("-Xmx512m");
+    options[2].optionString = const_cast<char*>("-XX:+UseSignalChaining");
+    options[3].optionString = const_cast<char*>("-XX:+ExitOnOutOfMemoryError");
+    options[4].optionString = const_cast<char*>("-XX:ErrorFile=./hs_err_pid%p.log");
+    options[5].optionString = const_cast<char*>("-Xrs");
+    options[6].optionString = const_cast<char*>("-Dsun.misc.SignalHandler.handlers=allow");
+
+    vm_args.version = JNI_VERSION_1_8;
+    vm_args.nOptions = 7;
+    vm_args.options = options;
+    vm_args.ignoreUnrecognized = JNI_FALSE;
+
+    JNIEnv* env = nullptr;
+    jint res = JNI_CreateJavaVM(&jvm, (void**)&env, &vm_args);
+
+    if (res != JNI_OK) {
+        std::cerr << "Failed to create JVM, error code: " << res << std::endl;
+        jvm = nullptr;
+    }
+}

--- a/helpers/jvmloader.h
+++ b/helpers/jvmloader.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <jni.h>
+#include <string>
+#include <vector>
+
+class JvmLoader {
+public:
+    JvmLoader();
+    ~JvmLoader();
+    static JavaVM* get_jvm();
+
+private:
+    void init();
+    static std::string build_classpath(const std::vector<std::string>& lib_dirs) ;
+
+    JavaVM* jvm;
+
+    JvmLoader(const JvmLoader&) = delete;
+    JvmLoader& operator=(const JvmLoader&) = delete;
+    JvmLoader(JvmLoader&&) = delete;
+    JvmLoader& operator=(JvmLoader&&) = delete;
+};

--- a/modules/eclair/Makefile
+++ b/modules/eclair/Makefile
@@ -1,5 +1,5 @@
 CXX = clang++
-CXXFLAGS += -Wall -Wextra -std=c++20 -fPIC  -I ../../include
+CXXFLAGS += -Wall -Wextra -std=c++20 -fPIC  -I ../../include -I ../../helpers
 
 OS_NAME := $(shell uname | tr '[:upper:]' '[:lower:]')
 

--- a/modules/eclair/module.cpp
+++ b/modules/eclair/module.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <cstring>
 #include <sstream>
+#include <jvmloader.h>
 
 namespace fs = std::filesystem;
 
@@ -14,59 +15,14 @@ static jclass decoderClass = nullptr;
 static jmethodID decodeBolt11InvoiceMethod = nullptr;
 static jmethodID decodeOfferMethod = nullptr;
 
-constexpr const char* LIB_DIR_PATH = LIB_DIR;
-
 static std::string cached_classpath;
-
-static const std::string build_classpath() {
-    if (!cached_classpath.empty()) return cached_classpath;
-    
-    std::ostringstream cp;
-    cp << "-Djava.class.path=";
-    bool first = true;
-    
-    try {
-        for (const auto& entry : fs::directory_iterator(LIB_DIR_PATH)) {
-            auto ext = entry.path().extension();
-            if (ext == ".jar" || ext == ".class") {
-                if (!first) cp << ":";
-                cp << entry.path().string();
-                first = false;
-            }
-        }
-    } catch (const fs::filesystem_error& e) {
-        std::cerr << "Filesystem error: " << e.what() << std::endl;
-    }
-    
-    cached_classpath = cp.str();
-    return cached_classpath;
-}
 
 static bool init_jvm() {
     if (jvm != nullptr) return true;
 
-    JavaVMInitArgs vm_args;
-    JavaVMOption options[7];
-
-    std::string classpathStr = build_classpath();
-    options[0].optionString = const_cast<char*>(classpathStr.c_str());
-    options[1].optionString = const_cast<char*>("-Xmx512m");
-    options[2].optionString = const_cast<char*>("-XX:+UseSignalChaining");
-    options[3].optionString = const_cast<char*>("-XX:+ExitOnOutOfMemoryError");
-    options[4].optionString = const_cast<char*>("-XX:ErrorFile=./hs_err_pid%p.log");
-    options[5].optionString = const_cast<char*>("-Xrs"); 
-    options[6].optionString = const_cast<char*>("-Dsun.misc.SignalHandler.handlers=allow");
-
-    vm_args.version = JNI_VERSION_1_8;
-    vm_args.nOptions = 7;
-    vm_args.options = options;
-    vm_args.ignoreUnrecognized = JNI_FALSE;
-
+    jvm = JvmLoader::get_jvm();
     JNIEnv* env = nullptr;
-    jint res = JNI_CreateJavaVM(&jvm, (void**)&env, &vm_args);
-    if (res != JNI_OK) {
-        return false;
-    }
+    jint ge = jvm->GetEnv((void**)&env, JNI_VERSION_1_8);
 
     decoderClass = env->FindClass("EclairWrapper");
     if (!decoderClass) {

--- a/modules/lightningkmp/Makefile
+++ b/modules/lightningkmp/Makefile
@@ -1,5 +1,5 @@
 CXX = clang++
-CXXFLAGS += -Wall -Wextra -std=c++20 -fPIC  -I ../../include
+CXXFLAGS += -Wall -Wextra -std=c++20 -fPIC  -I ../../include -I ../../helpers
 
 OS_NAME := $(shell uname | tr '[:upper:]' '[:lower:]')
 

--- a/modules/lightningkmp/module.cpp
+++ b/modules/lightningkmp/module.cpp
@@ -6,6 +6,8 @@
 #include <filesystem>
 #include <cstring>
 #include <sstream>
+#include <thread>
+#include <jvmloader.h>
 
 namespace fs = std::filesystem;
 
@@ -14,53 +16,14 @@ static jclass decoderClass = nullptr;
 static jmethodID decodeMethodInvoice = nullptr;
 static jmethodID decodeMethodOffer = nullptr;
 
-constexpr const char* LIB_DIR_PATH = LIB_DIR;
-
-static std::string build_classpath() {
-    std::ostringstream cp;
-    cp << "-Djava.class.path=";
-    bool first = true;
-    
-    try {
-        for (const auto& entry : fs::directory_iterator(LIB_DIR_PATH)) {
-            if (entry.path().extension() == ".jar") {
-                if (!first) cp << ":";
-                cp << entry.path().string();
-                first = false;
-            }
-        }
-    } catch (const fs::filesystem_error& e) {
-        std::cerr << "Filesystem error: " << e.what() << std::endl;
-    }
-    
-    return cp.str();
-}
-
 static bool init_jvm() {
-    if (jvm != nullptr) return true;
-
-    JavaVMInitArgs vm_args;
-    JavaVMOption options[7];
-
-    std::string classpathStr = build_classpath();
-    options[0].optionString = const_cast<char*>(classpathStr.c_str());
-    options[1].optionString = const_cast<char*>("-Xmx512m");
-    options[2].optionString = const_cast<char*>("-XX:+UseSignalChaining");
-    options[3].optionString = const_cast<char*>("-XX:+ExitOnOutOfMemoryError");
-    options[4].optionString = const_cast<char*>("-XX:ErrorFile=./hs_err_pid%p.log");
-    options[5].optionString = const_cast<char*>("-Xrs"); 
-    options[6].optionString = const_cast<char*>("-Dsun.misc.SignalHandler.handlers=allow");
-
-    vm_args.version = JNI_VERSION_1_8;
-    vm_args.nOptions = 7;
-    vm_args.options = options;
-    vm_args.ignoreUnrecognized = JNI_FALSE;
-
-    JNIEnv* env = nullptr;
-    jint res = JNI_CreateJavaVM(&jvm, (void**)&env, &vm_args);
-    if (res != JNI_OK) {
-        return false;
+    if (jvm != nullptr) {
+        return true;
     }
+    
+    jvm = JvmLoader::get_jvm();
+    JNIEnv* env = nullptr;
+    jint ge = jvm->GetEnv((void**)&env, JNI_VERSION_1_8);
 
     decoderClass = env->FindClass("invoice/decode/InvoiceDecoder");
     if (!decoderClass) {


### PR DESCRIPTION
This PR doesn’t fully resolve the problem, since starting the JVM with both .JAR libraries can cause one library to shadow another.

Related to: https://github.com/bitcoinfuzz/bitcoinfuzz/issues/266