### PR TITLE
nbitcoin: add `script_eval`

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -187,7 +187,7 @@ jobs:
             asan_options: ""
           - corpus: "script_eval"
             target: "script_eval"
-            cxxflags: "-DBITCOIN_CORE -DBTCD"
+            cxxflags: "-DBITCOIN_CORE -DBTCD -DNBITCOIN"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "descriptor_parse_clean"
             target: "descriptor_parse"

--- a/driver.cpp
+++ b/driver.cpp
@@ -70,6 +70,11 @@ namespace bitcoinfuzz
             provider.ConsumeIntegralInRange<size_t>(0, 1024)
         );
 
+        #ifdef BTCD
+        if (std::ranges::find(input_data, 0xAC) != input_data.end() ||
+            std::ranges::find(input_data, 0xAF) != input_data.end() ) return;
+        #endif
+
         auto flags = provider.ConsumeIntegral<unsigned int>();
 
         std::optional<bool> last_response{std::nullopt};

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -247,13 +247,6 @@ std::optional<bool> Bitcoin::script_eval(const std::vector<uint8_t>& input_data,
     CScript script(input_data.begin(), input_data.end());
     if (script.empty()) return std::nullopt;
 
-    // Skip sequence, locktime and multisig
-     auto hex_str{HexStr(script)};
-     if (hex_str.find("b1") != std::string::npos ||
-         hex_str.find("b2") != std::string::npos ||
-         hex_str.find("ae") != std::string::npos ||
-         hex_str.find("af") != std::string::npos) return std::nullopt;
-
     std::vector<std::vector<unsigned char>> stack;
     SigVersion sig_version = (version == 0) ? SigVersion::BASE : SigVersion::WITNESS_V0;
 

--- a/modules/nbitcoin/NBitcoin.CppBridge.csproj
+++ b/modules/nbitcoin/NBitcoin.CppBridge.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>NBitcoin.CppBridge</RootNamespace>
@@ -21,7 +20,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NBitcoin" Version="9.0.0" />
+    <PackageReference Include="NBitcoin.Bitcoinfuzz" Version="9.0.4-custom" />
   </ItemGroup>
-
 </Project>

--- a/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
+++ b/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
@@ -6,6 +6,41 @@ namespace NBitcoin.CppBridge;
 
 public static class Bridge
 {
+    [UnmanagedCallersOnly(EntryPoint = "nbitcoin_script_eval")]
+    public static bool ScriptEval(IntPtr inputDataPtr, int inputDataLength, uint flags, uint version)
+    {
+        if (inputDataPtr == IntPtr.Zero || inputDataLength <= 0)
+            return false;
+
+        try
+        {
+            // Marshal the input data from unmanaged memory
+            byte[] scriptBytes = new byte[inputDataLength];
+            Marshal.Copy(inputDataPtr, scriptBytes, 0, inputDataLength);
+
+            // Create script from bytes
+            Script script = new Script(scriptBytes);
+
+            // Determine the script verification flags
+            ScriptVerify scriptFlags = (ScriptVerify)flags;
+
+            // Determine witness version
+            var sigVersion = version == 0 ? HashVersion.Original : HashVersion.WitnessV0;
+
+            // Evaluate the script
+            var context = new ScriptEvaluationContext
+            {
+                ScriptVerify = scriptFlags
+            };
+
+            return context.EvalScript(script, new TransactionChecker(Network.Main.CreateTransaction(), 0), sigVersion);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     [UnmanagedCallersOnly(EntryPoint = "nbitcoin_miniscript_parse")]
     public static bool MiniscriptParse(IntPtr miniscriptStringPtr)
     {

--- a/modules/nbitcoin/NBitcoin/nbitcoin_lib.h
+++ b/modules/nbitcoin/NBitcoin/nbitcoin_lib.h
@@ -3,3 +3,5 @@
 extern "C" bool nbitcoin_miniscript_parse(const char* input);
 
 extern "C" bool nbitcoin_descriptor_parse(const char* input);
+
+extern "C" bool nbitcoin_script_eval(const uint8_t* input_data, int32_t input_data_length, uint32_t flags, uint32_t version);

--- a/modules/nbitcoin/module.cpp
+++ b/modules/nbitcoin/module.cpp
@@ -15,5 +15,9 @@ namespace bitcoinfuzz
         {
             return nbitcoin_descriptor_parse(str.c_str());
         }
+        std::optional<bool> NBitcoin::script_eval(const std::vector<uint8_t>& input_data, unsigned int flags, size_t version) const
+        {
+            return nbitcoin_script_eval(input_data.data(), input_data.size(), flags, version);
+        }
     }
 }

--- a/modules/nbitcoin/module.h
+++ b/modules/nbitcoin/module.h
@@ -15,6 +15,7 @@ namespace bitcoinfuzz
             NBitcoin(void);
             std::optional<bool> miniscript_parse(std::string str) const override;
             std::optional<bool> descriptor_parse(std::string str) const override;
+            std::optional<bool> script_eval(const std::vector<uint8_t>& input_data, unsigned int flags, size_t version) const override;
             ~NBitcoin() noexcept override = default;
         };
     }


### PR DESCRIPTION
Fixes #301

- [x] Bypass signature validation on our NBitcoin fork.