### PR TITLE
Add new target for transaction parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,9 @@ The `docker-compose.yml` file simplifies running multiple fuzzing scenarios. Eac
      ├── address_parse/
      ├── addrv2/
      ├── psbt_parse/
-     └── parse_p2p_message/
-     └── parse_p2p_lightning_message/
+     ├── parse_p2p_message/
+     ├── parse_p2p_lightning_message/
+     └── transaction_eval/
      ```
    - To ensure the corpus is saved locally, the `docker-compose.yml` file maps the `/app/data` directory inside the container to the corresponding subdirectory in `docker`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
-x-common-env:
-  &common-env
+x-common-env: &common-env
   FUZZ_RUNS: ${FUZZ_RUNS}
   FUZZ_INPUT: ${FUZZ_INPUT}
 
@@ -105,6 +104,17 @@ services:
       FUZZ: addrv2
     volumes:
       - ./docker/addrv2:/app/data
+
+  transaction_eval:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      <<: *common-env
+      CXXFLAGS: "-DBITCOIN_CORE -DBTCD"
+      FUZZ: transaction_eval
+    volumes:
+      - ./docker/transaction_eval:/app/data
 
   parse_p2p_message:
     build:

--- a/driver.cpp
+++ b/driver.cpp
@@ -372,6 +372,22 @@ namespace bitcoinfuzz
         }
     }
 
+    void Driver::TransactionEvalTarget(std::span<const uint8_t> buffer) const
+    {
+        std::optional<std::string> last_response{std::nullopt};
+        std::string last_module_name;
+
+        for (auto &module : modules)
+        {
+            std::optional<std::string> res{module.second->transaction_eval(buffer)};
+            if (!res.has_value()) continue;
+            if (last_response.has_value()) assert(*res == *last_response);
+
+            last_response = res.value();
+            last_module_name = module.first;
+        }
+    }
+
      void Driver::ParseLightningP2pMessageTarget(std::span<const uint8_t> buffer) const
     {
         std::optional<std::string> last_response{std::nullopt};
@@ -426,8 +442,8 @@ namespace bitcoinfuzz
             this->CompactBlocksTarget(buffer);
         } else if (target == "parse_p2p_message") {
             this->ParseP2PMessageTarget(buffer);
-        } else if (target == "parse_p2p_lightning_message") {
-            this->ParseLightningP2pMessageTarget(buffer);
+        } else if (target == "transaction_eval") {
+            this->TransactionEvalTarget(buffer);
         } else {
             std::cout << "Target not defined!" << std::endl;
             assert(false);

--- a/driver.h
+++ b/driver.h
@@ -37,5 +37,6 @@ namespace bitcoinfuzz
         void CompactBlocksTarget(std::span<const uint8_t> buffer) const;
         void ParseP2PMessageTarget(std::span<const uint8_t> buffer) const;
         void ParseLightningP2pMessageTarget(std::span<const uint8_t> buffer) const;
+        void TransactionEvalTarget(std::span<const uint8_t> buffer) const;
     };
 }

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -57,7 +57,7 @@ namespace bitcoinfuzz
     {
         return std::nullopt;
     }
-    
+
     std::optional<std::string> BaseModule::deserialize_offer(std::string str) const
     {
         return std::nullopt;
@@ -67,8 +67,13 @@ namespace bitcoinfuzz
     {
         return std::nullopt;
     }
-    
+
     std::optional<std::string> BaseModule::parse_p2p_message(std::span<const uint8_t> buffer) const
+    {
+        return std::nullopt;
+    }
+
+    std::optional<std::string> BaseModule::transaction_eval(std::span<const uint8_t> buffer) const
     {
         return std::nullopt;
     }

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -30,8 +30,9 @@ namespace bitcoinfuzz
         virtual std::optional<std::string> deserialize_offer(std::string str) const;
         virtual std::optional<int> cmpctblocks_parse(std::span<const uint8_t> buffer) const;
         virtual std::optional<std::string> parse_p2p_message(std::span<const uint8_t> buffer) const;
-        virtual std::optional<std::string> parse_p2p_lightning_message(std::span<const uint8_t> buffer) const;
-        
+        virtual std::optional<std::string> parse_p2p_lightning_message(std::span<const uint8_t> buffer) const; 
+        virtual std::optional<std::string> transaction_eval(std::span<const uint8_t> buffer) const;
+
         virtual ~BaseModule() noexcept;
     };
 }

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -1,5 +1,6 @@
 #include <optional>
 #include <span>
+#include <string>
 
 #include "blockencodings.h"
 #include "chainparams.h"
@@ -325,7 +326,11 @@ std::optional<std::string> Bitcoin::transaction_eval(std::span<const uint8_t> bu
     CTransaction tx{mutable_tx};
     TxValidationState state;
     if (!CheckTransaction(tx, state)) return "0";
-    return tx.GetWitnessHash().ToString();
+
+    auto res{tx.GetWitnessHash().ToString()};
+    res += std::to_string(tx.GetTotalSize());
+
+    return res;
 }
 
 std::optional<std::string> Bitcoin::address_parse(std::string str) const

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -4,6 +4,7 @@
 #include "blockencodings.h"
 #include "chainparams.h"
 #include "consensus/validation.h"
+#include "consensus/tx_check.h"
 #include "core_io.h"
 #include "descriptor.h"
 #include "key_io.h"
@@ -322,6 +323,8 @@ std::optional<std::string> Bitcoin::transaction_eval(std::span<const uint8_t> bu
     }
 
     CTransaction tx{mutable_tx};
+    TxValidationState state;
+    if (!CheckTransaction(tx, state)) return "0";
     return tx.GetWitnessHash().ToString();
 }
 

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -311,6 +311,20 @@ std::optional<std::string> Bitcoin::script_asm(std::span<const uint8_t> buffer) 
     return asm_str;
 }
 
+std::optional<std::string> Bitcoin::transaction_eval(std::span<const uint8_t> buffer) const
+{
+    DataStream ds_mtx{buffer};
+    CMutableTransaction mutable_tx;
+    try {
+        ds_mtx >> TX_WITH_WITNESS(mutable_tx);
+    } catch (const std::ios_base::failure& e) {
+        return "0";
+    }
+
+    CTransaction tx{mutable_tx};
+    return tx.GetWitnessHash().ToString();
+}
+
 std::optional<std::string> Bitcoin::address_parse(std::string str) const
 {
     static bool initialized = false;

--- a/modules/bitcoin/module.h
+++ b/modules/bitcoin/module.h
@@ -24,6 +24,7 @@ namespace bitcoinfuzz
             std::optional<std::string> addrv2_parse(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> psbt_parse(std::span<const uint8_t> buffer) const override;
             std::optional<int32_t> cmpctblocks_parse(std::span<const uint8_t> buffer) const override;
+            std::optional<std::string> transaction_eval(std::span<const uint8_t> buffer) const override;
             ~Bitcoin() noexcept override = default;
         };
 

--- a/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
+++ b/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
@@ -91,6 +91,7 @@ extern char* BTCDAddrv2(ByteArray addrv2Data);
 extern char* BTCDScriptAsm(ByteArray scriptData);
 extern char* BTCDDesBlock(ByteArray scriptData);
 extern void BTCDFreeString(char* ptr);
+extern char* BTCDTransactionEval(ByteArray data);
 extern char* BTCDParsePSBT(ByteArray data);
 extern char* BTCDAddress(ByteArray data);
 

--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -158,7 +158,11 @@ func BTCDTransactionEval(data C.ByteArray) *C.char {
 	buffer := C.GoBytes(unsafe.Pointer(data.data), data.length)
 	tx, err := btcutil.NewTxFromBytes(buffer)
 	if err != nil {
-		println("%v", err.Error())
+		return C.CString("0")
+	}
+
+	err_sanity := blockchain.CheckTransactionSanity(tx)
+	if err_sanity != nil {
 		return C.CString("0")
 	}
 

--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"strconv"
 	"strings"
 	"unsafe"
 
@@ -166,7 +167,9 @@ func BTCDTransactionEval(data C.ByteArray) *C.char {
 		return C.CString("0")
 	}
 
-	return C.CString(tx.WitnessHash().String())
+	res := tx.WitnessHash().String()
+	res += strconv.Itoa(tx.MsgTx().SerializeSize())
+	return C.CString(res)
 }
 
 //export BTCDParsePSBT

--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -153,6 +153,18 @@ func BTCDFreeString(ptr *C.char) {
 	C.free(unsafe.Pointer(ptr))
 }
 
+//export BTCDTransactionEval
+func BTCDTransactionEval(data C.ByteArray) *C.char {
+	buffer := C.GoBytes(unsafe.Pointer(data.data), data.length)
+	tx, err := btcutil.NewTxFromBytes(buffer)
+	if err != nil {
+		println("%v", err.Error())
+		return C.CString("0")
+	}
+
+	return C.CString(tx.WitnessHash().String())
+}
+
 //export BTCDParsePSBT
 func BTCDParsePSBT(data C.ByteArray) *C.char {
 	buffer := C.GoBytes(unsafe.Pointer(data.data), data.length)

--- a/modules/btcd/module.cpp
+++ b/modules/btcd/module.cpp
@@ -26,7 +26,7 @@ namespace bitcoinfuzz
                 .length = static_cast<int>(buffer.size())};
 
             const auto message_res = BTCDParseP2PMessage(message_data);
-        
+
             if (message_res == nullptr) {
                 return std::nullopt;
             }
@@ -96,14 +96,27 @@ namespace bitcoinfuzz
             return res;
         }
 
-        std::optional<std::string> Btcd::address_parse(std::string str) const 
+        std::optional<std::string> Btcd::address_parse(std::string str) const
         {
             ByteArray data;
-            data.data = const_cast<char*>(str.data());  
-            data.length = static_cast<int>(str.size()); 
+            data.data = const_cast<char*>(str.data());
+            data.length = static_cast<int>(str.size());
 
             char* result = BTCDAddress(data);
             if (!result) return std::nullopt;
+
+            std::string res(result);
+            BTCDFreeString(result);
+            return res;
+        }
+
+        std::optional<std::string> Btcd::transaction_eval(std::span<const uint8_t> buffer) const
+        {
+            ByteArray tx;
+            tx.data = (char*)buffer.data();
+            tx.length = buffer.size();
+
+            char* result = BTCDTransactionEval(tx);
 
             std::string res(result);
             BTCDFreeString(result);

--- a/modules/btcd/module.h
+++ b/modules/btcd/module.h
@@ -20,6 +20,7 @@ namespace bitcoinfuzz
             std::optional<std::string> psbt_parse(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> addrv2_parse(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> parse_p2p_message(std::span<const uint8_t> buffer) const override;
+            std::optional<std::string> transaction_eval(std::span<const uint8_t> buffer) const override;
             ~Btcd() noexcept override = default;
         };
 


### PR DESCRIPTION
This PR adds a new target (initially for Bitcoin Core and btcd) that deserializes a transaction, checks consensus rules, and returns the witness hash. The idea in a follow-up is to return more stuff to be compared.