### PR TITLE
Add BIP32 master key gen target for BITCOIN_CORE, RUST_BITCOIN and NBITCOIN

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -231,6 +231,10 @@ jobs:
             target: "parse_p2p_lightning_message"
             cxxflags: "-DLDK -DCLIGHTNING -DLND -DCUSTOM_MUTATOR_P2P_LIGHTNING_MESSAGE"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
+          - corpus: "bip32_master_keygen"
+            target: "bip32_master_keygen"
+            cxxflags: "-DNBITCOIN -DRUST_BITCOIN -DBITCOIN_CORE"
+            asan_options: "detect_leaks=0:detect_container_overflow=0"
 
     steps:
       - name: Checkout repo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,3 +160,14 @@ services:
       FUZZ: parse_p2p_lightning_message
     volumes:
       - ./docker/parse_p2p_lightning_message:/app/data
+
+  bip32_master_keygen:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      <<: *common-env
+      CXXFLAGS: "-DRUST_BITCOIN -DNBITCOIN -DBITCOIN_CORE"
+      FUZZ: bip32_master_keygen
+    volumes:
+      - ./docker/bip32_master_keygen:/app/data

--- a/driver.cpp
+++ b/driver.cpp
@@ -417,6 +417,30 @@ namespace bitcoinfuzz
             last_module_name = module.first;
         }
     }
+        void Driver::Bip32MasterKeygenTarget(std::span<const uint8_t> buffer) const
+    {
+        std::optional<std::string> last_response{std::nullopt};
+        std::string last_module_name;
+
+        for (auto &module : modules)
+        {
+            std::optional<std::string> res{module.second->bip32_master_keygen(buffer)};
+            if (!res.has_value()) continue;
+            if (last_response.has_value()) {
+                if (*res != *last_response) {
+                    std::cout << "BIP32 master keygen failed" << std::endl;
+                    std::cout << "Module: " << module.first << std::endl;
+                    std::cout << "Result: " << *res << std::endl;
+                    std::cout << "Module: " << last_module_name << std::endl;
+                    std::cout << "Result: " << *last_response << std::endl;
+                }
+                assert(*res == *last_response);
+            }
+
+            last_response = res.value();
+            last_module_name = module.first;
+        }
+    }
 
     void Driver::Run(const uint8_t *data, const size_t size, const std::string &target) const
     {
@@ -451,6 +475,8 @@ namespace bitcoinfuzz
             this->ParseLightningP2pMessageTarget(buffer);
         } else if (target == "transaction_eval") {
             this->TransactionEvalTarget(buffer);
+        } else if (target == "bip32_master_keygen") {
+            this->Bip32MasterKeygenTarget(buffer);
         } else {
             std::cout << "Target not defined!" << std::endl;
             assert(false);

--- a/driver.h
+++ b/driver.h
@@ -38,5 +38,6 @@ namespace bitcoinfuzz
         void ParseP2PMessageTarget(std::span<const uint8_t> buffer) const;
         void ParseLightningP2pMessageTarget(std::span<const uint8_t> buffer) const;
         void TransactionEvalTarget(std::span<const uint8_t> buffer) const;
+        void Bip32MasterKeygenTarget(std::span<const uint8_t> buffer) const;
     };
 }

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -82,4 +82,10 @@ namespace bitcoinfuzz
     {
         return std::nullopt;
     }
+    
+    std::optional<std::string> BaseModule::bip32_master_keygen(std::span<const uint8_t> buffer) const
+    {
+        return std::nullopt;
+    }
+
 }

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -32,6 +32,7 @@ namespace bitcoinfuzz
         virtual std::optional<std::string> parse_p2p_message(std::span<const uint8_t> buffer) const;
         virtual std::optional<std::string> parse_p2p_lightning_message(std::span<const uint8_t> buffer) const; 
         virtual std::optional<std::string> transaction_eval(std::span<const uint8_t> buffer) const;
+        virtual std::optional<std::string> bip32_master_keygen(std::span<const uint8_t> buffer) const;
 
         virtual ~BaseModule() noexcept;
     };

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -2,6 +2,7 @@
 #include <span>
 #include <string>
 
+#include "base58.h"
 #include "blockencodings.h"
 #include "chainparams.h"
 #include "consensus/validation.h"
@@ -23,6 +24,7 @@
 #include "key_io.h"
 #include "psbt.h"
 #include "span.h"
+#include "key.h"
 
 namespace {
 class FuzzedSignatureChecker : public BaseSignatureChecker
@@ -505,6 +507,14 @@ std::optional<int> Bitcoin::cmpctblocks_parse(std::span<const uint8_t> buffer) c
         return std::nullopt;
     }
 
+}
+
+std::optional<std::string> Bitcoin::bip32_master_keygen(std::span<const uint8_t> seed) const
+{
+    SelectParams(ChainType::MAIN);
+    CExtKey master;
+    master.SetSeed(std::span{reinterpret_cast<const std::byte*>(seed.data()), seed.size()});
+    return EncodeExtKey(master);
 }
 
 } // namespace module

--- a/modules/bitcoin/module.h
+++ b/modules/bitcoin/module.h
@@ -25,6 +25,7 @@ namespace bitcoinfuzz
             std::optional<std::string> psbt_parse(std::span<const uint8_t> buffer) const override;
             std::optional<int32_t> cmpctblocks_parse(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> transaction_eval(std::span<const uint8_t> buffer) const override;
+            std::optional<std::string> bip32_master_keygen(std::span<const uint8_t> buffer) const override;
             ~Bitcoin() noexcept override = default;
         };
 

--- a/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
+++ b/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
@@ -93,4 +93,21 @@ public static class Bridge
             return false;
         }
     }
+
+    [UnmanagedCallersOnly(EntryPoint = "nbitcoin_bip32_master_keygen")]
+    public static IntPtr BIP32MasterKeygen(IntPtr dataPtr, UIntPtr len)
+    {
+        var seed = new byte[(int)len];
+        Marshal.Copy(dataPtr, seed, 0, (int)len);
+        ExtKey sk = ExtKey.CreateFromSeed(seed);
+        IntPtr strPtr = Marshal.StringToHGlobalAnsi(sk.GetWif(Network.Main).ToString());
+        return strPtr;
+        
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "nbitcoin_free_c_string")]
+    public static void FreeString(IntPtr ptr)
+    {
+        if (ptr != IntPtr.Zero) Marshal.FreeHGlobal(ptr);
+    }
 }

--- a/modules/nbitcoin/NBitcoin/nbitcoin_lib.h
+++ b/modules/nbitcoin/NBitcoin/nbitcoin_lib.h
@@ -5,3 +5,7 @@ extern "C" bool nbitcoin_miniscript_parse(const char* input);
 extern "C" bool nbitcoin_descriptor_parse(const char* input);
 
 extern "C" bool nbitcoin_script_eval(const uint8_t* input_data, int32_t input_data_length, uint32_t flags, uint32_t version);
+
+extern "C" char* nbitcoin_bip32_master_keygen(const uint8_t *data, size_t len);
+
+extern "C" void nbitcoin_free_c_string(void* ptr);

--- a/modules/nbitcoin/module.cpp
+++ b/modules/nbitcoin/module.cpp
@@ -19,5 +19,13 @@ namespace bitcoinfuzz
         {
             return nbitcoin_script_eval(input_data.data(), input_data.size(), flags, version);
         }
+        std::optional<std::string> NBitcoin::bip32_master_keygen(std::span<const uint8_t> buffer) const
+        {
+            char* p = nbitcoin_bip32_master_keygen(buffer.data(), buffer.size());
+            if (!p) return std::nullopt;
+            std::string s(p);
+            nbitcoin_free_c_string(p);   
+            return s;
+        }
     }
 }

--- a/modules/nbitcoin/module.h
+++ b/modules/nbitcoin/module.h
@@ -16,6 +16,7 @@ namespace bitcoinfuzz
             std::optional<bool> miniscript_parse(std::string str) const override;
             std::optional<bool> descriptor_parse(std::string str) const override;
             std::optional<bool> script_eval(const std::vector<uint8_t>& input_data, unsigned int flags, size_t version) const override;
+            std::optional<std::string> bip32_master_keygen(std::span<const uint8_t> buffer) const override;
             ~NBitcoin() noexcept override = default;
         };
     }

--- a/modules/rustbitcoin/module.cpp
+++ b/modules/rustbitcoin/module.cpp
@@ -76,5 +76,13 @@ namespace bitcoinfuzz
             free_c_string(message);
             return result;
         }
+        std::optional<std::string> Rustbitcoin::bip32_master_keygen(std::span<const uint8_t> buffer) const
+        {
+            auto result_ptr = rust_bitcoin_bip32_master_keygen(buffer.data(), buffer.size());
+            if (result_ptr == nullptr) return std::nullopt;
+            std::string result(result_ptr);
+            free_c_string(result_ptr);
+            return result;
+        }
     }
 }

--- a/modules/rustbitcoin/module.h
+++ b/modules/rustbitcoin/module.h
@@ -21,6 +21,7 @@ namespace bitcoinfuzz
             std::optional<std::string> addrv2_parse(std::span<const uint8_t> buffer) const override;
             std::optional<int> cmpctblocks_parse(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> parse_p2p_message(std::span<const uint8_t> buffer) const override;
+            std::optional<std::string> bip32_master_keygen(std::span<const uint8_t> buffer) const override;
             ~Rustbitcoin() noexcept override = default;
         };
 

--- a/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
+++ b/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
@@ -9,3 +9,4 @@ extern "C" char* rust_bitcoin_addrv2(const uint8_t *data, size_t len);
 extern "C" int32_t rust_bitcoin_cmpctblocks_parse(const uint8_t *data, size_t len);
 extern "C" void free_c_string(char* ptr);
 extern "C" char* rust_bitcoin_parse_p2p_message(const uint8_t *data, size_t len);
+extern "C" char* rust_bitcoin_bip32_master_keygen(const uint8_t *data, size_t len);

--- a/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
+++ b/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
@@ -5,6 +5,8 @@ use bitcoin::block::BlockUncheckedExt;
 use bitcoin::consensus::{deserialize_partial, encode, serialize};
 use bitcoin::script::{ScriptBuf, ScriptExt};
 use bitcoin::Block;
+use bitcoin::bip32::Xpriv;
+use bitcoin::NetworkKind;
 use p2p::address::AddrV2;
 use p2p::message::{AddrV2Payload, RawNetworkMessage};
 use p2p::Magic;
@@ -249,6 +251,13 @@ pub unsafe extern "C" fn rust_bitcoin_cmpctblocks_parse(data: *const u8, len: us
             return -1;
         }
     }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_bitcoin_bip32_master_keygen(data: *const u8, len: usize) -> *mut c_char {
+    let seed = slice::from_raw_parts(data, len);
+    let sk = Xpriv::new_master(NetworkKind::Main, &seed);
+    str_to_c_string(&sk.to_string())
 }
 
 unsafe fn c_str_to_str<'a>(input: *const c_char) -> Result<&'a str, Utf8Error> {


### PR DESCRIPTION
Based on the discussion we had in [Issue](https://github.com/bitcoinfuzz/bitcoinfuzz/issues/272), I prepared a first basic BIP32 target for master key generation from seed/bytes generated by the fuzzer. This is mainly intended as an example and a place to discuss good/bad practices while contributing to your project. 

I already stumbled upon trouble - LeakSanitizer reports indirect leaks (3768 bytes) regarding NBITCOINs _ExtKey_ at the end of runtime (not per fuzzrun).  See it [here](https://gist.github.com/kuliq23/6de8effc57888ae02aae99a41c46fc17). I believe these are false positives as _ExtKey_ and _Key_  are managed objects and their memory is automatically reclaimed by the GC. Let me know your opinion on how to handle this, thx.
