### PR TITLE
BIP32: Add Deserialize extended key target

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -196,6 +196,10 @@ jobs:
           - corpus: "sign_schnorr"
             target: "sign_schnorr"
             cxxflags: "-DBTCD -DSECP256K1"
+          - corpus: "bip32_deserialize_extended_key"
+            target: "bip32_deserialize_extended_key"
+            cxxflags: "-DNBITCOIN -DRUST_BITCOIN -DBITCOIN_CORE -DCUSTOM_MUTATOR_EXTENDED_KEY"
+            asan_options: "detect_leaks=0:detect_container_overflow=0"
 
     steps:
       - name: Checkout repo

--- a/custommutator/mutators/extended_key.h
+++ b/custommutator/mutators/extended_key.h
@@ -1,0 +1,82 @@
+#ifndef BITCOINFUZZ_CUSTOMMUTATOR_EXTENDED_KEY_H
+#define BITCOINFUZZ_CUSTOMMUTATOR_EXTENDED_KEY_H
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <custommutator/utils/base58.h>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+extern "C" size_t LLVMFuzzerMutate(uint8_t *Data, size_t Size, size_t MaxSize);
+constexpr size_t VERSION_PREFIX_LEN = 4;
+constexpr size_t BIP32_PAYLOAD_LEN = 78;
+struct VersionBytes {
+  uint8_t data[VERSION_PREFIX_LEN];
+};
+constexpr std::array<VersionBytes, 4> VERSION_PREFIXES = {{
+    {{0x04, 0x88, 0xB2, 0x1E}}, // xpub
+    {{0x04, 0x88, 0xAD, 0xE4}}, // xprv
+    {{0x04, 0x35, 0x87, 0xCF}}, // tpub
+    {{0x04, 0x35, 0x83, 0x94}}, // tprv
+}};
+constexpr size_t IDX_XPUB = 0;
+constexpr size_t IDX_XPRV = 1;
+constexpr size_t IDX_TPUB = 2;
+constexpr size_t IDX_TPRV = 3;
+const VersionBytes &GetVersionBytes(std::string_view key_type) {
+  if (key_type == "xprv")
+    return VERSION_PREFIXES[IDX_XPRV];
+  if (key_type == "tpub")
+    return VERSION_PREFIXES[IDX_TPUB];
+  if (key_type == "tprv")
+    return VERSION_PREFIXES[IDX_TPRV];
+  return VERSION_PREFIXES[IDX_XPUB];
+}
+const VersionBytes &GetRandomVersion(unsigned int seed) {
+  return VERSION_PREFIXES[seed % VERSION_PREFIXES.size()];
+}
+extern "C" size_t LLVMFuzzerCustomMutator(uint8_t *fuzz_data, size_t size,
+                                          size_t max_size, unsigned int seed) {
+
+  // Decode input from base58check
+  std::string_view input{reinterpret_cast<const char *>(fuzz_data), size};
+  std::vector<unsigned char> payload(BIP32_PAYLOAD_LEN, 0x00);
+
+  std::vector<unsigned char> decoded;
+  if (DecodeBase58Check(std::string{input}, decoded,
+                        static_cast<int>(max_size))) {
+    const size_t copy_len = std::min(decoded.size(), BIP32_PAYLOAD_LEN);
+    std::memcpy(payload.data(), decoded.data(), copy_len);
+  } else {
+    const size_t copy_len = std::min(size, BIP32_PAYLOAD_LEN);
+    std::memcpy(payload.data(), fuzz_data, copy_len);
+  }
+
+  // Mutate the payload
+  size_t mutated_size =
+      LLVMFuzzerMutate(payload.data(), BIP32_PAYLOAD_LEN, BIP32_PAYLOAD_LEN);
+
+  // Ensure we have exactly BIP32_PAYLOAD_LEN bytes
+  if (mutated_size < BIP32_PAYLOAD_LEN) {
+    std::memset(payload.data() + mutated_size, 0,
+                BIP32_PAYLOAD_LEN - mutated_size);
+  }
+  payload.resize(BIP32_PAYLOAD_LEN);
+
+  // Apply version prefix: use env if set, otherwise random
+  const char *env = std::getenv("EXTKEYTYPE");
+  const auto &version = env ? GetVersionBytes(env) : GetRandomVersion(seed);
+  std::memcpy(payload.data(), version.data, VERSION_PREFIX_LEN);
+
+  // Encode back to base58check
+  std::string encoded =
+      EncodeBase58Check(std::span<const unsigned char>{payload});
+
+  // Copy result to output buffer
+  const size_t output_len = std::min(encoded.size(), max_size);
+  std::memcpy(fuzz_data, encoded.data(), output_len);
+  return output_len;
+}
+#endif // BITCOINFUZZ_CUSTOMMUTATOR_EXTENDED_KEY_H

--- a/custommutator/utils/attributes.h
+++ b/custommutator/utils/attributes.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_ATTRIBUTES_H
+#define BITCOIN_ATTRIBUTES_H
+
+#if defined(__clang__)
+#  if __has_attribute(lifetimebound)
+#    define LIFETIMEBOUND [[clang::lifetimebound]]
+#  else
+#    define LIFETIMEBOUND
+#  endif
+#else
+#  define LIFETIMEBOUND
+#endif
+
+#if defined(__GNUC__)
+#  define ALWAYS_INLINE inline __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#  define ALWAYS_INLINE __forceinline
+#else
+#  error No known always_inline attribute for this platform.
+#endif
+
+#endif // BITCOIN_ATTRIBUTES_H

--- a/custommutator/utils/base58.cpp
+++ b/custommutator/utils/base58.cpp
@@ -1,0 +1,169 @@
+// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <base58.h>
+
+#include <hash.h>
+#include <uint256.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+
+#include <assert.h>
+#include <string.h>
+
+#include <limits>
+
+using util::ContainsNoNUL;
+
+/** All alphanumeric characters except for "0", "I", "O", and "l" */
+static const char* pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+static const int8_t mapBase58[256] = {
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1, 0, 1, 2, 3, 4, 5, 6,  7, 8,-1,-1,-1,-1,-1,-1,
+    -1, 9,10,11,12,13,14,15, 16,-1,17,18,19,20,21,-1,
+    22,23,24,25,26,27,28,29, 30,31,32,-1,-1,-1,-1,-1,
+    -1,33,34,35,36,37,38,39, 40,41,42,43,-1,44,45,46,
+    47,48,49,50,51,52,53,54, 55,56,57,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+};
+
+[[nodiscard]] static bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch, int max_ret_len)
+{
+    // Skip leading spaces.
+    while (*psz && IsSpace(*psz))
+        psz++;
+    // Skip and count leading '1's.
+    int zeroes = 0;
+    int length = 0;
+    while (*psz == '1') {
+        zeroes++;
+        if (zeroes > max_ret_len) return false;
+        psz++;
+    }
+    // Allocate enough space in big-endian base256 representation.
+    int size = strlen(psz) * 733 /1000 + 1; // log(58) / log(256), rounded up.
+    std::vector<unsigned char> b256(size);
+    // Process the characters.
+    static_assert(std::size(mapBase58) == 256, "mapBase58.size() should be 256"); // guarantee not out of range
+    while (*psz && !IsSpace(*psz)) {
+        // Decode base58 character
+        int carry = mapBase58[(uint8_t)*psz];
+        if (carry == -1)  // Invalid b58 character
+            return false;
+        int i = 0;
+        for (std::vector<unsigned char>::reverse_iterator it = b256.rbegin(); (carry != 0 || i < length) && (it != b256.rend()); ++it, ++i) {
+            carry += 58 * (*it);
+            *it = carry % 256;
+            carry /= 256;
+        }
+        assert(carry == 0);
+        length = i;
+        if (length + zeroes > max_ret_len) return false;
+        psz++;
+    }
+    // Skip trailing spaces.
+    while (IsSpace(*psz))
+        psz++;
+    if (*psz != 0)
+        return false;
+    // Skip leading zeroes in b256.
+    std::vector<unsigned char>::iterator it = b256.begin() + (size - length);
+    // Copy result into output vector.
+    vch.reserve(zeroes + (b256.end() - it));
+    vch.assign(zeroes, 0x00);
+    while (it != b256.end())
+        vch.push_back(*(it++));
+    return true;
+}
+
+std::string EncodeBase58(std::span<const unsigned char> input)
+{
+    // Skip & count leading zeroes.
+    int zeroes = 0;
+    int length = 0;
+    while (input.size() > 0 && input[0] == 0) {
+        input = input.subspan(1);
+        zeroes++;
+    }
+    // Allocate enough space in big-endian base58 representation.
+    int size = input.size() * 138 / 100 + 1; // log(256) / log(58), rounded up.
+    std::vector<unsigned char> b58(size);
+    // Process the bytes.
+    while (input.size() > 0) {
+        int carry = input[0];
+        int i = 0;
+        // Apply "b58 = b58 * 256 + ch".
+        for (std::vector<unsigned char>::reverse_iterator it = b58.rbegin(); (carry != 0 || i < length) && (it != b58.rend()); it++, i++) {
+            carry += 256 * (*it);
+            *it = carry % 58;
+            carry /= 58;
+        }
+
+        assert(carry == 0);
+        length = i;
+        input = input.subspan(1);
+    }
+    // Skip leading zeroes in base58 result.
+    std::vector<unsigned char>::iterator it = b58.begin() + (size - length);
+    while (it != b58.end() && *it == 0)
+        it++;
+    // Translate the result into a string.
+    std::string str;
+    str.reserve(zeroes + (b58.end() - it));
+    str.assign(zeroes, '1');
+    while (it != b58.end())
+        str += pszBase58[*(it++)];
+    return str;
+}
+
+bool DecodeBase58(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret_len)
+{
+    if (!ContainsNoNUL(str)) {
+        return false;
+    }
+    return DecodeBase58(str.c_str(), vchRet, max_ret_len);
+}
+
+std::string EncodeBase58Check(std::span<const unsigned char> input)
+{
+    // add 4-byte hash check to the end
+    std::vector<unsigned char> vch(input.begin(), input.end());
+    uint256 hash = Hash(vch);
+    vch.insert(vch.end(), (unsigned char*)&hash, (unsigned char*)&hash + 4);
+    return EncodeBase58(vch);
+}
+
+[[nodiscard]] static bool DecodeBase58Check(const char* psz, std::vector<unsigned char>& vchRet, int max_ret_len)
+{
+    if (!DecodeBase58(psz, vchRet, max_ret_len > std::numeric_limits<int>::max() - 4 ? std::numeric_limits<int>::max() : max_ret_len + 4) ||
+        (vchRet.size() < 4)) {
+        vchRet.clear();
+        return false;
+    }
+    // re-calculate the checksum, ensure it matches the included 4-byte checksum
+    uint256 hash = Hash(std::span{vchRet}.first(vchRet.size() - 4));
+    if (memcmp(&hash, &vchRet[vchRet.size() - 4], 4) != 0) {
+        vchRet.clear();
+        return false;
+    }
+    vchRet.resize(vchRet.size() - 4);
+    return true;
+}
+
+bool DecodeBase58Check(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret)
+{
+    if (!ContainsNoNUL(str)) {
+        return false;
+    }
+    return DecodeBase58Check(str.c_str(), vchRet, max_ret);
+}

--- a/custommutator/utils/base58.h
+++ b/custommutator/utils/base58.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/**
+ * Why base-58 instead of standard base-64 encoding?
+ * - Don't want 0OIl characters that look the same in some fonts and
+ *      could be used to create visually identical looking data.
+ * - A string with non-alphanumeric characters is not as easily accepted as input.
+ * - E-mail usually won't line-break if there's no punctuation to break at.
+ * - Double-clicking selects the whole string as one word if it's all alphanumeric.
+ */
+#ifndef BITCOIN_BASE58_H
+#define BITCOIN_BASE58_H
+
+#include "span.h"
+
+#include <string>
+#include <vector>
+
+/**
+ * Encode a byte span as a base58-encoded string
+ */
+std::string EncodeBase58(std::span<const unsigned char> input);
+
+/**
+ * Decode a base58-encoded string (str) into a byte vector (vchRet).
+ * return true if decoding is successful.
+ */
+[[nodiscard]] bool DecodeBase58(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret_len);
+
+/**
+ * Encode a byte span into a base58-encoded string, including checksum
+ */
+std::string EncodeBase58Check(std::span<const unsigned char> input);
+
+/**
+ * Decode a base58-encoded string (str) that includes a checksum into a byte
+ * vector (vchRet), return true if decoding is successful
+ */
+[[nodiscard]] bool DecodeBase58Check(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret_len);
+
+#endif // BITCOIN_BASE58_H

--- a/custommutator/utils/compat/assumptions.h
+++ b/custommutator/utils/compat/assumptions.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Compile-time verification of assumptions we make.
+
+#ifndef BITCOIN_COMPAT_ASSUMPTIONS_H
+#define BITCOIN_COMPAT_ASSUMPTIONS_H
+
+#include <cstddef>
+#include <limits>
+
+// Assumption: We assume the floating-point types to fulfill the requirements of
+//             IEC 559 (IEEE 754) standard.
+// Example(s): Floating-point division by zero in ConnectBlock, CreateTransaction
+//             and EstimateMedianVal.
+static_assert(std::numeric_limits<float>::is_iec559, "IEEE 754 float assumed");
+static_assert(std::numeric_limits<double>::is_iec559, "IEEE 754 double assumed");
+
+// Assumption: We assume eight bits per byte (obviously, but remember: don't
+//             trust -- verify!).
+// Example(s): Everywhere :-)
+static_assert(std::numeric_limits<unsigned char>::digits == 8, "8-bit byte assumed");
+
+// Assumption: We assume integer widths.
+// Example(s): GetSizeOfCompactSize and WriteCompactSize in the serialization
+//             code.
+static_assert(sizeof(short) == 2, "16-bit short assumed");
+static_assert(sizeof(int) == 4, "32-bit int assumed");
+static_assert(sizeof(unsigned) == 4, "32-bit unsigned assumed");
+
+// Assumption: We assume size_t to be 32-bit or 64-bit.
+// Example(s): size_t assumed to be at least 32-bit in ecdsa_signature_parse_der_lax(...).
+//             size_t assumed to be 32-bit or 64-bit in MallocUsage(...).
+static_assert(sizeof(size_t) == 4 || sizeof(size_t) == 8, "size_t assumed to be 32-bit or 64-bit");
+static_assert(sizeof(size_t) == sizeof(void*), "Sizes of size_t and void* assumed to be equal");
+
+// Some important things we are NOT assuming (non-exhaustive list):
+// * We are NOT assuming a specific value for std::endian::native.
+// * We are NOT assuming a specific value for std::locale("").name().
+// * We are NOT assuming a specific value for std::numeric_limits<char>::is_signed.
+
+#endif // BITCOIN_COMPAT_ASSUMPTIONS_H

--- a/custommutator/utils/crypto/hex_base.cpp
+++ b/custommutator/utils/crypto/hex_base.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2009-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <crypto/hex_base.h>
+
+#include <array>
+#include <cstring>
+#include <string>
+
+namespace {
+
+using ByteAsHex = std::array<char, 2>;
+
+constexpr std::array<ByteAsHex, 256> CreateByteToHexMap()
+{
+    constexpr char hexmap[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+    std::array<ByteAsHex, 256> byte_to_hex{};
+    for (size_t i = 0; i < byte_to_hex.size(); ++i) {
+        byte_to_hex[i][0] = hexmap[i >> 4];
+        byte_to_hex[i][1] = hexmap[i & 15];
+    }
+    return byte_to_hex;
+}
+
+} // namespace
+
+std::string HexStr(const std::span<const uint8_t> s)
+{
+    std::string rv(s.size() * 2, '\0');
+    static constexpr auto byte_to_hex = CreateByteToHexMap();
+    static_assert(sizeof(byte_to_hex) == 512);
+
+    char* it = rv.data();
+    for (uint8_t v : s) {
+        std::memcpy(it, byte_to_hex[v].data(), 2);
+        it += 2;
+    }
+
+    assert(it == rv.data() + rv.size());
+    return rv;
+}
+
+const signed char p_util_hexdigit[256] =
+{ -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+  -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+  -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+  0,1,2,3,4,5,6,7,8,9,-1,-1,-1,-1,-1,-1,
+  -1,0xa,0xb,0xc,0xd,0xe,0xf,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+  -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+  -1,0xa,0xb,0xc,0xd,0xe,0xf,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+  -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+  -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+  -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+  -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+  -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+  -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+  -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+  -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+  -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1, };
+
+signed char HexDigit(char c)
+{
+    return p_util_hexdigit[(unsigned char)c];
+}

--- a/custommutator/utils/crypto/hex_base.h
+++ b/custommutator/utils/crypto/hex_base.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2009-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CRYPTO_HEX_BASE_H
+#define BITCOIN_CRYPTO_HEX_BASE_H
+
+#include <span.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+/**
+ * Convert a span of bytes to a lower-case hexadecimal string.
+ */
+std::string HexStr(const std::span<const uint8_t> s);
+inline std::string HexStr(const std::span<const char> s) { return HexStr(MakeUCharSpan(s)); }
+inline std::string HexStr(const std::span<const std::byte> s) { return HexStr(MakeUCharSpan(s)); }
+
+signed char HexDigit(char c);
+
+#endif // BITCOIN_CRYPTO_HEX_BASE_H

--- a/custommutator/utils/crypto/hmac_sha512.cpp
+++ b/custommutator/utils/crypto/hmac_sha512.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2014-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <crypto/hmac_sha512.h>
+
+#include <string.h>
+
+CHMAC_SHA512::CHMAC_SHA512(const unsigned char* key, size_t keylen)
+{
+    unsigned char rkey[128];
+    if (keylen <= 128) {
+        memcpy(rkey, key, keylen);
+        memset(rkey + keylen, 0, 128 - keylen);
+    } else {
+        CSHA512().Write(key, keylen).Finalize(rkey);
+        memset(rkey + 64, 0, 64);
+    }
+
+    for (int n = 0; n < 128; n++)
+        rkey[n] ^= 0x5c;
+    outer.Write(rkey, 128);
+
+    for (int n = 0; n < 128; n++)
+        rkey[n] ^= 0x5c ^ 0x36;
+    inner.Write(rkey, 128);
+}
+
+void CHMAC_SHA512::Finalize(unsigned char hash[OUTPUT_SIZE])
+{
+    unsigned char temp[64];
+    inner.Finalize(temp);
+    outer.Write(temp, 64).Finalize(hash);
+}

--- a/custommutator/utils/crypto/hmac_sha512.h
+++ b/custommutator/utils/crypto/hmac_sha512.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CRYPTO_HMAC_SHA512_H
+#define BITCOIN_CRYPTO_HMAC_SHA512_H
+
+#include <crypto/sha512.h>
+
+#include <cstdlib>
+#include <stdint.h>
+
+/** A hasher class for HMAC-SHA-512. */
+class CHMAC_SHA512
+{
+private:
+    CSHA512 outer;
+    CSHA512 inner;
+
+public:
+    static const size_t OUTPUT_SIZE = 64;
+
+    CHMAC_SHA512(const unsigned char* key, size_t keylen);
+    CHMAC_SHA512& Write(const unsigned char* data, size_t len)
+    {
+        inner.Write(data, len);
+        return *this;
+    }
+    void Finalize(unsigned char hash[OUTPUT_SIZE]);
+};
+
+#endif // BITCOIN_CRYPTO_HMAC_SHA512_H

--- a/custommutator/utils/crypto/ripemd160.cpp
+++ b/custommutator/utils/crypto/ripemd160.cpp
@@ -1,0 +1,292 @@
+// Copyright (c) 2014-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <crypto/ripemd160.h>
+
+#include <crypto/common.h>
+
+#include <string.h>
+
+// Internal implementation code.
+namespace
+{
+/// Internal RIPEMD-160 implementation.
+namespace ripemd160
+{
+uint32_t inline f1(uint32_t x, uint32_t y, uint32_t z) { return x ^ y ^ z; }
+uint32_t inline f2(uint32_t x, uint32_t y, uint32_t z) { return (x & y) | (~x & z); }
+uint32_t inline f3(uint32_t x, uint32_t y, uint32_t z) { return (x | ~y) ^ z; }
+uint32_t inline f4(uint32_t x, uint32_t y, uint32_t z) { return (x & z) | (y & ~z); }
+uint32_t inline f5(uint32_t x, uint32_t y, uint32_t z) { return x ^ (y | ~z); }
+
+/** Initialize RIPEMD-160 state. */
+void inline Initialize(uint32_t* s)
+{
+    s[0] = 0x67452301ul;
+    s[1] = 0xEFCDAB89ul;
+    s[2] = 0x98BADCFEul;
+    s[3] = 0x10325476ul;
+    s[4] = 0xC3D2E1F0ul;
+}
+
+uint32_t inline rol(uint32_t x, int i) { return (x << i) | (x >> (32 - i)); }
+
+void inline Round(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t f, uint32_t x, uint32_t k, int r)
+{
+    a = rol(a + f + x + k, r) + e;
+    c = rol(c, 10);
+}
+
+void inline R11(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t x, int r) { Round(a, b, c, d, e, f1(b, c, d), x, 0, r); }
+void inline R21(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t x, int r) { Round(a, b, c, d, e, f2(b, c, d), x, 0x5A827999ul, r); }
+void inline R31(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t x, int r) { Round(a, b, c, d, e, f3(b, c, d), x, 0x6ED9EBA1ul, r); }
+void inline R41(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t x, int r) { Round(a, b, c, d, e, f4(b, c, d), x, 0x8F1BBCDCul, r); }
+void inline R51(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t x, int r) { Round(a, b, c, d, e, f5(b, c, d), x, 0xA953FD4Eul, r); }
+
+void inline R12(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t x, int r) { Round(a, b, c, d, e, f5(b, c, d), x, 0x50A28BE6ul, r); }
+void inline R22(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t x, int r) { Round(a, b, c, d, e, f4(b, c, d), x, 0x5C4DD124ul, r); }
+void inline R32(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t x, int r) { Round(a, b, c, d, e, f3(b, c, d), x, 0x6D703EF3ul, r); }
+void inline R42(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t x, int r) { Round(a, b, c, d, e, f2(b, c, d), x, 0x7A6D76E9ul, r); }
+void inline R52(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t x, int r) { Round(a, b, c, d, e, f1(b, c, d), x, 0, r); }
+
+/** Perform a RIPEMD-160 transformation, processing a 64-byte chunk. */
+void Transform(uint32_t* s, const unsigned char* chunk)
+{
+    uint32_t a1 = s[0], b1 = s[1], c1 = s[2], d1 = s[3], e1 = s[4];
+    uint32_t a2 = a1, b2 = b1, c2 = c1, d2 = d1, e2 = e1;
+    uint32_t w0 = ReadLE32(chunk + 0), w1 = ReadLE32(chunk + 4), w2 = ReadLE32(chunk + 8), w3 = ReadLE32(chunk + 12);
+    uint32_t w4 = ReadLE32(chunk + 16), w5 = ReadLE32(chunk + 20), w6 = ReadLE32(chunk + 24), w7 = ReadLE32(chunk + 28);
+    uint32_t w8 = ReadLE32(chunk + 32), w9 = ReadLE32(chunk + 36), w10 = ReadLE32(chunk + 40), w11 = ReadLE32(chunk + 44);
+    uint32_t w12 = ReadLE32(chunk + 48), w13 = ReadLE32(chunk + 52), w14 = ReadLE32(chunk + 56), w15 = ReadLE32(chunk + 60);
+
+    R11(a1, b1, c1, d1, e1, w0, 11);
+    R12(a2, b2, c2, d2, e2, w5, 8);
+    R11(e1, a1, b1, c1, d1, w1, 14);
+    R12(e2, a2, b2, c2, d2, w14, 9);
+    R11(d1, e1, a1, b1, c1, w2, 15);
+    R12(d2, e2, a2, b2, c2, w7, 9);
+    R11(c1, d1, e1, a1, b1, w3, 12);
+    R12(c2, d2, e2, a2, b2, w0, 11);
+    R11(b1, c1, d1, e1, a1, w4, 5);
+    R12(b2, c2, d2, e2, a2, w9, 13);
+    R11(a1, b1, c1, d1, e1, w5, 8);
+    R12(a2, b2, c2, d2, e2, w2, 15);
+    R11(e1, a1, b1, c1, d1, w6, 7);
+    R12(e2, a2, b2, c2, d2, w11, 15);
+    R11(d1, e1, a1, b1, c1, w7, 9);
+    R12(d2, e2, a2, b2, c2, w4, 5);
+    R11(c1, d1, e1, a1, b1, w8, 11);
+    R12(c2, d2, e2, a2, b2, w13, 7);
+    R11(b1, c1, d1, e1, a1, w9, 13);
+    R12(b2, c2, d2, e2, a2, w6, 7);
+    R11(a1, b1, c1, d1, e1, w10, 14);
+    R12(a2, b2, c2, d2, e2, w15, 8);
+    R11(e1, a1, b1, c1, d1, w11, 15);
+    R12(e2, a2, b2, c2, d2, w8, 11);
+    R11(d1, e1, a1, b1, c1, w12, 6);
+    R12(d2, e2, a2, b2, c2, w1, 14);
+    R11(c1, d1, e1, a1, b1, w13, 7);
+    R12(c2, d2, e2, a2, b2, w10, 14);
+    R11(b1, c1, d1, e1, a1, w14, 9);
+    R12(b2, c2, d2, e2, a2, w3, 12);
+    R11(a1, b1, c1, d1, e1, w15, 8);
+    R12(a2, b2, c2, d2, e2, w12, 6);
+
+    R21(e1, a1, b1, c1, d1, w7, 7);
+    R22(e2, a2, b2, c2, d2, w6, 9);
+    R21(d1, e1, a1, b1, c1, w4, 6);
+    R22(d2, e2, a2, b2, c2, w11, 13);
+    R21(c1, d1, e1, a1, b1, w13, 8);
+    R22(c2, d2, e2, a2, b2, w3, 15);
+    R21(b1, c1, d1, e1, a1, w1, 13);
+    R22(b2, c2, d2, e2, a2, w7, 7);
+    R21(a1, b1, c1, d1, e1, w10, 11);
+    R22(a2, b2, c2, d2, e2, w0, 12);
+    R21(e1, a1, b1, c1, d1, w6, 9);
+    R22(e2, a2, b2, c2, d2, w13, 8);
+    R21(d1, e1, a1, b1, c1, w15, 7);
+    R22(d2, e2, a2, b2, c2, w5, 9);
+    R21(c1, d1, e1, a1, b1, w3, 15);
+    R22(c2, d2, e2, a2, b2, w10, 11);
+    R21(b1, c1, d1, e1, a1, w12, 7);
+    R22(b2, c2, d2, e2, a2, w14, 7);
+    R21(a1, b1, c1, d1, e1, w0, 12);
+    R22(a2, b2, c2, d2, e2, w15, 7);
+    R21(e1, a1, b1, c1, d1, w9, 15);
+    R22(e2, a2, b2, c2, d2, w8, 12);
+    R21(d1, e1, a1, b1, c1, w5, 9);
+    R22(d2, e2, a2, b2, c2, w12, 7);
+    R21(c1, d1, e1, a1, b1, w2, 11);
+    R22(c2, d2, e2, a2, b2, w4, 6);
+    R21(b1, c1, d1, e1, a1, w14, 7);
+    R22(b2, c2, d2, e2, a2, w9, 15);
+    R21(a1, b1, c1, d1, e1, w11, 13);
+    R22(a2, b2, c2, d2, e2, w1, 13);
+    R21(e1, a1, b1, c1, d1, w8, 12);
+    R22(e2, a2, b2, c2, d2, w2, 11);
+
+    R31(d1, e1, a1, b1, c1, w3, 11);
+    R32(d2, e2, a2, b2, c2, w15, 9);
+    R31(c1, d1, e1, a1, b1, w10, 13);
+    R32(c2, d2, e2, a2, b2, w5, 7);
+    R31(b1, c1, d1, e1, a1, w14, 6);
+    R32(b2, c2, d2, e2, a2, w1, 15);
+    R31(a1, b1, c1, d1, e1, w4, 7);
+    R32(a2, b2, c2, d2, e2, w3, 11);
+    R31(e1, a1, b1, c1, d1, w9, 14);
+    R32(e2, a2, b2, c2, d2, w7, 8);
+    R31(d1, e1, a1, b1, c1, w15, 9);
+    R32(d2, e2, a2, b2, c2, w14, 6);
+    R31(c1, d1, e1, a1, b1, w8, 13);
+    R32(c2, d2, e2, a2, b2, w6, 6);
+    R31(b1, c1, d1, e1, a1, w1, 15);
+    R32(b2, c2, d2, e2, a2, w9, 14);
+    R31(a1, b1, c1, d1, e1, w2, 14);
+    R32(a2, b2, c2, d2, e2, w11, 12);
+    R31(e1, a1, b1, c1, d1, w7, 8);
+    R32(e2, a2, b2, c2, d2, w8, 13);
+    R31(d1, e1, a1, b1, c1, w0, 13);
+    R32(d2, e2, a2, b2, c2, w12, 5);
+    R31(c1, d1, e1, a1, b1, w6, 6);
+    R32(c2, d2, e2, a2, b2, w2, 14);
+    R31(b1, c1, d1, e1, a1, w13, 5);
+    R32(b2, c2, d2, e2, a2, w10, 13);
+    R31(a1, b1, c1, d1, e1, w11, 12);
+    R32(a2, b2, c2, d2, e2, w0, 13);
+    R31(e1, a1, b1, c1, d1, w5, 7);
+    R32(e2, a2, b2, c2, d2, w4, 7);
+    R31(d1, e1, a1, b1, c1, w12, 5);
+    R32(d2, e2, a2, b2, c2, w13, 5);
+
+    R41(c1, d1, e1, a1, b1, w1, 11);
+    R42(c2, d2, e2, a2, b2, w8, 15);
+    R41(b1, c1, d1, e1, a1, w9, 12);
+    R42(b2, c2, d2, e2, a2, w6, 5);
+    R41(a1, b1, c1, d1, e1, w11, 14);
+    R42(a2, b2, c2, d2, e2, w4, 8);
+    R41(e1, a1, b1, c1, d1, w10, 15);
+    R42(e2, a2, b2, c2, d2, w1, 11);
+    R41(d1, e1, a1, b1, c1, w0, 14);
+    R42(d2, e2, a2, b2, c2, w3, 14);
+    R41(c1, d1, e1, a1, b1, w8, 15);
+    R42(c2, d2, e2, a2, b2, w11, 14);
+    R41(b1, c1, d1, e1, a1, w12, 9);
+    R42(b2, c2, d2, e2, a2, w15, 6);
+    R41(a1, b1, c1, d1, e1, w4, 8);
+    R42(a2, b2, c2, d2, e2, w0, 14);
+    R41(e1, a1, b1, c1, d1, w13, 9);
+    R42(e2, a2, b2, c2, d2, w5, 6);
+    R41(d1, e1, a1, b1, c1, w3, 14);
+    R42(d2, e2, a2, b2, c2, w12, 9);
+    R41(c1, d1, e1, a1, b1, w7, 5);
+    R42(c2, d2, e2, a2, b2, w2, 12);
+    R41(b1, c1, d1, e1, a1, w15, 6);
+    R42(b2, c2, d2, e2, a2, w13, 9);
+    R41(a1, b1, c1, d1, e1, w14, 8);
+    R42(a2, b2, c2, d2, e2, w9, 12);
+    R41(e1, a1, b1, c1, d1, w5, 6);
+    R42(e2, a2, b2, c2, d2, w7, 5);
+    R41(d1, e1, a1, b1, c1, w6, 5);
+    R42(d2, e2, a2, b2, c2, w10, 15);
+    R41(c1, d1, e1, a1, b1, w2, 12);
+    R42(c2, d2, e2, a2, b2, w14, 8);
+
+    R51(b1, c1, d1, e1, a1, w4, 9);
+    R52(b2, c2, d2, e2, a2, w12, 8);
+    R51(a1, b1, c1, d1, e1, w0, 15);
+    R52(a2, b2, c2, d2, e2, w15, 5);
+    R51(e1, a1, b1, c1, d1, w5, 5);
+    R52(e2, a2, b2, c2, d2, w10, 12);
+    R51(d1, e1, a1, b1, c1, w9, 11);
+    R52(d2, e2, a2, b2, c2, w4, 9);
+    R51(c1, d1, e1, a1, b1, w7, 6);
+    R52(c2, d2, e2, a2, b2, w1, 12);
+    R51(b1, c1, d1, e1, a1, w12, 8);
+    R52(b2, c2, d2, e2, a2, w5, 5);
+    R51(a1, b1, c1, d1, e1, w2, 13);
+    R52(a2, b2, c2, d2, e2, w8, 14);
+    R51(e1, a1, b1, c1, d1, w10, 12);
+    R52(e2, a2, b2, c2, d2, w7, 6);
+    R51(d1, e1, a1, b1, c1, w14, 5);
+    R52(d2, e2, a2, b2, c2, w6, 8);
+    R51(c1, d1, e1, a1, b1, w1, 12);
+    R52(c2, d2, e2, a2, b2, w2, 13);
+    R51(b1, c1, d1, e1, a1, w3, 13);
+    R52(b2, c2, d2, e2, a2, w13, 6);
+    R51(a1, b1, c1, d1, e1, w8, 14);
+    R52(a2, b2, c2, d2, e2, w14, 5);
+    R51(e1, a1, b1, c1, d1, w11, 11);
+    R52(e2, a2, b2, c2, d2, w0, 15);
+    R51(d1, e1, a1, b1, c1, w6, 8);
+    R52(d2, e2, a2, b2, c2, w3, 13);
+    R51(c1, d1, e1, a1, b1, w15, 5);
+    R52(c2, d2, e2, a2, b2, w9, 11);
+    R51(b1, c1, d1, e1, a1, w13, 6);
+    R52(b2, c2, d2, e2, a2, w11, 11);
+
+    uint32_t t = s[0];
+    s[0] = s[1] + c1 + d2;
+    s[1] = s[2] + d1 + e2;
+    s[2] = s[3] + e1 + a2;
+    s[3] = s[4] + a1 + b2;
+    s[4] = t + b1 + c2;
+}
+
+} // namespace ripemd160
+
+} // namespace
+
+////// RIPEMD160
+
+CRIPEMD160::CRIPEMD160()
+{
+    ripemd160::Initialize(s);
+}
+
+CRIPEMD160& CRIPEMD160::Write(const unsigned char* data, size_t len)
+{
+    const unsigned char* end = data + len;
+    size_t bufsize = bytes % 64;
+    if (bufsize && bufsize + len >= 64) {
+        // Fill the buffer, and process it.
+        memcpy(buf + bufsize, data, 64 - bufsize);
+        bytes += 64 - bufsize;
+        data += 64 - bufsize;
+        ripemd160::Transform(s, buf);
+        bufsize = 0;
+    }
+    while (end - data >= 64) {
+        // Process full chunks directly from the source.
+        ripemd160::Transform(s, data);
+        bytes += 64;
+        data += 64;
+    }
+    if (end > data) {
+        // Fill the buffer with what remains.
+        memcpy(buf + bufsize, data, end - data);
+        bytes += end - data;
+    }
+    return *this;
+}
+
+void CRIPEMD160::Finalize(unsigned char hash[OUTPUT_SIZE])
+{
+    static const unsigned char pad[64] = {0x80};
+    unsigned char sizedesc[8];
+    WriteLE64(sizedesc, bytes << 3);
+    Write(pad, 1 + ((119 - (bytes % 64)) % 64));
+    Write(sizedesc, 8);
+    WriteLE32(hash, s[0]);
+    WriteLE32(hash + 4, s[1]);
+    WriteLE32(hash + 8, s[2]);
+    WriteLE32(hash + 12, s[3]);
+    WriteLE32(hash + 16, s[4]);
+}
+
+CRIPEMD160& CRIPEMD160::Reset()
+{
+    bytes = 0;
+    ripemd160::Initialize(s);
+    return *this;
+}

--- a/custommutator/utils/crypto/ripemd160.h
+++ b/custommutator/utils/crypto/ripemd160.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CRYPTO_RIPEMD160_H
+#define BITCOIN_CRYPTO_RIPEMD160_H
+
+#include <cstdlib>
+#include <stdint.h>
+
+/** A hasher class for RIPEMD-160. */
+class CRIPEMD160
+{
+private:
+    uint32_t s[5];
+    unsigned char buf[64];
+    uint64_t bytes{0};
+
+public:
+    static const size_t OUTPUT_SIZE = 20;
+
+    CRIPEMD160();
+    CRIPEMD160& Write(const unsigned char* data, size_t len);
+    void Finalize(unsigned char hash[OUTPUT_SIZE]);
+    CRIPEMD160& Reset();
+};
+
+#endif // BITCOIN_CRYPTO_RIPEMD160_H

--- a/custommutator/utils/crypto/sha512.cpp
+++ b/custommutator/utils/crypto/sha512.cpp
@@ -1,0 +1,207 @@
+// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <crypto/sha512.h>
+
+#include <crypto/common.h>
+
+#include <string.h>
+
+// Internal implementation code.
+namespace
+{
+/// Internal SHA-512 implementation.
+namespace sha512
+{
+uint64_t inline Ch(uint64_t x, uint64_t y, uint64_t z) { return z ^ (x & (y ^ z)); }
+uint64_t inline Maj(uint64_t x, uint64_t y, uint64_t z) { return (x & y) | (z & (x | y)); }
+uint64_t inline Sigma0(uint64_t x) { return (x >> 28 | x << 36) ^ (x >> 34 | x << 30) ^ (x >> 39 | x << 25); }
+uint64_t inline Sigma1(uint64_t x) { return (x >> 14 | x << 50) ^ (x >> 18 | x << 46) ^ (x >> 41 | x << 23); }
+uint64_t inline sigma0(uint64_t x) { return (x >> 1 | x << 63) ^ (x >> 8 | x << 56) ^ (x >> 7); }
+uint64_t inline sigma1(uint64_t x) { return (x >> 19 | x << 45) ^ (x >> 61 | x << 3) ^ (x >> 6); }
+
+/** One round of SHA-512. */
+void inline Round(uint64_t a, uint64_t b, uint64_t c, uint64_t& d, uint64_t e, uint64_t f, uint64_t g, uint64_t& h, uint64_t k, uint64_t w)
+{
+    uint64_t t1 = h + Sigma1(e) + Ch(e, f, g) + k + w;
+    uint64_t t2 = Sigma0(a) + Maj(a, b, c);
+    d += t1;
+    h = t1 + t2;
+}
+
+/** Initialize SHA-512 state. */
+void inline Initialize(uint64_t* s)
+{
+    s[0] = 0x6a09e667f3bcc908ull;
+    s[1] = 0xbb67ae8584caa73bull;
+    s[2] = 0x3c6ef372fe94f82bull;
+    s[3] = 0xa54ff53a5f1d36f1ull;
+    s[4] = 0x510e527fade682d1ull;
+    s[5] = 0x9b05688c2b3e6c1full;
+    s[6] = 0x1f83d9abfb41bd6bull;
+    s[7] = 0x5be0cd19137e2179ull;
+}
+
+/** Perform one SHA-512 transformation, processing a 128-byte chunk. */
+void Transform(uint64_t* s, const unsigned char* chunk)
+{
+    uint64_t a = s[0], b = s[1], c = s[2], d = s[3], e = s[4], f = s[5], g = s[6], h = s[7];
+    uint64_t w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14, w15;
+
+    Round(a, b, c, d, e, f, g, h, 0x428a2f98d728ae22ull, w0 = ReadBE64(chunk + 0));
+    Round(h, a, b, c, d, e, f, g, 0x7137449123ef65cdull, w1 = ReadBE64(chunk + 8));
+    Round(g, h, a, b, c, d, e, f, 0xb5c0fbcfec4d3b2full, w2 = ReadBE64(chunk + 16));
+    Round(f, g, h, a, b, c, d, e, 0xe9b5dba58189dbbcull, w3 = ReadBE64(chunk + 24));
+    Round(e, f, g, h, a, b, c, d, 0x3956c25bf348b538ull, w4 = ReadBE64(chunk + 32));
+    Round(d, e, f, g, h, a, b, c, 0x59f111f1b605d019ull, w5 = ReadBE64(chunk + 40));
+    Round(c, d, e, f, g, h, a, b, 0x923f82a4af194f9bull, w6 = ReadBE64(chunk + 48));
+    Round(b, c, d, e, f, g, h, a, 0xab1c5ed5da6d8118ull, w7 = ReadBE64(chunk + 56));
+    Round(a, b, c, d, e, f, g, h, 0xd807aa98a3030242ull, w8 = ReadBE64(chunk + 64));
+    Round(h, a, b, c, d, e, f, g, 0x12835b0145706fbeull, w9 = ReadBE64(chunk + 72));
+    Round(g, h, a, b, c, d, e, f, 0x243185be4ee4b28cull, w10 = ReadBE64(chunk + 80));
+    Round(f, g, h, a, b, c, d, e, 0x550c7dc3d5ffb4e2ull, w11 = ReadBE64(chunk + 88));
+    Round(e, f, g, h, a, b, c, d, 0x72be5d74f27b896full, w12 = ReadBE64(chunk + 96));
+    Round(d, e, f, g, h, a, b, c, 0x80deb1fe3b1696b1ull, w13 = ReadBE64(chunk + 104));
+    Round(c, d, e, f, g, h, a, b, 0x9bdc06a725c71235ull, w14 = ReadBE64(chunk + 112));
+    Round(b, c, d, e, f, g, h, a, 0xc19bf174cf692694ull, w15 = ReadBE64(chunk + 120));
+
+    Round(a, b, c, d, e, f, g, h, 0xe49b69c19ef14ad2ull, w0 += sigma1(w14) + w9 + sigma0(w1));
+    Round(h, a, b, c, d, e, f, g, 0xefbe4786384f25e3ull, w1 += sigma1(w15) + w10 + sigma0(w2));
+    Round(g, h, a, b, c, d, e, f, 0x0fc19dc68b8cd5b5ull, w2 += sigma1(w0) + w11 + sigma0(w3));
+    Round(f, g, h, a, b, c, d, e, 0x240ca1cc77ac9c65ull, w3 += sigma1(w1) + w12 + sigma0(w4));
+    Round(e, f, g, h, a, b, c, d, 0x2de92c6f592b0275ull, w4 += sigma1(w2) + w13 + sigma0(w5));
+    Round(d, e, f, g, h, a, b, c, 0x4a7484aa6ea6e483ull, w5 += sigma1(w3) + w14 + sigma0(w6));
+    Round(c, d, e, f, g, h, a, b, 0x5cb0a9dcbd41fbd4ull, w6 += sigma1(w4) + w15 + sigma0(w7));
+    Round(b, c, d, e, f, g, h, a, 0x76f988da831153b5ull, w7 += sigma1(w5) + w0 + sigma0(w8));
+    Round(a, b, c, d, e, f, g, h, 0x983e5152ee66dfabull, w8 += sigma1(w6) + w1 + sigma0(w9));
+    Round(h, a, b, c, d, e, f, g, 0xa831c66d2db43210ull, w9 += sigma1(w7) + w2 + sigma0(w10));
+    Round(g, h, a, b, c, d, e, f, 0xb00327c898fb213full, w10 += sigma1(w8) + w3 + sigma0(w11));
+    Round(f, g, h, a, b, c, d, e, 0xbf597fc7beef0ee4ull, w11 += sigma1(w9) + w4 + sigma0(w12));
+    Round(e, f, g, h, a, b, c, d, 0xc6e00bf33da88fc2ull, w12 += sigma1(w10) + w5 + sigma0(w13));
+    Round(d, e, f, g, h, a, b, c, 0xd5a79147930aa725ull, w13 += sigma1(w11) + w6 + sigma0(w14));
+    Round(c, d, e, f, g, h, a, b, 0x06ca6351e003826full, w14 += sigma1(w12) + w7 + sigma0(w15));
+    Round(b, c, d, e, f, g, h, a, 0x142929670a0e6e70ull, w15 += sigma1(w13) + w8 + sigma0(w0));
+
+    Round(a, b, c, d, e, f, g, h, 0x27b70a8546d22ffcull, w0 += sigma1(w14) + w9 + sigma0(w1));
+    Round(h, a, b, c, d, e, f, g, 0x2e1b21385c26c926ull, w1 += sigma1(w15) + w10 + sigma0(w2));
+    Round(g, h, a, b, c, d, e, f, 0x4d2c6dfc5ac42aedull, w2 += sigma1(w0) + w11 + sigma0(w3));
+    Round(f, g, h, a, b, c, d, e, 0x53380d139d95b3dfull, w3 += sigma1(w1) + w12 + sigma0(w4));
+    Round(e, f, g, h, a, b, c, d, 0x650a73548baf63deull, w4 += sigma1(w2) + w13 + sigma0(w5));
+    Round(d, e, f, g, h, a, b, c, 0x766a0abb3c77b2a8ull, w5 += sigma1(w3) + w14 + sigma0(w6));
+    Round(c, d, e, f, g, h, a, b, 0x81c2c92e47edaee6ull, w6 += sigma1(w4) + w15 + sigma0(w7));
+    Round(b, c, d, e, f, g, h, a, 0x92722c851482353bull, w7 += sigma1(w5) + w0 + sigma0(w8));
+    Round(a, b, c, d, e, f, g, h, 0xa2bfe8a14cf10364ull, w8 += sigma1(w6) + w1 + sigma0(w9));
+    Round(h, a, b, c, d, e, f, g, 0xa81a664bbc423001ull, w9 += sigma1(w7) + w2 + sigma0(w10));
+    Round(g, h, a, b, c, d, e, f, 0xc24b8b70d0f89791ull, w10 += sigma1(w8) + w3 + sigma0(w11));
+    Round(f, g, h, a, b, c, d, e, 0xc76c51a30654be30ull, w11 += sigma1(w9) + w4 + sigma0(w12));
+    Round(e, f, g, h, a, b, c, d, 0xd192e819d6ef5218ull, w12 += sigma1(w10) + w5 + sigma0(w13));
+    Round(d, e, f, g, h, a, b, c, 0xd69906245565a910ull, w13 += sigma1(w11) + w6 + sigma0(w14));
+    Round(c, d, e, f, g, h, a, b, 0xf40e35855771202aull, w14 += sigma1(w12) + w7 + sigma0(w15));
+    Round(b, c, d, e, f, g, h, a, 0x106aa07032bbd1b8ull, w15 += sigma1(w13) + w8 + sigma0(w0));
+
+    Round(a, b, c, d, e, f, g, h, 0x19a4c116b8d2d0c8ull, w0 += sigma1(w14) + w9 + sigma0(w1));
+    Round(h, a, b, c, d, e, f, g, 0x1e376c085141ab53ull, w1 += sigma1(w15) + w10 + sigma0(w2));
+    Round(g, h, a, b, c, d, e, f, 0x2748774cdf8eeb99ull, w2 += sigma1(w0) + w11 + sigma0(w3));
+    Round(f, g, h, a, b, c, d, e, 0x34b0bcb5e19b48a8ull, w3 += sigma1(w1) + w12 + sigma0(w4));
+    Round(e, f, g, h, a, b, c, d, 0x391c0cb3c5c95a63ull, w4 += sigma1(w2) + w13 + sigma0(w5));
+    Round(d, e, f, g, h, a, b, c, 0x4ed8aa4ae3418acbull, w5 += sigma1(w3) + w14 + sigma0(w6));
+    Round(c, d, e, f, g, h, a, b, 0x5b9cca4f7763e373ull, w6 += sigma1(w4) + w15 + sigma0(w7));
+    Round(b, c, d, e, f, g, h, a, 0x682e6ff3d6b2b8a3ull, w7 += sigma1(w5) + w0 + sigma0(w8));
+    Round(a, b, c, d, e, f, g, h, 0x748f82ee5defb2fcull, w8 += sigma1(w6) + w1 + sigma0(w9));
+    Round(h, a, b, c, d, e, f, g, 0x78a5636f43172f60ull, w9 += sigma1(w7) + w2 + sigma0(w10));
+    Round(g, h, a, b, c, d, e, f, 0x84c87814a1f0ab72ull, w10 += sigma1(w8) + w3 + sigma0(w11));
+    Round(f, g, h, a, b, c, d, e, 0x8cc702081a6439ecull, w11 += sigma1(w9) + w4 + sigma0(w12));
+    Round(e, f, g, h, a, b, c, d, 0x90befffa23631e28ull, w12 += sigma1(w10) + w5 + sigma0(w13));
+    Round(d, e, f, g, h, a, b, c, 0xa4506cebde82bde9ull, w13 += sigma1(w11) + w6 + sigma0(w14));
+    Round(c, d, e, f, g, h, a, b, 0xbef9a3f7b2c67915ull, w14 += sigma1(w12) + w7 + sigma0(w15));
+    Round(b, c, d, e, f, g, h, a, 0xc67178f2e372532bull, w15 += sigma1(w13) + w8 + sigma0(w0));
+
+    Round(a, b, c, d, e, f, g, h, 0xca273eceea26619cull, w0 += sigma1(w14) + w9 + sigma0(w1));
+    Round(h, a, b, c, d, e, f, g, 0xd186b8c721c0c207ull, w1 += sigma1(w15) + w10 + sigma0(w2));
+    Round(g, h, a, b, c, d, e, f, 0xeada7dd6cde0eb1eull, w2 += sigma1(w0) + w11 + sigma0(w3));
+    Round(f, g, h, a, b, c, d, e, 0xf57d4f7fee6ed178ull, w3 += sigma1(w1) + w12 + sigma0(w4));
+    Round(e, f, g, h, a, b, c, d, 0x06f067aa72176fbaull, w4 += sigma1(w2) + w13 + sigma0(w5));
+    Round(d, e, f, g, h, a, b, c, 0x0a637dc5a2c898a6ull, w5 += sigma1(w3) + w14 + sigma0(w6));
+    Round(c, d, e, f, g, h, a, b, 0x113f9804bef90daeull, w6 += sigma1(w4) + w15 + sigma0(w7));
+    Round(b, c, d, e, f, g, h, a, 0x1b710b35131c471bull, w7 += sigma1(w5) + w0 + sigma0(w8));
+    Round(a, b, c, d, e, f, g, h, 0x28db77f523047d84ull, w8 += sigma1(w6) + w1 + sigma0(w9));
+    Round(h, a, b, c, d, e, f, g, 0x32caab7b40c72493ull, w9 += sigma1(w7) + w2 + sigma0(w10));
+    Round(g, h, a, b, c, d, e, f, 0x3c9ebe0a15c9bebcull, w10 += sigma1(w8) + w3 + sigma0(w11));
+    Round(f, g, h, a, b, c, d, e, 0x431d67c49c100d4cull, w11 += sigma1(w9) + w4 + sigma0(w12));
+    Round(e, f, g, h, a, b, c, d, 0x4cc5d4becb3e42b6ull, w12 += sigma1(w10) + w5 + sigma0(w13));
+    Round(d, e, f, g, h, a, b, c, 0x597f299cfc657e2aull, w13 += sigma1(w11) + w6 + sigma0(w14));
+    Round(c, d, e, f, g, h, a, b, 0x5fcb6fab3ad6faecull, w14 + sigma1(w12) + w7 + sigma0(w15));
+    Round(b, c, d, e, f, g, h, a, 0x6c44198c4a475817ull, w15 + sigma1(w13) + w8 + sigma0(w0));
+
+    s[0] += a;
+    s[1] += b;
+    s[2] += c;
+    s[3] += d;
+    s[4] += e;
+    s[5] += f;
+    s[6] += g;
+    s[7] += h;
+}
+
+} // namespace sha512
+
+} // namespace
+
+
+////// SHA-512
+
+CSHA512::CSHA512()
+{
+    sha512::Initialize(s);
+}
+
+CSHA512& CSHA512::Write(const unsigned char* data, size_t len)
+{
+    const unsigned char* end = data + len;
+    size_t bufsize = bytes % 128;
+    if (bufsize && bufsize + len >= 128) {
+        // Fill the buffer, and process it.
+        memcpy(buf + bufsize, data, 128 - bufsize);
+        bytes += 128 - bufsize;
+        data += 128 - bufsize;
+        sha512::Transform(s, buf);
+        bufsize = 0;
+    }
+    while (end - data >= 128) {
+        // Process full chunks directly from the source.
+        sha512::Transform(s, data);
+        data += 128;
+        bytes += 128;
+    }
+    if (end > data) {
+        // Fill the buffer with what remains.
+        memcpy(buf + bufsize, data, end - data);
+        bytes += end - data;
+    }
+    return *this;
+}
+
+void CSHA512::Finalize(unsigned char hash[OUTPUT_SIZE])
+{
+    static const unsigned char pad[128] = {0x80};
+    unsigned char sizedesc[16] = {0x00};
+    WriteBE64(sizedesc + 8, bytes << 3);
+    Write(pad, 1 + ((239 - (bytes % 128)) % 128));
+    Write(sizedesc, 16);
+    WriteBE64(hash, s[0]);
+    WriteBE64(hash + 8, s[1]);
+    WriteBE64(hash + 16, s[2]);
+    WriteBE64(hash + 24, s[3]);
+    WriteBE64(hash + 32, s[4]);
+    WriteBE64(hash + 40, s[5]);
+    WriteBE64(hash + 48, s[6]);
+    WriteBE64(hash + 56, s[7]);
+}
+
+CSHA512& CSHA512::Reset()
+{
+    bytes = 0;
+    sha512::Initialize(s);
+    return *this;
+}

--- a/custommutator/utils/crypto/sha512.h
+++ b/custommutator/utils/crypto/sha512.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2014-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CRYPTO_SHA512_H
+#define BITCOIN_CRYPTO_SHA512_H
+
+#include <cstdlib>
+#include <stdint.h>
+
+/** A hasher class for SHA-512. */
+class CSHA512
+{
+private:
+    uint64_t s[8];
+    unsigned char buf[128];
+    uint64_t bytes{0};
+
+public:
+    static constexpr size_t OUTPUT_SIZE = 64;
+
+    CSHA512();
+    CSHA512& Write(const unsigned char* data, size_t len);
+    void Finalize(unsigned char hash[OUTPUT_SIZE]);
+    CSHA512& Reset();
+    uint64_t Size() const { return bytes; }
+};
+
+#endif // BITCOIN_CRYPTO_SHA512_H

--- a/custommutator/utils/hash.cpp
+++ b/custommutator/utils/hash.cpp
@@ -1,0 +1,92 @@
+// Copyright (c) 2013-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <hash.h>
+#include <span.h>
+#include <crypto/common.h>
+#include <crypto/hmac_sha512.h>
+
+#include <bit>
+#include <string>
+
+unsigned int MurmurHash3(unsigned int nHashSeed, std::span<const unsigned char> vDataToHash)
+{
+    // The following is MurmurHash3 (x86_32), see https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp
+    uint32_t h1 = nHashSeed;
+    const uint32_t c1 = 0xcc9e2d51;
+    const uint32_t c2 = 0x1b873593;
+
+    const int nblocks = vDataToHash.size() / 4;
+
+    //----------
+    // body
+    const uint8_t* blocks = vDataToHash.data();
+
+    for (int i = 0; i < nblocks; ++i) {
+        uint32_t k1 = ReadLE32(blocks + i*4);
+
+        k1 *= c1;
+        k1 = std::rotl(k1, 15);
+        k1 *= c2;
+
+        h1 ^= k1;
+        h1 = std::rotl(h1, 13);
+        h1 = h1 * 5 + 0xe6546b64;
+    }
+
+    //----------
+    // tail
+    const uint8_t* tail = vDataToHash.data() + nblocks * 4;
+
+    uint32_t k1 = 0;
+
+    switch (vDataToHash.size() & 3) {
+        case 3:
+            k1 ^= tail[2] << 16;
+            [[fallthrough]];
+        case 2:
+            k1 ^= tail[1] << 8;
+            [[fallthrough]];
+        case 1:
+            k1 ^= tail[0];
+            k1 *= c1;
+            k1 = std::rotl(k1, 15);
+            k1 *= c2;
+            h1 ^= k1;
+    }
+
+    //----------
+    // finalization
+    h1 ^= vDataToHash.size();
+    h1 ^= h1 >> 16;
+    h1 *= 0x85ebca6b;
+    h1 ^= h1 >> 13;
+    h1 *= 0xc2b2ae35;
+    h1 ^= h1 >> 16;
+
+    return h1;
+}
+
+void BIP32Hash(const ChainCode &chainCode, unsigned int nChild, unsigned char header, const unsigned char data[32], unsigned char output[64])
+{
+    unsigned char num[4];
+    WriteBE32(num, nChild);
+    CHMAC_SHA512(chainCode.begin(), chainCode.size()).Write(&header, 1).Write(data, 32).Write(num, 4).Finalize(output);
+}
+
+uint256 SHA256Uint256(const uint256& input)
+{
+    uint256 result;
+    CSHA256().Write(input.begin(), 32).Finalize(result.begin());
+    return result;
+}
+
+HashWriter TaggedHash(const std::string& tag)
+{
+    HashWriter writer{};
+    uint256 taghash;
+    CSHA256().Write((const unsigned char*)tag.data(), tag.size()).Finalize(taghash.begin());
+    writer << taghash << taghash;
+    return writer;
+}

--- a/custommutator/utils/hash.h
+++ b/custommutator/utils/hash.h
@@ -1,0 +1,229 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_HASH_H
+#define BITCOIN_HASH_H
+
+#include <attributes.h>
+#include <crypto/common.h>
+#include <crypto/ripemd160.h>
+#include <crypto/sha256.h>
+#include <prevector.h>
+#include <serialize.h>
+#include <span.h>
+#include <uint256.h>
+
+#include <string>
+#include <vector>
+
+typedef uint256 ChainCode;
+
+/** A hasher class for Bitcoin's 256-bit hash (double SHA-256). */
+class CHash256 {
+private:
+    CSHA256 sha;
+public:
+    static const size_t OUTPUT_SIZE = CSHA256::OUTPUT_SIZE;
+
+    void Finalize(std::span<unsigned char> output) {
+        assert(output.size() == OUTPUT_SIZE);
+        unsigned char buf[CSHA256::OUTPUT_SIZE];
+        sha.Finalize(buf);
+        sha.Reset().Write(buf, CSHA256::OUTPUT_SIZE).Finalize(output.data());
+    }
+
+    CHash256& Write(std::span<const unsigned char> input) {
+        sha.Write(input.data(), input.size());
+        return *this;
+    }
+
+    CHash256& Reset() {
+        sha.Reset();
+        return *this;
+    }
+};
+
+/** A hasher class for Bitcoin's 160-bit hash (SHA-256 + RIPEMD-160). */
+class CHash160 {
+private:
+    CSHA256 sha;
+public:
+    static const size_t OUTPUT_SIZE = CRIPEMD160::OUTPUT_SIZE;
+
+    void Finalize(std::span<unsigned char> output) {
+        assert(output.size() == OUTPUT_SIZE);
+        unsigned char buf[CSHA256::OUTPUT_SIZE];
+        sha.Finalize(buf);
+        CRIPEMD160().Write(buf, CSHA256::OUTPUT_SIZE).Finalize(output.data());
+    }
+
+    CHash160& Write(std::span<const unsigned char> input) {
+        sha.Write(input.data(), input.size());
+        return *this;
+    }
+
+    CHash160& Reset() {
+        sha.Reset();
+        return *this;
+    }
+};
+
+/** Compute the 256-bit hash of an object. */
+template<typename T>
+inline uint256 Hash(const T& in1)
+{
+    uint256 result;
+    CHash256().Write(MakeUCharSpan(in1)).Finalize(result);
+    return result;
+}
+
+/** Compute the 256-bit hash of the concatenation of two objects. */
+template<typename T1, typename T2>
+inline uint256 Hash(const T1& in1, const T2& in2) {
+    uint256 result;
+    CHash256().Write(MakeUCharSpan(in1)).Write(MakeUCharSpan(in2)).Finalize(result);
+    return result;
+}
+
+/** Compute the 160-bit hash an object. */
+template<typename T1>
+inline uint160 Hash160(const T1& in1)
+{
+    uint160 result;
+    CHash160().Write(MakeUCharSpan(in1)).Finalize(result);
+    return result;
+}
+
+/** A writer stream (for serialization) that computes a 256-bit hash. */
+class HashWriter
+{
+private:
+    CSHA256 ctx;
+
+public:
+    void write(std::span<const std::byte> src)
+    {
+        ctx.Write(UCharCast(src.data()), src.size());
+    }
+
+    /** Compute the double-SHA256 hash of all data written to this object.
+     *
+     * Invalidates this object.
+     */
+    uint256 GetHash() {
+        uint256 result;
+        ctx.Finalize(result.begin());
+        ctx.Reset().Write(result.begin(), CSHA256::OUTPUT_SIZE).Finalize(result.begin());
+        return result;
+    }
+
+    /** Compute the SHA256 hash of all data written to this object.
+     *
+     * Invalidates this object.
+     */
+    uint256 GetSHA256() {
+        uint256 result;
+        ctx.Finalize(result.begin());
+        return result;
+    }
+
+    /**
+     * Returns the first 64 bits from the resulting hash.
+     */
+    inline uint64_t GetCheapHash() {
+        uint256 result = GetHash();
+        return ReadLE64(result.begin());
+    }
+
+    template <typename T>
+    HashWriter& operator<<(const T& obj)
+    {
+        ::Serialize(*this, obj);
+        return *this;
+    }
+};
+
+/** Reads data from an underlying stream, while hashing the read data. */
+template <typename Source>
+class HashVerifier : public HashWriter
+{
+private:
+    Source& m_source;
+
+public:
+    explicit HashVerifier(Source& source LIFETIMEBOUND) : m_source{source} {}
+
+    void read(std::span<std::byte> dst)
+    {
+        m_source.read(dst);
+        this->write(dst);
+    }
+
+    void ignore(size_t num_bytes)
+    {
+        std::byte data[1024];
+        while (num_bytes > 0) {
+            size_t now = std::min<size_t>(num_bytes, 1024);
+            read({data, now});
+            num_bytes -= now;
+        }
+    }
+
+    template <typename T>
+    HashVerifier<Source>& operator>>(T&& obj)
+    {
+        ::Unserialize(*this, obj);
+        return *this;
+    }
+};
+
+/** Writes data to an underlying source stream, while hashing the written data. */
+template <typename Source>
+class HashedSourceWriter : public HashWriter
+{
+private:
+    Source& m_source;
+
+public:
+    explicit HashedSourceWriter(Source& source LIFETIMEBOUND) : HashWriter{}, m_source{source} {}
+
+    void write(std::span<const std::byte> src)
+    {
+        m_source.write(src);
+        HashWriter::write(src);
+    }
+
+    template <typename T>
+    HashedSourceWriter& operator<<(const T& obj)
+    {
+        ::Serialize(*this, obj);
+        return *this;
+    }
+};
+
+/** Single-SHA256 a 32-byte input (represented as uint256). */
+[[nodiscard]] uint256 SHA256Uint256(const uint256& input);
+
+unsigned int MurmurHash3(unsigned int nHashSeed, std::span<const unsigned char> vDataToHash);
+
+void BIP32Hash(const ChainCode &chainCode, unsigned int nChild, unsigned char header, const unsigned char data[32], unsigned char output[64]);
+
+/** Return a HashWriter primed for tagged hashes (as specified in BIP 340).
+ *
+ * The returned object will have SHA256(tag) written to it twice (= 64 bytes).
+ * A tagged hash can be computed by feeding the message into this object, and
+ * then calling HashWriter::GetSHA256().
+ */
+HashWriter TaggedHash(const std::string& tag);
+
+/** Compute the 160-bit RIPEMD-160 hash of an array. */
+inline uint160 RIPEMD160(std::span<const unsigned char> data)
+{
+    uint160 result;
+    CRIPEMD160().Write(data.data(), data.size()).Finalize(result.begin());
+    return result;
+}
+
+#endif // BITCOIN_HASH_H

--- a/custommutator/utils/prevector.h
+++ b/custommutator/utils/prevector.h
@@ -1,0 +1,542 @@
+// Copyright (c) 2015-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_PREVECTOR_H
+#define BITCOIN_PREVECTOR_H
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+/** Implements a drop-in replacement for std::vector<T> which stores up to N
+ *  elements directly (without heap allocation). The types Size and Diff are
+ *  used to store element counts, and can be any unsigned + signed type.
+ *
+ *  Storage layout is either:
+ *  - Direct allocation:
+ *    - Size _size: the number of used elements (between 0 and N)
+ *    - T direct[N]: an array of N elements of type T
+ *      (only the first _size are initialized).
+ *  - Indirect allocation:
+ *    - Size _size: the number of used elements plus N + 1
+ *    - Size capacity: the number of allocated elements
+ *    - T* indirect: a pointer to an array of capacity elements of type T
+ *      (only the first _size are initialized).
+ *
+ *  The data type T must be movable by memmove/realloc(). Once we switch to C++,
+ *  move constructors can be used instead.
+ */
+template<unsigned int N, typename T, typename Size = uint32_t, typename Diff = int32_t>
+class prevector {
+    static_assert(std::is_trivially_copyable_v<T>);
+
+public:
+    typedef Size size_type;
+    typedef Diff difference_type;
+    typedef T value_type;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+    typedef value_type* pointer;
+    typedef const value_type* const_pointer;
+
+    class iterator {
+        T* ptr{};
+    public:
+        typedef Diff difference_type;
+        typedef T* pointer;
+        typedef T& reference;
+        using element_type = T;
+        using iterator_category = std::contiguous_iterator_tag;
+        iterator() = default;
+        iterator(T* ptr_) : ptr(ptr_) {}
+        T& operator*() const { return *ptr; }
+        T* operator->() const { return ptr; }
+        T& operator[](size_type pos) const { return ptr[pos]; }
+        iterator& operator++() { ptr++; return *this; }
+        iterator& operator--() { ptr--; return *this; }
+        iterator operator++(int) { iterator copy(*this); ++(*this); return copy; }
+        iterator operator--(int) { iterator copy(*this); --(*this); return copy; }
+        difference_type friend operator-(iterator a, iterator b) { return (&(*a) - &(*b)); }
+        iterator operator+(size_type n) const { return iterator(ptr + n); }
+        iterator friend operator+(size_type n, iterator x) { return x + n; }
+        iterator& operator+=(size_type n) { ptr += n; return *this; }
+        iterator operator-(size_type n) const { return iterator(ptr - n); }
+        iterator& operator-=(size_type n) { ptr -= n; return *this; }
+        bool operator==(iterator x) const { return ptr == x.ptr; }
+        bool operator!=(iterator x) const { return ptr != x.ptr; }
+        bool operator>=(iterator x) const { return ptr >= x.ptr; }
+        bool operator<=(iterator x) const { return ptr <= x.ptr; }
+        bool operator>(iterator x) const { return ptr > x.ptr; }
+        bool operator<(iterator x) const { return ptr < x.ptr; }
+    };
+
+    class reverse_iterator {
+        T* ptr{};
+    public:
+        typedef Diff difference_type;
+        typedef T value_type;
+        typedef T* pointer;
+        typedef T& reference;
+        typedef std::bidirectional_iterator_tag iterator_category;
+        reverse_iterator() = default;
+        reverse_iterator(T* ptr_) : ptr(ptr_) {}
+        T& operator*() const { return *ptr; }
+        T* operator->() const { return ptr; }
+        reverse_iterator& operator--() { ptr++; return *this; }
+        reverse_iterator& operator++() { ptr--; return *this; }
+        reverse_iterator operator++(int) { reverse_iterator copy(*this); ++(*this); return copy; }
+        reverse_iterator operator--(int) { reverse_iterator copy(*this); --(*this); return copy; }
+        bool operator==(reverse_iterator x) const { return ptr == x.ptr; }
+        bool operator!=(reverse_iterator x) const { return ptr != x.ptr; }
+    };
+
+    class const_iterator {
+        const T* ptr{};
+    public:
+        typedef Diff difference_type;
+        typedef const T* pointer;
+        typedef const T& reference;
+        using element_type = const T;
+        using iterator_category = std::contiguous_iterator_tag;
+        const_iterator() = default;
+        const_iterator(const T* ptr_) : ptr(ptr_) {}
+        const_iterator(iterator x) : ptr(&(*x)) {}
+        const T& operator*() const { return *ptr; }
+        const T* operator->() const { return ptr; }
+        const T& operator[](size_type pos) const { return ptr[pos]; }
+        const_iterator& operator++() { ptr++; return *this; }
+        const_iterator& operator--() { ptr--; return *this; }
+        const_iterator operator++(int) { const_iterator copy(*this); ++(*this); return copy; }
+        const_iterator operator--(int) { const_iterator copy(*this); --(*this); return copy; }
+        difference_type friend operator-(const_iterator a, const_iterator b) { return (&(*a) - &(*b)); }
+        const_iterator operator+(size_type n) const { return const_iterator(ptr + n); }
+        const_iterator friend operator+(size_type n, const_iterator x) { return x + n; }
+        const_iterator& operator+=(size_type n) { ptr += n; return *this; }
+        const_iterator operator-(size_type n) const { return const_iterator(ptr - n); }
+        const_iterator& operator-=(size_type n) { ptr -= n; return *this; }
+        bool operator==(const_iterator x) const { return ptr == x.ptr; }
+        bool operator!=(const_iterator x) const { return ptr != x.ptr; }
+        bool operator>=(const_iterator x) const { return ptr >= x.ptr; }
+        bool operator<=(const_iterator x) const { return ptr <= x.ptr; }
+        bool operator>(const_iterator x) const { return ptr > x.ptr; }
+        bool operator<(const_iterator x) const { return ptr < x.ptr; }
+    };
+
+    class const_reverse_iterator {
+        const T* ptr{};
+    public:
+        typedef Diff difference_type;
+        typedef const T value_type;
+        typedef const T* pointer;
+        typedef const T& reference;
+        typedef std::bidirectional_iterator_tag iterator_category;
+        const_reverse_iterator() = default;
+        const_reverse_iterator(const T* ptr_) : ptr(ptr_) {}
+        const_reverse_iterator(reverse_iterator x) : ptr(&(*x)) {}
+        const T& operator*() const { return *ptr; }
+        const T* operator->() const { return ptr; }
+        const_reverse_iterator& operator--() { ptr++; return *this; }
+        const_reverse_iterator& operator++() { ptr--; return *this; }
+        const_reverse_iterator operator++(int) { const_reverse_iterator copy(*this); ++(*this); return copy; }
+        const_reverse_iterator operator--(int) { const_reverse_iterator copy(*this); --(*this); return copy; }
+        bool operator==(const_reverse_iterator x) const { return ptr == x.ptr; }
+        bool operator!=(const_reverse_iterator x) const { return ptr != x.ptr; }
+    };
+
+private:
+#pragma pack(push, 1)
+    union direct_or_indirect {
+        char direct[sizeof(T) * N];
+        struct {
+            char* indirect;
+            size_type capacity;
+        } indirect_contents;
+    };
+#pragma pack(pop)
+    alignas(char*) direct_or_indirect _union = {};
+    size_type _size = 0;
+
+    static_assert(alignof(char*) % alignof(size_type) == 0 && sizeof(char*) % alignof(size_type) == 0, "size_type cannot have more restrictive alignment requirement than pointer");
+    static_assert(alignof(char*) % alignof(T) == 0, "value_type T cannot have more restrictive alignment requirement than pointer");
+
+    T* direct_ptr(difference_type pos) { return reinterpret_cast<T*>(_union.direct) + pos; }
+    const T* direct_ptr(difference_type pos) const { return reinterpret_cast<const T*>(_union.direct) + pos; }
+    T* indirect_ptr(difference_type pos) { return reinterpret_cast<T*>(_union.indirect_contents.indirect) + pos; }
+    const T* indirect_ptr(difference_type pos) const { return reinterpret_cast<const T*>(_union.indirect_contents.indirect) + pos; }
+    bool is_direct() const { return _size <= N; }
+
+    void change_capacity(size_type new_capacity) {
+        if (new_capacity <= N) {
+            if (!is_direct()) {
+                T* indirect = indirect_ptr(0);
+                T* src = indirect;
+                T* dst = direct_ptr(0);
+                memcpy(dst, src, size() * sizeof(T));
+                free(indirect);
+                _size -= N + 1;
+            }
+        } else {
+            if (!is_direct()) {
+                /* FIXME: Because malloc/realloc here won't call new_handler if allocation fails, assert
+                    success. These should instead use an allocator or new/delete so that handlers
+                    are called as necessary, but performance would be slightly degraded by doing so. */
+                _union.indirect_contents.indirect = static_cast<char*>(realloc(_union.indirect_contents.indirect, ((size_t)sizeof(T)) * new_capacity));
+                assert(_union.indirect_contents.indirect);
+                _union.indirect_contents.capacity = new_capacity;
+            } else {
+                char* new_indirect = static_cast<char*>(malloc(((size_t)sizeof(T)) * new_capacity));
+                assert(new_indirect);
+                T* src = direct_ptr(0);
+                T* dst = reinterpret_cast<T*>(new_indirect);
+                memcpy(dst, src, size() * sizeof(T));
+                _union.indirect_contents.indirect = new_indirect;
+                _union.indirect_contents.capacity = new_capacity;
+                _size += N + 1;
+            }
+        }
+    }
+
+    T* item_ptr(difference_type pos) { return is_direct() ? direct_ptr(pos) : indirect_ptr(pos); }
+    const T* item_ptr(difference_type pos) const { return is_direct() ? direct_ptr(pos) : indirect_ptr(pos); }
+
+    void fill(T* dst, ptrdiff_t count, const T& value = T{}) {
+        std::fill_n(dst, count, value);
+    }
+
+    template <std::input_iterator InputIterator>
+    void fill(T* dst, InputIterator first, InputIterator last) {
+        while (first != last) {
+            new(static_cast<void*>(dst)) T(*first);
+            ++dst;
+            ++first;
+        }
+    }
+
+public:
+    void assign(size_type n, const T& val) {
+        clear();
+        if (capacity() < n) {
+            change_capacity(n);
+        }
+        _size += n;
+        fill(item_ptr(0), n, val);
+    }
+
+    template <std::input_iterator InputIterator>
+    void assign(InputIterator first, InputIterator last) {
+        size_type n = last - first;
+        clear();
+        if (capacity() < n) {
+            change_capacity(n);
+        }
+        _size += n;
+        fill(item_ptr(0), first, last);
+    }
+
+    prevector() = default;
+
+    explicit prevector(size_type n) {
+        resize(n);
+    }
+
+    explicit prevector(size_type n, const T& val) {
+        change_capacity(n);
+        _size += n;
+        fill(item_ptr(0), n, val);
+    }
+
+    template <std::input_iterator InputIterator>
+    prevector(InputIterator first, InputIterator last) {
+        size_type n = last - first;
+        change_capacity(n);
+        _size += n;
+        fill(item_ptr(0), first, last);
+    }
+
+    prevector(const prevector<N, T, Size, Diff>& other) {
+        size_type n = other.size();
+        change_capacity(n);
+        _size += n;
+        fill(item_ptr(0), other.begin(),  other.end());
+    }
+
+    prevector(prevector<N, T, Size, Diff>&& other) noexcept
+        : _union(std::move(other._union)), _size(other._size)
+    {
+        other._size = 0;
+    }
+
+    prevector& operator=(const prevector<N, T, Size, Diff>& other) {
+        if (&other == this) {
+            return *this;
+        }
+        assign(other.begin(), other.end());
+        return *this;
+    }
+
+    prevector& operator=(prevector<N, T, Size, Diff>&& other) noexcept {
+        if (!is_direct()) {
+            free(_union.indirect_contents.indirect);
+        }
+        _union = std::move(other._union);
+        _size = other._size;
+        other._size = 0;
+        return *this;
+    }
+
+    size_type size() const {
+        return is_direct() ? _size : _size - N - 1;
+    }
+
+    bool empty() const {
+        return size() == 0;
+    }
+
+    iterator begin() { return iterator(item_ptr(0)); }
+    const_iterator begin() const { return const_iterator(item_ptr(0)); }
+    iterator end() { return iterator(item_ptr(size())); }
+    const_iterator end() const { return const_iterator(item_ptr(size())); }
+
+    reverse_iterator rbegin() { return reverse_iterator(item_ptr(size() - 1)); }
+    const_reverse_iterator rbegin() const { return const_reverse_iterator(item_ptr(size() - 1)); }
+    reverse_iterator rend() { return reverse_iterator(item_ptr(-1)); }
+    const_reverse_iterator rend() const { return const_reverse_iterator(item_ptr(-1)); }
+
+    size_t capacity() const {
+        if (is_direct()) {
+            return N;
+        } else {
+            return _union.indirect_contents.capacity;
+        }
+    }
+
+    T& operator[](size_type pos) {
+        return *item_ptr(pos);
+    }
+
+    const T& operator[](size_type pos) const {
+        return *item_ptr(pos);
+    }
+
+    void resize(size_type new_size) {
+        size_type cur_size = size();
+        if (cur_size == new_size) {
+            return;
+        }
+        if (cur_size > new_size) {
+            erase(item_ptr(new_size), end());
+            return;
+        }
+        if (new_size > capacity()) {
+            change_capacity(new_size);
+        }
+        ptrdiff_t increase = new_size - cur_size;
+        fill(item_ptr(cur_size), increase);
+        _size += increase;
+    }
+
+    void reserve(size_type new_capacity) {
+        if (new_capacity > capacity()) {
+            change_capacity(new_capacity);
+        }
+    }
+
+    void shrink_to_fit() {
+        change_capacity(size());
+    }
+
+    void clear() {
+        resize(0);
+    }
+
+    iterator insert(iterator pos, const T& value) {
+        size_type p = pos - begin();
+        size_type new_size = size() + 1;
+        if (capacity() < new_size) {
+            change_capacity(new_size + (new_size >> 1));
+        }
+        T* ptr = item_ptr(p);
+        T* dst = ptr + 1;
+        memmove(dst, ptr, (size() - p) * sizeof(T));
+        _size++;
+        new(static_cast<void*>(ptr)) T(value);
+        return iterator(ptr);
+    }
+
+    void insert(iterator pos, size_type count, const T& value) {
+        size_type p = pos - begin();
+        size_type new_size = size() + count;
+        if (capacity() < new_size) {
+            change_capacity(new_size + (new_size >> 1));
+        }
+        T* ptr = item_ptr(p);
+        T* dst = ptr + count;
+        memmove(dst, ptr, (size() - p) * sizeof(T));
+        _size += count;
+        fill(item_ptr(p), count, value);
+    }
+
+    template <std::input_iterator InputIterator>
+    void insert(iterator pos, InputIterator first, InputIterator last) {
+        size_type p = pos - begin();
+        difference_type count = last - first;
+        size_type new_size = size() + count;
+        if (capacity() < new_size) {
+            change_capacity(new_size + (new_size >> 1));
+        }
+        T* ptr = item_ptr(p);
+        T* dst = ptr + count;
+        memmove(dst, ptr, (size() - p) * sizeof(T));
+        _size += count;
+        fill(ptr, first, last);
+    }
+
+    inline void resize_uninitialized(size_type new_size) {
+        // resize_uninitialized changes the size of the prevector but does not initialize it.
+        // If size < new_size, the added elements must be initialized explicitly.
+        if (capacity() < new_size) {
+            change_capacity(new_size);
+            _size += new_size - size();
+            return;
+        }
+        if (new_size < size()) {
+            erase(item_ptr(new_size), end());
+        } else {
+            _size += new_size - size();
+        }
+    }
+
+    iterator erase(iterator pos) {
+        return erase(pos, pos + 1);
+    }
+
+    iterator erase(iterator first, iterator last) {
+        // Erase is not allowed to the change the object's capacity. That means
+        // that when starting with an indirectly allocated prevector with
+        // size and capacity > N, the result may be a still indirectly allocated
+        // prevector with size <= N and capacity > N. A shrink_to_fit() call is
+        // necessary to switch to the (more efficient) directly allocated
+        // representation (with capacity N and size <= N).
+        iterator p = first;
+        char* endp = (char*)&(*end());
+        _size -= last - p;
+        memmove(&(*first), &(*last), endp - ((char*)(&(*last))));
+        return first;
+    }
+
+    template<typename... Args>
+    void emplace_back(Args&&... args) {
+        size_type new_size = size() + 1;
+        if (capacity() < new_size) {
+            change_capacity(new_size + (new_size >> 1));
+        }
+        new(item_ptr(size())) T(std::forward<Args>(args)...);
+        _size++;
+    }
+
+    void push_back(const T& value) {
+        emplace_back(value);
+    }
+
+    void pop_back() {
+        erase(end() - 1, end());
+    }
+
+    T& front() {
+        return *item_ptr(0);
+    }
+
+    const T& front() const {
+        return *item_ptr(0);
+    }
+
+    T& back() {
+        return *item_ptr(size() - 1);
+    }
+
+    const T& back() const {
+        return *item_ptr(size() - 1);
+    }
+
+    void swap(prevector<N, T, Size, Diff>& other) noexcept
+    {
+        std::swap(_union, other._union);
+        std::swap(_size, other._size);
+    }
+
+    ~prevector() {
+        if (!is_direct()) {
+            free(_union.indirect_contents.indirect);
+            _union.indirect_contents.indirect = nullptr;
+        }
+    }
+
+    bool operator==(const prevector<N, T, Size, Diff>& other) const {
+        if (other.size() != size()) {
+            return false;
+        }
+        const_iterator b1 = begin();
+        const_iterator b2 = other.begin();
+        const_iterator e1 = end();
+        while (b1 != e1) {
+            if ((*b1) != (*b2)) {
+                return false;
+            }
+            ++b1;
+            ++b2;
+        }
+        return true;
+    }
+
+    bool operator!=(const prevector<N, T, Size, Diff>& other) const {
+        return !(*this == other);
+    }
+
+    bool operator<(const prevector<N, T, Size, Diff>& other) const {
+        if (size() < other.size()) {
+            return true;
+        }
+        if (size() > other.size()) {
+            return false;
+        }
+        const_iterator b1 = begin();
+        const_iterator b2 = other.begin();
+        const_iterator e1 = end();
+        while (b1 != e1) {
+            if ((*b1) < (*b2)) {
+                return true;
+            }
+            if ((*b2) < (*b1)) {
+                return false;
+            }
+            ++b1;
+            ++b2;
+        }
+        return false;
+    }
+
+    size_t allocated_memory() const {
+        if (is_direct()) {
+            return 0;
+        } else {
+            return ((size_t)(sizeof(T))) * _union.indirect_contents.capacity;
+        }
+    }
+
+    value_type* data() {
+        return item_ptr(0);
+    }
+
+    const value_type* data() const {
+        return item_ptr(0);
+    }
+};
+
+#endif // BITCOIN_PREVECTOR_H

--- a/custommutator/utils/serialize.h
+++ b/custommutator/utils/serialize.h
@@ -1,0 +1,1233 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SERIALIZE_H
+#define BITCOIN_SERIALIZE_H
+
+#include <attributes.h>
+#include <compat/assumptions.h> // IWYU pragma: keep
+#include <compat/endian.h>
+#include <prevector.h>
+#include <span.h>
+#include <span>
+
+#include <algorithm>
+#include <concepts>
+#include <cstdint>
+#include <cstring>
+#include <ios>
+#include <limits>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+/**
+ * The maximum size of a serialized object in bytes or number of elements
+ * (for eg vectors) when the size is encoded as CompactSize.
+ */
+static constexpr uint64_t MAX_SIZE = 0x02000000;
+
+/** Maximum amount of memory (in bytes) to allocate at once when deserializing vectors. */
+static const unsigned int MAX_VECTOR_ALLOCATE = 5000000;
+
+/**
+ * Dummy data type to identify deserializing constructors.
+ *
+ * By convention, a constructor of a type T with signature
+ *
+ *   template <typename Stream> T::T(deserialize_type, Stream& s)
+ *
+ * is a deserializing constructor, which builds the type by
+ * deserializing it from s. If T contains const fields, this
+ * is likely the only way to do so.
+ */
+struct deserialize_type {};
+constexpr deserialize_type deserialize {};
+
+/*
+ * Lowest-level serialization and conversion.
+ */
+template<typename Stream> inline void ser_writedata8(Stream &s, uint8_t obj)
+{
+    s.write(std::as_bytes(std::span{&obj, 1}));
+}
+template<typename Stream> inline void ser_writedata16(Stream &s, uint16_t obj)
+{
+    obj = htole16_internal(obj);
+    s.write(std::as_bytes(std::span{&obj, 1}));
+}
+template<typename Stream> inline void ser_writedata16be(Stream &s, uint16_t obj)
+{
+    obj = htobe16_internal(obj);
+    s.write(std::as_bytes(std::span{&obj, 1}));
+}
+template<typename Stream> inline void ser_writedata32(Stream &s, uint32_t obj)
+{
+    obj = htole32_internal(obj);
+    s.write(std::as_bytes(std::span{&obj, 1}));
+}
+template<typename Stream> inline void ser_writedata32be(Stream &s, uint32_t obj)
+{
+    obj = htobe32_internal(obj);
+    s.write(std::as_bytes(std::span{&obj, 1}));
+}
+template<typename Stream> inline void ser_writedata64(Stream &s, uint64_t obj)
+{
+    obj = htole64_internal(obj);
+    s.write(std::as_bytes(std::span{&obj, 1}));
+}
+template<typename Stream> inline uint8_t ser_readdata8(Stream &s)
+{
+    uint8_t obj;
+    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    return obj;
+}
+template<typename Stream> inline uint16_t ser_readdata16(Stream &s)
+{
+    uint16_t obj;
+    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    return le16toh_internal(obj);
+}
+template<typename Stream> inline uint16_t ser_readdata16be(Stream &s)
+{
+    uint16_t obj;
+    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    return be16toh_internal(obj);
+}
+template<typename Stream> inline uint32_t ser_readdata32(Stream &s)
+{
+    uint32_t obj;
+    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    return le32toh_internal(obj);
+}
+template<typename Stream> inline uint32_t ser_readdata32be(Stream &s)
+{
+    uint32_t obj;
+    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    return be32toh_internal(obj);
+}
+template<typename Stream> inline uint64_t ser_readdata64(Stream &s)
+{
+    uint64_t obj;
+    s.read(std::as_writable_bytes(std::span{&obj, 1}));
+    return le64toh_internal(obj);
+}
+
+
+class SizeComputer;
+
+/**
+ * Convert any argument to a reference to X, maintaining constness.
+ *
+ * This can be used in serialization code to invoke a base class's
+ * serialization routines.
+ *
+ * Example use:
+ *   class Base { ... };
+ *   class Child : public Base {
+ *     int m_data;
+ *   public:
+ *     SERIALIZE_METHODS(Child, obj) {
+ *       READWRITE(AsBase<Base>(obj), obj.m_data);
+ *     }
+ *   };
+ *
+ * static_cast cannot easily be used here, as the type of Obj will be const Child&
+ * during serialization and Child& during deserialization. AsBase will convert to
+ * const Base& and Base& appropriately.
+ */
+template <class Out, class In>
+Out& AsBase(In& x)
+{
+    static_assert(std::is_base_of_v<Out, In>);
+    return x;
+}
+template <class Out, class In>
+const Out& AsBase(const In& x)
+{
+    static_assert(std::is_base_of_v<Out, In>);
+    return x;
+}
+
+#define READWRITE(...) (ser_action.SerReadWriteMany(s, __VA_ARGS__))
+#define SER_READ(obj, code) ser_action.SerRead(s, obj, [&](Stream& s, std::remove_const_t<Type>& obj) { code; })
+#define SER_WRITE(obj, code) ser_action.SerWrite(s, obj, [&](Stream& s, const Type& obj) { code; })
+
+/**
+ * Implement the Ser and Unser methods needed for implementing a formatter (see Using below).
+ *
+ * Both Ser and Unser are delegated to a single static method SerializationOps, which is polymorphic
+ * in the serialized/deserialized type (allowing it to be const when serializing, and non-const when
+ * deserializing).
+ *
+ * Example use:
+ *   struct FooFormatter {
+ *     FORMATTER_METHODS(Class, obj) { READWRITE(obj.val1, VARINT(obj.val2)); }
+ *   }
+ *   would define a class FooFormatter that defines a serialization of Class objects consisting
+ *   of serializing its val1 member using the default serialization, and its val2 member using
+ *   VARINT serialization. That FooFormatter can then be used in statements like
+ *   READWRITE(Using<FooFormatter>(obj.bla)).
+ */
+#define FORMATTER_METHODS(cls, obj) \
+    template<typename Stream> \
+    static void Ser(Stream& s, const cls& obj) { SerializationOps(obj, s, ActionSerialize{}); } \
+    template<typename Stream> \
+    static void Unser(Stream& s, cls& obj) { SerializationOps(obj, s, ActionUnserialize{}); } \
+    template<typename Stream, typename Type, typename Operation> \
+    static void SerializationOps(Type& obj, Stream& s, Operation ser_action)
+
+/**
+ * Formatter methods can retrieve parameters attached to a stream using the
+ * SER_PARAMS(type) macro as long as the stream is created directly or
+ * indirectly with a parameter of that type. This permits making serialization
+ * depend on run-time context in a type-safe way.
+ *
+ * Example use:
+ *   struct BarParameter { bool fancy; ... };
+ *   struct Bar { ... };
+ *   struct FooFormatter {
+ *     FORMATTER_METHODS(Bar, obj) {
+ *       auto& param = SER_PARAMS(BarParameter);
+ *       if (param.fancy) {
+ *         READWRITE(VARINT(obj.value));
+ *       } else {
+ *         READWRITE(obj.value);
+ *       }
+ *     }
+ *   };
+ * which would then be invoked as
+ *   READWRITE(BarParameter{...}(Using<FooFormatter>(obj.foo)))
+ *
+ * parameter(obj) can be invoked anywhere in the call stack; it is
+ * passed down recursively into all serialization code, until another
+ * serialization parameter overrides it.
+ *
+ * Parameters will be implicitly converted where appropriate. This means that
+ * "parent" serialization code can use a parameter that derives from, or is
+ * convertible to, a "child" formatter's parameter type.
+ *
+ * Compilation will fail in any context where serialization is invoked but
+ * no parameter of a type convertible to BarParameter is provided.
+ */
+#define SER_PARAMS(type) (s.template GetParams<type>())
+
+#define BASE_SERIALIZE_METHODS(cls)                                                                 \
+    template <typename Stream>                                                                      \
+    void Serialize(Stream& s) const                                                                 \
+    {                                                                                               \
+        static_assert(std::is_same_v<const cls&, decltype(*this)>, "Serialize type mismatch");      \
+        Ser(s, *this);                                                                              \
+    }                                                                                               \
+    template <typename Stream>                                                                      \
+    void Unserialize(Stream& s)                                                                     \
+    {                                                                                               \
+        static_assert(std::is_same_v<cls&, decltype(*this)>, "Unserialize type mismatch");          \
+        Unser(s, *this);                                                                            \
+    }
+
+/**
+ * Implement the Serialize and Unserialize methods by delegating to a single templated
+ * static method that takes the to-be-(de)serialized object as a parameter. This approach
+ * has the advantage that the constness of the object becomes a template parameter, and
+ * thus allows a single implementation that sees the object as const for serializing
+ * and non-const for deserializing, without casts.
+ */
+#define SERIALIZE_METHODS(cls, obj) \
+    BASE_SERIALIZE_METHODS(cls)     \
+    FORMATTER_METHODS(cls, obj)
+
+// Templates for serializing to anything that looks like a stream,
+// i.e. anything that supports .read(std::span<std::byte>) and .write(std::span<const std::byte>)
+//
+// clang-format off
+
+// Typically int8_t and char are distinct types, but some systems may define int8_t
+// in terms of char. Forbid serialization of char in the typical case, but allow it if
+// it's the only way to describe an int8_t.
+template<class T>
+concept CharNotInt8 = std::same_as<T, char> && !std::same_as<T, int8_t>;
+
+template <typename Stream, CharNotInt8 V> void Serialize(Stream&, V) = delete; // char serialization forbidden. Use uint8_t or int8_t
+template <typename Stream> void Serialize(Stream& s, std::byte a) { ser_writedata8(s, uint8_t(a)); }
+template<typename Stream> inline void Serialize(Stream& s, int8_t a  ) { ser_writedata8(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, uint8_t a ) { ser_writedata8(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, int16_t a ) { ser_writedata16(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, uint16_t a) { ser_writedata16(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, int32_t a ) { ser_writedata32(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, uint32_t a) { ser_writedata32(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, int64_t a ) { ser_writedata64(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, uint64_t a) { ser_writedata64(s, a); }
+template <typename Stream, BasicByte B, int N> void Serialize(Stream& s, const B (&a)[N]) { s.write(MakeByteSpan(a)); }
+template <typename Stream, BasicByte B, std::size_t N> void Serialize(Stream& s, const std::array<B, N>& a) { s.write(MakeByteSpan(a)); }
+template <typename Stream, BasicByte B, std::size_t N> void Serialize(Stream& s, std::span<B, N> span) { s.write(std::as_bytes(span)); }
+template <typename Stream, BasicByte B> void Serialize(Stream& s, std::span<B> span) { s.write(std::as_bytes(span)); }
+
+template <typename Stream, CharNotInt8 V> void Unserialize(Stream&, V) = delete; // char serialization forbidden. Use uint8_t or int8_t
+template <typename Stream> void Unserialize(Stream& s, std::byte& a) { a = std::byte{ser_readdata8(s)}; }
+template<typename Stream> inline void Unserialize(Stream& s, int8_t& a  ) { a = ser_readdata8(s); }
+template<typename Stream> inline void Unserialize(Stream& s, uint8_t& a ) { a = ser_readdata8(s); }
+template<typename Stream> inline void Unserialize(Stream& s, int16_t& a ) { a = ser_readdata16(s); }
+template<typename Stream> inline void Unserialize(Stream& s, uint16_t& a) { a = ser_readdata16(s); }
+template<typename Stream> inline void Unserialize(Stream& s, int32_t& a ) { a = ser_readdata32(s); }
+template<typename Stream> inline void Unserialize(Stream& s, uint32_t& a) { a = ser_readdata32(s); }
+template<typename Stream> inline void Unserialize(Stream& s, int64_t& a ) { a = ser_readdata64(s); }
+template<typename Stream> inline void Unserialize(Stream& s, uint64_t& a) { a = ser_readdata64(s); }
+template <typename Stream, BasicByte B, int N> void Unserialize(Stream& s, B (&a)[N]) { s.read(MakeWritableByteSpan(a)); }
+template <typename Stream, BasicByte B, std::size_t N> void Unserialize(Stream& s, std::array<B, N>& a) { s.read(MakeWritableByteSpan(a)); }
+template <typename Stream, BasicByte B, std::size_t N> void Unserialize(Stream& s, std::span<B, N> span) { s.read(std::as_writable_bytes(span)); }
+template <typename Stream, BasicByte B> void Unserialize(Stream& s, std::span<B> span) { s.read(std::as_writable_bytes(span)); }
+
+template <typename Stream> inline void Serialize(Stream& s, bool a) { uint8_t f = a; ser_writedata8(s, f); }
+template <typename Stream> inline void Unserialize(Stream& s, bool& a) { uint8_t f = ser_readdata8(s); a = f; }
+// clang-format on
+
+
+/**
+ * Compact Size
+ * size <  253        -- 1 byte
+ * size <= USHRT_MAX  -- 3 bytes  (253 + 2 bytes)
+ * size <= UINT_MAX   -- 5 bytes  (254 + 4 bytes)
+ * size >  UINT_MAX   -- 9 bytes  (255 + 8 bytes)
+ */
+constexpr inline unsigned int GetSizeOfCompactSize(uint64_t nSize)
+{
+    if (nSize < 253)             return sizeof(unsigned char);
+    else if (nSize <= std::numeric_limits<uint16_t>::max()) return sizeof(unsigned char) + sizeof(uint16_t);
+    else if (nSize <= std::numeric_limits<unsigned int>::max())  return sizeof(unsigned char) + sizeof(unsigned int);
+    else                         return sizeof(unsigned char) + sizeof(uint64_t);
+}
+
+inline void WriteCompactSize(SizeComputer& os, uint64_t nSize);
+
+template<typename Stream>
+void WriteCompactSize(Stream& os, uint64_t nSize)
+{
+    if (nSize < 253)
+    {
+        ser_writedata8(os, nSize);
+    }
+    else if (nSize <= std::numeric_limits<uint16_t>::max())
+    {
+        ser_writedata8(os, 253);
+        ser_writedata16(os, nSize);
+    }
+    else if (nSize <= std::numeric_limits<unsigned int>::max())
+    {
+        ser_writedata8(os, 254);
+        ser_writedata32(os, nSize);
+    }
+    else
+    {
+        ser_writedata8(os, 255);
+        ser_writedata64(os, nSize);
+    }
+    return;
+}
+
+/**
+ * Decode a CompactSize-encoded variable-length integer.
+ *
+ * As these are primarily used to encode the size of vector-like serializations, by default a range
+ * check is performed. When used as a generic number encoding, range_check should be set to false.
+ */
+template<typename Stream>
+uint64_t ReadCompactSize(Stream& is, bool range_check = true)
+{
+    uint8_t chSize = ser_readdata8(is);
+    uint64_t nSizeRet = 0;
+    if (chSize < 253)
+    {
+        nSizeRet = chSize;
+    }
+    else if (chSize == 253)
+    {
+        nSizeRet = ser_readdata16(is);
+        if (nSizeRet < 253)
+            throw std::ios_base::failure("non-canonical ReadCompactSize()");
+    }
+    else if (chSize == 254)
+    {
+        nSizeRet = ser_readdata32(is);
+        if (nSizeRet < 0x10000u)
+            throw std::ios_base::failure("non-canonical ReadCompactSize()");
+    }
+    else
+    {
+        nSizeRet = ser_readdata64(is);
+        if (nSizeRet < 0x100000000ULL)
+            throw std::ios_base::failure("non-canonical ReadCompactSize()");
+    }
+    if (range_check && nSizeRet > MAX_SIZE) {
+        throw std::ios_base::failure("ReadCompactSize(): size too large");
+    }
+    return nSizeRet;
+}
+
+/**
+ * Variable-length integers: bytes are a MSB base-128 encoding of the number.
+ * The high bit in each byte signifies whether another digit follows. To make
+ * sure the encoding is one-to-one, one is subtracted from all but the last digit.
+ * Thus, the byte sequence a[] with length len, where all but the last byte
+ * has bit 128 set, encodes the number:
+ *
+ *  (a[len-1] & 0x7F) + sum(i=1..len-1, 128^i*((a[len-i-1] & 0x7F)+1))
+ *
+ * Properties:
+ * * Very small (0-127: 1 byte, 128-16511: 2 bytes, 16512-2113663: 3 bytes)
+ * * Every integer has exactly one encoding
+ * * Encoding does not depend on size of original integer type
+ * * No redundancy: every (infinite) byte sequence corresponds to a list
+ *   of encoded integers.
+ *
+ * 0:         [0x00]  256:        [0x81 0x00]
+ * 1:         [0x01]  16383:      [0xFE 0x7F]
+ * 127:       [0x7F]  16384:      [0xFF 0x00]
+ * 128:  [0x80 0x00]  16511:      [0xFF 0x7F]
+ * 255:  [0x80 0x7F]  65535: [0x82 0xFE 0x7F]
+ * 2^32:           [0x8E 0xFE 0xFE 0xFF 0x00]
+ */
+
+/**
+ * Mode for encoding VarInts.
+ *
+ * Currently there is no support for signed encodings. The default mode will not
+ * compile with signed values, and the legacy "nonnegative signed" mode will
+ * accept signed values, but improperly encode and decode them if they are
+ * negative. In the future, the DEFAULT mode could be extended to support
+ * negative numbers in a backwards compatible way, and additional modes could be
+ * added to support different varint formats (e.g. zigzag encoding).
+ */
+enum class VarIntMode { DEFAULT, NONNEGATIVE_SIGNED };
+
+template <VarIntMode Mode, typename I>
+struct CheckVarIntMode {
+    constexpr CheckVarIntMode()
+    {
+        static_assert(Mode != VarIntMode::DEFAULT || std::is_unsigned_v<I>, "Unsigned type required with mode DEFAULT.");
+        static_assert(Mode != VarIntMode::NONNEGATIVE_SIGNED || std::is_signed_v<I>, "Signed type required with mode NONNEGATIVE_SIGNED.");
+    }
+};
+
+template<VarIntMode Mode, typename I>
+inline unsigned int GetSizeOfVarInt(I n)
+{
+    CheckVarIntMode<Mode, I>();
+    int nRet = 0;
+    while(true) {
+        nRet++;
+        if (n <= 0x7F)
+            break;
+        n = (n >> 7) - 1;
+    }
+    return nRet;
+}
+
+template<typename I>
+inline void WriteVarInt(SizeComputer& os, I n);
+
+template<typename Stream, VarIntMode Mode, typename I>
+void WriteVarInt(Stream& os, I n)
+{
+    CheckVarIntMode<Mode, I>();
+    unsigned char tmp[(sizeof(n)*8+6)/7];
+    int len=0;
+    while(true) {
+        tmp[len] = (n & 0x7F) | (len ? 0x80 : 0x00);
+        if (n <= 0x7F)
+            break;
+        n = (n >> 7) - 1;
+        len++;
+    }
+    do {
+        ser_writedata8(os, tmp[len]);
+    } while(len--);
+}
+
+template<typename Stream, VarIntMode Mode, typename I>
+I ReadVarInt(Stream& is)
+{
+    CheckVarIntMode<Mode, I>();
+    I n = 0;
+    while(true) {
+        unsigned char chData = ser_readdata8(is);
+        if (n > (std::numeric_limits<I>::max() >> 7)) {
+           throw std::ios_base::failure("ReadVarInt(): size too large");
+        }
+        n = (n << 7) | (chData & 0x7F);
+        if (chData & 0x80) {
+            if (n == std::numeric_limits<I>::max()) {
+                throw std::ios_base::failure("ReadVarInt(): size too large");
+            }
+            n++;
+        } else {
+            return n;
+        }
+    }
+}
+
+/** Simple wrapper class to serialize objects using a formatter; used by Using(). */
+template<typename Formatter, typename T>
+class Wrapper
+{
+    static_assert(std::is_lvalue_reference_v<T>, "Wrapper needs an lvalue reference type T");
+protected:
+    T m_object;
+public:
+    explicit Wrapper(T obj) : m_object(obj) {}
+    template<typename Stream> void Serialize(Stream &s) const { Formatter().Ser(s, m_object); }
+    template<typename Stream> void Unserialize(Stream &s) { Formatter().Unser(s, m_object); }
+};
+
+/** Cause serialization/deserialization of an object to be done using a specified formatter class.
+ *
+ * To use this, you need a class Formatter that has public functions Ser(stream, const object&) for
+ * serialization, and Unser(stream, object&) for deserialization. Serialization routines (inside
+ * READWRITE, or directly with << and >> operators), can then use Using<Formatter>(object).
+ *
+ * This works by constructing a Wrapper<Formatter, T>-wrapped version of object, where T is
+ * const during serialization, and non-const during deserialization, which maintains const
+ * correctness.
+ */
+template<typename Formatter, typename T>
+static inline Wrapper<Formatter, T&> Using(T&& t) { return Wrapper<Formatter, T&>(t); }
+
+#define VARINT_MODE(obj, mode) Using<VarIntFormatter<mode>>(obj)
+#define VARINT(obj) Using<VarIntFormatter<VarIntMode::DEFAULT>>(obj)
+#define COMPACTSIZE(obj) Using<CompactSizeFormatter<true>>(obj)
+#define LIMITED_STRING(obj,n) Using<LimitedStringFormatter<n>>(obj)
+
+/** Serialization wrapper class for integers in VarInt format. */
+template<VarIntMode Mode>
+struct VarIntFormatter
+{
+    template<typename Stream, typename I> void Ser(Stream &s, I v)
+    {
+        WriteVarInt<Stream,Mode, std::remove_cv_t<I>>(s, v);
+    }
+
+    template<typename Stream, typename I> void Unser(Stream& s, I& v)
+    {
+        v = ReadVarInt<Stream,Mode, std::remove_cv_t<I>>(s);
+    }
+};
+
+/** Serialization wrapper class for custom integers and enums.
+ *
+ * It permits specifying the serialized size (1 to 8 bytes) and endianness.
+ *
+ * Use the big endian mode for values that are stored in memory in native
+ * byte order, but serialized in big endian notation. This is only intended
+ * to implement serializers that are compatible with existing formats, and
+ * its use is not recommended for new data structures.
+ */
+template<int Bytes, bool BigEndian = false>
+struct CustomUintFormatter
+{
+    static_assert(Bytes > 0 && Bytes <= 8, "CustomUintFormatter Bytes out of range");
+    static constexpr uint64_t MAX = 0xffffffffffffffff >> (8 * (8 - Bytes));
+
+    template <typename Stream, typename I> void Ser(Stream& s, I v)
+    {
+        if (v < 0 || v > MAX) throw std::ios_base::failure("CustomUintFormatter value out of range");
+        if (BigEndian) {
+            uint64_t raw = htobe64_internal(v);
+            s.write(std::as_bytes(std::span{&raw, 1}).last(Bytes));
+        } else {
+            uint64_t raw = htole64_internal(v);
+            s.write(std::as_bytes(std::span{&raw, 1}).first(Bytes));
+        }
+    }
+
+    template <typename Stream, typename I> void Unser(Stream& s, I& v)
+    {
+        using U = typename std::conditional_t<std::is_enum_v<I>, std::underlying_type<I>, std::common_type<I>>::type;
+        static_assert(std::numeric_limits<U>::max() >= MAX && std::numeric_limits<U>::min() <= 0, "Assigned type too small");
+        uint64_t raw = 0;
+        if (BigEndian) {
+            s.read(std::as_writable_bytes(std::span{&raw, 1}).last(Bytes));
+            v = static_cast<I>(be64toh_internal(raw));
+        } else {
+            s.read(std::as_writable_bytes(std::span{&raw, 1}).first(Bytes));
+            v = static_cast<I>(le64toh_internal(raw));
+        }
+    }
+};
+
+template<int Bytes> using BigEndianFormatter = CustomUintFormatter<Bytes, true>;
+
+/** Formatter for integers in CompactSize format. */
+template<bool RangeCheck>
+struct CompactSizeFormatter
+{
+    template<typename Stream, typename I>
+    void Unser(Stream& s, I& v)
+    {
+        uint64_t n = ReadCompactSize<Stream>(s, RangeCheck);
+        if (n < std::numeric_limits<I>::min() || n > std::numeric_limits<I>::max()) {
+            throw std::ios_base::failure("CompactSize exceeds limit of type");
+        }
+        v = n;
+    }
+
+    template<typename Stream, typename I>
+    void Ser(Stream& s, I v)
+    {
+        static_assert(std::is_unsigned_v<I>, "CompactSize only supported for unsigned integers");
+        static_assert(std::numeric_limits<I>::max() <= std::numeric_limits<uint64_t>::max(), "CompactSize only supports 64-bit integers and below");
+
+        WriteCompactSize<Stream>(s, v);
+    }
+};
+
+template <typename U, bool LOSSY = false>
+struct ChronoFormatter {
+    template <typename Stream, typename Tp>
+    void Unser(Stream& s, Tp& tp)
+    {
+        U u;
+        s >> u;
+        // Lossy deserialization does not make sense, so force Wnarrowing
+        tp = Tp{typename Tp::duration{typename Tp::duration::rep{u}}};
+    }
+    template <typename Stream, typename Tp>
+    void Ser(Stream& s, Tp tp)
+    {
+        if constexpr (LOSSY) {
+            s << U(tp.time_since_epoch().count());
+        } else {
+            s << U{tp.time_since_epoch().count()};
+        }
+    }
+};
+template <typename U>
+using LossyChronoFormatter = ChronoFormatter<U, true>;
+
+class CompactSizeWriter
+{
+protected:
+    uint64_t n;
+public:
+    explicit CompactSizeWriter(uint64_t n_in) : n(n_in) { }
+
+    template<typename Stream>
+    void Serialize(Stream &s) const {
+        WriteCompactSize<Stream>(s, n);
+    }
+};
+
+template<size_t Limit>
+struct LimitedStringFormatter
+{
+    template<typename Stream>
+    void Unser(Stream& s, std::string& v)
+    {
+        size_t size = ReadCompactSize(s);
+        if (size > Limit) {
+            throw std::ios_base::failure("String length limit exceeded");
+        }
+        v.resize(size);
+        if (size != 0) s.read(MakeWritableByteSpan(v));
+    }
+
+    template<typename Stream>
+    void Ser(Stream& s, const std::string& v)
+    {
+        s << v;
+    }
+};
+
+/** Formatter to serialize/deserialize vector elements using another formatter
+ *
+ * Example:
+ *   struct X {
+ *     std::vector<uint64_t> v;
+ *     SERIALIZE_METHODS(X, obj) { READWRITE(Using<VectorFormatter<VarInt>>(obj.v)); }
+ *   };
+ * will define a struct that contains a vector of uint64_t, which is serialized
+ * as a vector of VarInt-encoded integers.
+ *
+ * V is not required to be an std::vector type. It works for any class that
+ * exposes a value_type, size, reserve, emplace_back, back, and const iterators.
+ */
+template<class Formatter>
+struct VectorFormatter
+{
+    template<typename Stream, typename V>
+    void Ser(Stream& s, const V& v)
+    {
+        Formatter formatter;
+        WriteCompactSize(s, v.size());
+        for (const typename V::value_type& elem : v) {
+            formatter.Ser(s, elem);
+        }
+    }
+
+    template<typename Stream, typename V>
+    void Unser(Stream& s, V& v)
+    {
+        Formatter formatter;
+        v.clear();
+        size_t size = ReadCompactSize(s);
+        size_t allocated = 0;
+        while (allocated < size) {
+            // For DoS prevention, do not blindly allocate as much as the stream claims to contain.
+            // Instead, allocate in 5MiB batches, so that an attacker actually needs to provide
+            // X MiB of data to make us allocate X+5 Mib.
+            static_assert(sizeof(typename V::value_type) <= MAX_VECTOR_ALLOCATE, "Vector element size too large");
+            allocated = std::min(size, allocated + MAX_VECTOR_ALLOCATE / sizeof(typename V::value_type));
+            v.reserve(allocated);
+            while (v.size() < allocated) {
+                v.emplace_back();
+                formatter.Unser(s, v.back());
+            }
+        }
+    };
+};
+
+/**
+ * Forward declarations
+ */
+
+/**
+ *  string
+ */
+template<typename Stream, typename C> void Serialize(Stream& os, const std::basic_string<C>& str);
+template<typename Stream, typename C> void Unserialize(Stream& is, std::basic_string<C>& str);
+
+/**
+ * prevector
+ */
+template<typename Stream, unsigned int N, typename T> inline void Serialize(Stream& os, const prevector<N, T>& v);
+template<typename Stream, unsigned int N, typename T> inline void Unserialize(Stream& is, prevector<N, T>& v);
+
+/**
+ * vector
+ */
+template<typename Stream, typename T, typename A> inline void Serialize(Stream& os, const std::vector<T, A>& v);
+template<typename Stream, typename T, typename A> inline void Unserialize(Stream& is, std::vector<T, A>& v);
+
+/**
+ * pair
+ */
+template<typename Stream, typename K, typename T> void Serialize(Stream& os, const std::pair<K, T>& item);
+template<typename Stream, typename K, typename T> void Unserialize(Stream& is, std::pair<K, T>& item);
+
+/**
+ * map
+ */
+template<typename Stream, typename K, typename T, typename Pred, typename A> void Serialize(Stream& os, const std::map<K, T, Pred, A>& m);
+template<typename Stream, typename K, typename T, typename Pred, typename A> void Unserialize(Stream& is, std::map<K, T, Pred, A>& m);
+
+/**
+ * set
+ */
+template<typename Stream, typename K, typename Pred, typename A> void Serialize(Stream& os, const std::set<K, Pred, A>& m);
+template<typename Stream, typename K, typename Pred, typename A> void Unserialize(Stream& is, std::set<K, Pred, A>& m);
+
+/**
+ * shared_ptr
+ */
+template<typename Stream, typename T> void Serialize(Stream& os, const std::shared_ptr<const T>& p);
+template<typename Stream, typename T> void Unserialize(Stream& os, std::shared_ptr<const T>& p);
+
+/**
+ * unique_ptr
+ */
+template<typename Stream, typename T> void Serialize(Stream& os, const std::unique_ptr<const T>& p);
+template<typename Stream, typename T> void Unserialize(Stream& os, std::unique_ptr<const T>& p);
+
+
+/**
+ * If none of the specialized versions above matched, default to calling member function.
+ */
+template <class T, class Stream>
+concept Serializable = requires(T a, Stream s) { a.Serialize(s); };
+template <typename Stream, typename T>
+    requires Serializable<T, Stream>
+void Serialize(Stream& os, const T& a)
+{
+    a.Serialize(os);
+}
+
+template <class T, class Stream>
+concept Unserializable = requires(T a, Stream s) { a.Unserialize(s); };
+template <typename Stream, typename T>
+    requires Unserializable<T, Stream>
+void Unserialize(Stream& is, T&& a)
+{
+    a.Unserialize(is);
+}
+
+/** Default formatter. Serializes objects as themselves.
+ *
+ * The vector/prevector serialization code passes this to VectorFormatter
+ * to enable reusing that logic. It shouldn't be needed elsewhere.
+ */
+struct DefaultFormatter
+{
+    template<typename Stream, typename T>
+    static void Ser(Stream& s, const T& t) { Serialize(s, t); }
+
+    template<typename Stream, typename T>
+    static void Unser(Stream& s, T& t) { Unserialize(s, t); }
+};
+
+
+
+
+
+/**
+ * string
+ */
+template<typename Stream, typename C>
+void Serialize(Stream& os, const std::basic_string<C>& str)
+{
+    WriteCompactSize(os, str.size());
+    if (!str.empty())
+        os.write(MakeByteSpan(str));
+}
+
+template<typename Stream, typename C>
+void Unserialize(Stream& is, std::basic_string<C>& str)
+{
+    unsigned int nSize = ReadCompactSize(is);
+    str.resize(nSize);
+    if (nSize != 0)
+        is.read(MakeWritableByteSpan(str));
+}
+
+
+
+/**
+ * prevector
+ */
+template <typename Stream, unsigned int N, typename T>
+void Serialize(Stream& os, const prevector<N, T>& v)
+{
+    if constexpr (BasicByte<T>) { // Use optimized version for unformatted basic bytes
+        WriteCompactSize(os, v.size());
+        if (!v.empty()) os.write(MakeByteSpan(v));
+    } else {
+        Serialize(os, Using<VectorFormatter<DefaultFormatter>>(v));
+    }
+}
+
+
+template <typename Stream, unsigned int N, typename T>
+void Unserialize(Stream& is, prevector<N, T>& v)
+{
+    if constexpr (BasicByte<T>) { // Use optimized version for unformatted basic bytes
+        // Limit size per read so bogus size value won't cause out of memory
+        v.clear();
+        unsigned int nSize = ReadCompactSize(is);
+        unsigned int i = 0;
+        while (i < nSize) {
+            unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
+            v.resize_uninitialized(i + blk);
+            is.read(std::as_writable_bytes(std::span{&v[i], blk}));
+            i += blk;
+        }
+    } else {
+        Unserialize(is, Using<VectorFormatter<DefaultFormatter>>(v));
+    }
+}
+
+
+/**
+ * vector
+ */
+template <typename Stream, typename T, typename A>
+void Serialize(Stream& os, const std::vector<T, A>& v)
+{
+    if constexpr (BasicByte<T>) { // Use optimized version for unformatted basic bytes
+        WriteCompactSize(os, v.size());
+        if (!v.empty()) os.write(MakeByteSpan(v));
+    } else if constexpr (std::is_same_v<T, bool>) {
+        // A special case for std::vector<bool>, as dereferencing
+        // std::vector<bool>::const_iterator does not result in a const bool&
+        // due to std::vector's special casing for bool arguments.
+        WriteCompactSize(os, v.size());
+        for (bool elem : v) {
+            ::Serialize(os, elem);
+        }
+    } else {
+        Serialize(os, Using<VectorFormatter<DefaultFormatter>>(v));
+    }
+}
+
+
+template <typename Stream, typename T, typename A>
+void Unserialize(Stream& is, std::vector<T, A>& v)
+{
+    if constexpr (BasicByte<T>) { // Use optimized version for unformatted basic bytes
+        // Limit size per read so bogus size value won't cause out of memory
+        v.clear();
+        unsigned int nSize = ReadCompactSize(is);
+        unsigned int i = 0;
+        while (i < nSize) {
+            unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
+            v.resize(i + blk);
+            is.read(std::as_writable_bytes(std::span{&v[i], blk}));
+            i += blk;
+        }
+    } else {
+        Unserialize(is, Using<VectorFormatter<DefaultFormatter>>(v));
+    }
+}
+
+
+/**
+ * pair
+ */
+template<typename Stream, typename K, typename T>
+void Serialize(Stream& os, const std::pair<K, T>& item)
+{
+    Serialize(os, item.first);
+    Serialize(os, item.second);
+}
+
+template<typename Stream, typename K, typename T>
+void Unserialize(Stream& is, std::pair<K, T>& item)
+{
+    Unserialize(is, item.first);
+    Unserialize(is, item.second);
+}
+
+
+
+/**
+ * map
+ */
+template<typename Stream, typename K, typename T, typename Pred, typename A>
+void Serialize(Stream& os, const std::map<K, T, Pred, A>& m)
+{
+    WriteCompactSize(os, m.size());
+    for (const auto& entry : m)
+        Serialize(os, entry);
+}
+
+template<typename Stream, typename K, typename T, typename Pred, typename A>
+void Unserialize(Stream& is, std::map<K, T, Pred, A>& m)
+{
+    m.clear();
+    unsigned int nSize = ReadCompactSize(is);
+    typename std::map<K, T, Pred, A>::iterator mi = m.begin();
+    for (unsigned int i = 0; i < nSize; i++)
+    {
+        std::pair<K, T> item;
+        Unserialize(is, item);
+        mi = m.insert(mi, item);
+    }
+}
+
+
+
+/**
+ * set
+ */
+template<typename Stream, typename K, typename Pred, typename A>
+void Serialize(Stream& os, const std::set<K, Pred, A>& m)
+{
+    WriteCompactSize(os, m.size());
+    for (typename std::set<K, Pred, A>::const_iterator it = m.begin(); it != m.end(); ++it)
+        Serialize(os, (*it));
+}
+
+template<typename Stream, typename K, typename Pred, typename A>
+void Unserialize(Stream& is, std::set<K, Pred, A>& m)
+{
+    m.clear();
+    unsigned int nSize = ReadCompactSize(is);
+    typename std::set<K, Pred, A>::iterator it = m.begin();
+    for (unsigned int i = 0; i < nSize; i++)
+    {
+        K key;
+        Unserialize(is, key);
+        it = m.insert(it, key);
+    }
+}
+
+
+
+/**
+ * unique_ptr
+ */
+template<typename Stream, typename T> void
+Serialize(Stream& os, const std::unique_ptr<const T>& p)
+{
+    Serialize(os, *p);
+}
+
+template<typename Stream, typename T>
+void Unserialize(Stream& is, std::unique_ptr<const T>& p)
+{
+    p.reset(new T(deserialize, is));
+}
+
+
+
+/**
+ * shared_ptr
+ */
+template<typename Stream, typename T> void
+Serialize(Stream& os, const std::shared_ptr<const T>& p)
+{
+    Serialize(os, *p);
+}
+
+template<typename Stream, typename T>
+void Unserialize(Stream& is, std::shared_ptr<const T>& p)
+{
+    p = std::make_shared<const T>(deserialize, is);
+}
+
+/**
+ * Support for (un)serializing many things at once
+ */
+
+template <typename Stream, typename... Args>
+void SerializeMany(Stream& s, const Args&... args)
+{
+    (::Serialize(s, args), ...);
+}
+
+template <typename Stream, typename... Args>
+inline void UnserializeMany(Stream& s, Args&&... args)
+{
+    (::Unserialize(s, args), ...);
+}
+
+/**
+ * Support for all macros providing or using the ser_action parameter of the SerializationOps method.
+ */
+struct ActionSerialize {
+    static constexpr bool ForRead() { return false; }
+
+    template<typename Stream, typename... Args>
+    static void SerReadWriteMany(Stream& s, const Args&... args)
+    {
+        ::SerializeMany(s, args...);
+    }
+
+    template<typename Stream, typename Type, typename Fn>
+    static void SerRead(Stream& s, Type&&, Fn&&)
+    {
+    }
+
+    template<typename Stream, typename Type, typename Fn>
+    static void SerWrite(Stream& s, Type&& obj, Fn&& fn)
+    {
+        fn(s, std::forward<Type>(obj));
+    }
+};
+struct ActionUnserialize {
+    static constexpr bool ForRead() { return true; }
+
+    template<typename Stream, typename... Args>
+    static void SerReadWriteMany(Stream& s, Args&&... args)
+    {
+        ::UnserializeMany(s, args...);
+    }
+
+    template<typename Stream, typename Type, typename Fn>
+    static void SerRead(Stream& s, Type&& obj, Fn&& fn)
+    {
+        fn(s, std::forward<Type>(obj));
+    }
+
+    template<typename Stream, typename Type, typename Fn>
+    static void SerWrite(Stream& s, Type&&, Fn&&)
+    {
+    }
+};
+
+/* ::GetSerializeSize implementations
+ *
+ * Computing the serialized size of objects is done through a special stream
+ * object of type SizeComputer, which only records the number of bytes written
+ * to it.
+ *
+ * If your Serialize or SerializationOp method has non-trivial overhead for
+ * serialization, it may be worthwhile to implement a specialized version for
+ * SizeComputer, which uses the s.seek() method to record bytes that would
+ * be written instead.
+ */
+class SizeComputer
+{
+protected:
+    size_t nSize{0};
+
+public:
+    SizeComputer() = default;
+
+    void write(std::span<const std::byte> src)
+    {
+        this->nSize += src.size();
+    }
+
+    /** Pretend _nSize bytes are written, without specifying them. */
+    void seek(size_t _nSize)
+    {
+        this->nSize += _nSize;
+    }
+
+    template<typename T>
+    SizeComputer& operator<<(const T& obj)
+    {
+        ::Serialize(*this, obj);
+        return (*this);
+    }
+
+    size_t size() const {
+        return nSize;
+    }
+};
+
+template<typename I>
+inline void WriteVarInt(SizeComputer &s, I n)
+{
+    s.seek(GetSizeOfVarInt<I>(n));
+}
+
+inline void WriteCompactSize(SizeComputer &s, uint64_t nSize)
+{
+    s.seek(GetSizeOfCompactSize(nSize));
+}
+
+template <typename T>
+size_t GetSerializeSize(const T& t)
+{
+    return (SizeComputer() << t).size();
+}
+
+//! Check if type contains a stream by seeing if has a GetStream() method.
+template<typename T>
+concept ContainsStream = requires(T t) { t.GetStream(); };
+
+/** Wrapper that overrides the GetParams() function of a stream. */
+template <typename SubStream, typename Params>
+class ParamsStream
+{
+    const Params& m_params;
+    // If ParamsStream constructor is passed an lvalue argument, Substream will
+    // be a reference type, and m_substream will reference that argument.
+    // Otherwise m_substream will be a substream instance and move from the
+    // argument. Letting ParamsStream contain a substream instance instead of
+    // just a reference is useful to make the ParamsStream object self contained
+    // and let it do cleanup when destroyed, for example by closing files if
+    // SubStream is a file stream.
+    SubStream m_substream;
+
+public:
+    ParamsStream(SubStream&& substream, const Params& params LIFETIMEBOUND) : m_params{params}, m_substream{std::forward<SubStream>(substream)} {}
+
+    template <typename NestedSubstream, typename Params1, typename Params2, typename... NestedParams>
+    ParamsStream(NestedSubstream&& s, const Params1& params1 LIFETIMEBOUND, const Params2& params2 LIFETIMEBOUND, const NestedParams&... params LIFETIMEBOUND)
+        : ParamsStream{::ParamsStream{std::forward<NestedSubstream>(s), params2, params...}, params1} {}
+
+    template <typename U> ParamsStream& operator<<(const U& obj) { ::Serialize(*this, obj); return *this; }
+    template <typename U> ParamsStream& operator>>(U&& obj) { ::Unserialize(*this, obj); return *this; }
+    void write(std::span<const std::byte> src) { GetStream().write(src); }
+    void read(std::span<std::byte> dst) { GetStream().read(dst); }
+    void ignore(size_t num) { GetStream().ignore(num); }
+    bool eof() const { return GetStream().eof(); }
+    size_t size() const { return GetStream().size(); }
+
+    //! Get reference to stream parameters.
+    template <typename P>
+    const auto& GetParams() const
+    {
+        if constexpr (std::is_convertible_v<Params, P>) {
+            return m_params;
+        } else {
+            return m_substream.template GetParams<P>();
+        }
+    }
+
+    //! Get reference to underlying stream.
+    auto& GetStream()
+    {
+        if constexpr (ContainsStream<SubStream>) {
+            return m_substream.GetStream();
+        } else {
+            return m_substream;
+        }
+    }
+    const auto& GetStream() const
+    {
+        if constexpr (ContainsStream<SubStream>) {
+            return m_substream.GetStream();
+        } else {
+            return m_substream;
+        }
+    }
+};
+
+/**
+ * Explicit template deduction guide is required for single-parameter
+ * constructor so Substream&& is treated as a forwarding reference, and
+ * SubStream is deduced as reference type for lvalue arguments.
+ */
+template <typename Substream, typename Params>
+ParamsStream(Substream&&, const Params&) -> ParamsStream<Substream, Params>;
+
+/**
+ * Template deduction guide for multiple params arguments that creates a nested
+ * ParamsStream.
+ */
+template <typename Substream, typename Params1, typename Params2, typename... Params>
+ParamsStream(Substream&& s, const Params1& params1, const Params2& params2, const Params&... params) ->
+    ParamsStream<decltype(ParamsStream{std::forward<Substream>(s), params2, params...}), Params1>;
+
+/** Wrapper that serializes objects with the specified parameters. */
+template <typename Params, typename T>
+class ParamsWrapper
+{
+    const Params& m_params;
+    T& m_object;
+
+public:
+    explicit ParamsWrapper(const Params& params, T& obj) : m_params{params}, m_object{obj} {}
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        ParamsStream ss{s, m_params};
+        ::Serialize(ss, m_object);
+    }
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        ParamsStream ss{s, m_params};
+        ::Unserialize(ss, m_object);
+    }
+};
+
+/**
+ * Helper macro for SerParams structs
+ *
+ * Allows you define SerParams instances and then apply them directly
+ * to an object via function call syntax, eg:
+ *
+ *   constexpr SerParams FOO{....};
+ *   ss << FOO(obj);
+ */
+#define SER_PARAMS_OPFUNC                                                                \
+    /**                                                                                  \
+     * Return a wrapper around t that (de)serializes it with specified parameter params. \
+     *                                                                                   \
+     * See SER_PARAMS for more information on serialization parameters.                  \
+     */                                                                                  \
+    template <typename T>                                                                \
+    auto operator()(T&& t) const                                                         \
+    {                                                                                    \
+        return ParamsWrapper{*this, t};                                                  \
+    }
+
+#endif // BITCOIN_SERIALIZE_H

--- a/custommutator/utils/span.h
+++ b/custommutator/utils/span.h
@@ -1,0 +1,114 @@
+// Copyright (c) 2018-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SPAN_H
+#define BITCOIN_SPAN_H
+
+#include <cassert>
+#include <cstddef>
+#include <span>
+#include <type_traits>
+#include <utility>
+
+/** A span is an object that can refer to a contiguous sequence of objects.
+ *
+ * Things to be aware of when writing code that deals with spans:
+ *
+ * - Similar to references themselves, spans are subject to reference lifetime
+ *   issues. The user is responsible for making sure the objects pointed to by
+ *   a span live as long as the span is used. For example:
+ *
+ *       std::vector<int> vec{1,2,3,4};
+ *       std::span<int> sp(vec);
+ *       vec.push_back(5);
+ *       printf("%i\n", sp.front()); // UB!
+ *
+ *   may exhibit undefined behavior, as increasing the size of a vector may
+ *   invalidate references.
+ *
+ * - One particular pitfall is that spans can be constructed from temporaries,
+ *   but this is unsafe when the span is stored in a variable, outliving the
+ *   temporary. For example, this will compile, but exhibits undefined behavior:
+ *
+ *       std::span<const int> sp(std::vector<int>{1, 2, 3});
+ *       printf("%i\n", sp.front()); // UB!
+ *
+ *   The lifetime of the vector ends when the statement it is created in ends.
+ *   Thus the span is left with a dangling reference, and using it is undefined.
+ *
+ * - Due to spans automatic creation from range-like objects (arrays, and data
+ *   types that expose a data() and size() member function), functions that
+ *   accept a span as input parameter can be called with any compatible
+ *   range-like object. For example, this works:
+ *
+ *       void Foo(std::span<const int> arg);
+ *
+ *       Foo(std::vector<int>{1, 2, 3}); // Works
+ *
+ *   This is very useful in cases where a function truly does not care about the
+ *   container, and only about having exactly a range of elements. However it
+ *   may also be surprising to see automatic conversions in this case.
+ *
+ *   When a function accepts a span with a mutable element type, it will not
+ *   accept temporaries; only variables or other references. For example:
+ *
+ *       void FooMut(std::span<int> arg);
+ *
+ *       FooMut(std::vector<int>{1, 2, 3}); // Does not compile
+ *       std::vector<int> baz{1, 2, 3};
+ *       FooMut(baz); // Works
+ *
+ *   This is similar to how functions that take (non-const) lvalue references
+ *   as input cannot accept temporaries. This does not work either:
+ *
+ *       void FooVec(std::vector<int>& arg);
+ *       FooVec(std::vector<int>{1, 2, 3}); // Does not compile
+ *
+ *   The idea is that if a function accepts a mutable reference, a meaningful
+ *   result will be present in that variable after the call. Passing a temporary
+ *   is useless in that context.
+ */
+
+/** Pop the last element off a span, and return a reference to that element. */
+template <typename T>
+T& SpanPopBack(std::span<T>& span)
+{
+    size_t size = span.size();
+    T& back = span.back();
+    span = span.first(size - 1);
+    return back;
+}
+
+template <typename V>
+auto MakeByteSpan(const V& v) noexcept
+{
+    return std::as_bytes(std::span{v});
+}
+template <typename V>
+auto MakeWritableByteSpan(V&& v) noexcept
+{
+    return std::as_writable_bytes(std::span{std::forward<V>(v)});
+}
+
+// Helper functions to safely cast basic byte pointers to unsigned char pointers.
+inline unsigned char* UCharCast(char* c) { return reinterpret_cast<unsigned char*>(c); }
+inline unsigned char* UCharCast(unsigned char* c) { return c; }
+inline unsigned char* UCharCast(signed char* c) { return reinterpret_cast<unsigned char*>(c); }
+inline unsigned char* UCharCast(std::byte* c) { return reinterpret_cast<unsigned char*>(c); }
+inline const unsigned char* UCharCast(const char* c) { return reinterpret_cast<const unsigned char*>(c); }
+inline const unsigned char* UCharCast(const unsigned char* c) { return c; }
+inline const unsigned char* UCharCast(const signed char* c) { return reinterpret_cast<const unsigned char*>(c); }
+inline const unsigned char* UCharCast(const std::byte* c) { return reinterpret_cast<const unsigned char*>(c); }
+// Helper concept for the basic byte types.
+template <typename B>
+concept BasicByte = requires { UCharCast(std::span<B>{}.data()); };
+
+// Helper function to safely convert a span to a span<[const] unsigned char>.
+template <typename T, size_t N> constexpr auto UCharSpanCast(std::span<T, N> s) { return std::span<std::remove_pointer_t<decltype(UCharCast(s.data()))>, N>{UCharCast(s.data()), s.size()}; }
+
+/** Like the std::span constructor, but for (const) unsigned char member types only. Only works for (un)signed char containers. */
+template <typename V> constexpr auto MakeUCharSpan(const V& v) -> decltype(UCharSpanCast(std::span{v})) { return UCharSpanCast(std::span{v}); }
+template <typename V> constexpr auto MakeWritableUCharSpan(V&& v) -> decltype(UCharSpanCast(std::span{std::forward<V>(v)})) { return UCharSpanCast(std::span{std::forward<V>(v)}); }
+
+#endif // BITCOIN_SPAN_H

--- a/custommutator/utils/uint256.cpp
+++ b/custommutator/utils/uint256.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <uint256.h>
+
+#include <util/strencodings.h>
+
+template <unsigned int BITS>
+std::string base_blob<BITS>::GetHex() const
+{
+    uint8_t m_data_rev[WIDTH];
+    for (int i = 0; i < WIDTH; ++i) {
+        m_data_rev[i] = m_data[WIDTH - 1 - i];
+    }
+    return HexStr(m_data_rev);
+}
+
+template <unsigned int BITS>
+std::string base_blob<BITS>::ToString() const
+{
+    return (GetHex());
+}
+
+// Explicit instantiations for base_blob<160>
+template std::string base_blob<160>::GetHex() const;
+template std::string base_blob<160>::ToString() const;
+
+// Explicit instantiations for base_blob<256>
+template std::string base_blob<256>::GetHex() const;
+template std::string base_blob<256>::ToString() const;
+
+const uint256 uint256::ZERO(0);
+const uint256 uint256::ONE(1);

--- a/custommutator/utils/uint256.h
+++ b/custommutator/utils/uint256.h
@@ -1,0 +1,208 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UINT256_H
+#define BITCOIN_UINT256_H
+
+#include <crypto/common.h>
+#include <span.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <string_view>
+
+/** Template base class for fixed-sized opaque blobs. */
+template<unsigned int BITS>
+class base_blob
+{
+protected:
+    static constexpr int WIDTH = BITS / 8;
+    static_assert(BITS % 8 == 0, "base_blob currently only supports whole bytes.");
+    std::array<uint8_t, WIDTH> m_data;
+    static_assert(WIDTH == sizeof(m_data), "Sanity check");
+
+public:
+    /* construct 0 value by default */
+    constexpr base_blob() : m_data() {}
+
+    /* constructor for constants between 1 and 255 */
+    constexpr explicit base_blob(uint8_t v) : m_data{v} {}
+
+    constexpr explicit base_blob(std::span<const unsigned char> vch)
+    {
+        assert(vch.size() == WIDTH);
+        std::copy(vch.begin(), vch.end(), m_data.begin());
+    }
+
+    consteval explicit base_blob(std::string_view hex_str);
+
+    constexpr bool IsNull() const
+    {
+        return std::all_of(m_data.begin(), m_data.end(), [](uint8_t val) {
+            return val == 0;
+        });
+    }
+
+    constexpr void SetNull()
+    {
+        std::fill(m_data.begin(), m_data.end(), 0);
+    }
+
+    /** Lexicographic ordering
+     * @note Does NOT match the ordering on the corresponding \ref
+     *       base_uint::CompareTo, which starts comparing from the end.
+     */
+    constexpr int Compare(const base_blob& other) const { return std::memcmp(m_data.data(), other.m_data.data(), WIDTH); }
+
+    friend constexpr bool operator==(const base_blob& a, const base_blob& b) { return a.Compare(b) == 0; }
+    friend constexpr bool operator!=(const base_blob& a, const base_blob& b) { return a.Compare(b) != 0; }
+    friend constexpr bool operator<(const base_blob& a, const base_blob& b) { return a.Compare(b) < 0; }
+
+    /** @name Hex representation
+     *
+     * The hex representation used by GetHex(), ToString(), and FromHex()
+     * is unusual, since it shows bytes of the base_blob in reverse order.
+     * For example, a 4-byte blob {0x12, 0x34, 0x56, 0x78} is represented
+     * as "78563412" instead of the more typical "12345678" representation
+     * that would be shown in a hex editor or used by typical
+     * byte-array / hex conversion functions like python's bytes.hex() and
+     * bytes.fromhex().
+     *
+     * The nice thing about the reverse-byte representation, even though it is
+     * unusual, is that if a blob contains an arithmetic number in little endian
+     * format (with least significant bytes first, and most significant bytes
+     * last), the GetHex() output will match the way the number would normally
+     * be written in base-16 (with most significant digits first and least
+     * significant digits last).
+     *
+     * This means, for example, that ArithToUint256(num).GetHex() can be used to
+     * display an arith_uint256 num value as a number, because
+     * ArithToUint256() converts the number to a blob in little-endian format,
+     * so the arith_uint256 class doesn't need to have its own number parsing
+     * and formatting functions.
+     *
+     * @{*/
+    std::string GetHex() const;
+    std::string ToString() const;
+    /**@}*/
+
+    constexpr const unsigned char* data() const { return m_data.data(); }
+    constexpr unsigned char* data() { return m_data.data(); }
+
+    constexpr unsigned char* begin() { return m_data.data(); }
+    constexpr unsigned char* end() { return m_data.data() + WIDTH; }
+
+    constexpr const unsigned char* begin() const { return m_data.data(); }
+    constexpr const unsigned char* end() const { return m_data.data() + WIDTH; }
+
+    static constexpr unsigned int size() { return WIDTH; }
+
+    constexpr uint64_t GetUint64(int pos) const { return ReadLE64(m_data.data() + pos * 8); }
+
+    template<typename Stream>
+    void Serialize(Stream& s) const
+    {
+        s << std::span(m_data);
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s)
+    {
+        s.read(MakeWritableByteSpan(m_data));
+    }
+};
+
+template <unsigned int BITS>
+consteval base_blob<BITS>::base_blob(std::string_view hex_str)
+{
+    if (hex_str.length() != m_data.size() * 2) throw "Hex string must fit exactly";
+    auto str_it = hex_str.rbegin();
+    for (auto& elem : m_data) {
+        auto lo = util::ConstevalHexDigit(*(str_it++));
+        elem = (util::ConstevalHexDigit(*(str_it++)) << 4) | lo;
+    }
+}
+
+namespace detail {
+/**
+ * Writes the hex string (in reverse byte order) into a new uintN_t object
+ * and only returns a value iff all of the checks pass:
+ *   - Input length is uintN_t::size()*2
+ *   - All characters are hex
+ */
+template <class uintN_t>
+std::optional<uintN_t> FromHex(std::string_view str)
+{
+    if (uintN_t::size() * 2 != str.size() || !IsHex(str)) return std::nullopt;
+    uintN_t rv;
+    unsigned char* p1 = rv.begin();
+    unsigned char* pend = rv.end();
+    size_t digits = str.size();
+    while (digits > 0 && p1 < pend) {
+        *p1 = ::HexDigit(str[--digits]);
+        if (digits > 0) {
+            *p1 |= ((unsigned char)::HexDigit(str[--digits]) << 4);
+            p1++;
+        }
+    }
+    return rv;
+}
+/**
+ * @brief Like FromHex(std::string_view str), but allows an "0x" prefix
+ *        and pads the input with leading zeroes if it is shorter than
+ *        the expected length of uintN_t::size()*2.
+ *
+ *        Designed to be used when dealing with user input.
+ */
+template <class uintN_t>
+std::optional<uintN_t> FromUserHex(std::string_view input)
+{
+    input = util::RemovePrefixView(input, "0x");
+    constexpr auto expected_size{uintN_t::size() * 2};
+    if (input.size() < expected_size) {
+        auto padded = std::string(expected_size, '0');
+        std::copy(input.begin(), input.end(), padded.begin() + expected_size - input.size());
+        return FromHex<uintN_t>(padded);
+    }
+    return FromHex<uintN_t>(input);
+}
+} // namespace detail
+
+/** 160-bit opaque blob.
+ * @note This type is called uint160 for historical reasons only. It is an opaque
+ * blob of 160 bits and has no integer operations.
+ */
+class uint160 : public base_blob<160> {
+public:
+    static std::optional<uint160> FromHex(std::string_view str) { return detail::FromHex<uint160>(str); }
+    constexpr uint160() = default;
+    constexpr explicit uint160(std::span<const unsigned char> vch) : base_blob<160>(vch) {}
+};
+
+/** 256-bit opaque blob.
+ * @note This type is called uint256 for historical reasons only. It is an
+ * opaque blob of 256 bits and has no integer operations. Use arith_uint256 if
+ * those are required.
+ */
+class uint256 : public base_blob<256> {
+public:
+    static std::optional<uint256> FromHex(std::string_view str) { return detail::FromHex<uint256>(str); }
+    static std::optional<uint256> FromUserHex(std::string_view str) { return detail::FromUserHex<uint256>(str); }
+    constexpr uint256() = default;
+    consteval explicit uint256(std::string_view hex_str) : base_blob<256>(hex_str) {}
+    constexpr explicit uint256(uint8_t v) : base_blob<256>(v) {}
+    constexpr explicit uint256(std::span<const unsigned char> vch) : base_blob<256>(vch) {}
+    static const uint256 ZERO;
+    static const uint256 ONE;
+};
+
+#endif // BITCOIN_UINT256_H

--- a/custommutator/utils/util/strencodings.cpp
+++ b/custommutator/utils/util/strencodings.cpp
@@ -1,0 +1,481 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/strencodings.h>
+
+#include <crypto/hex_base.h>
+#include <span.h>
+
+#include <array>
+#include <cassert>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <vector>
+
+static const std::string CHARS_ALPHA_NUM = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+static const std::string SAFE_CHARS[] =
+{
+    CHARS_ALPHA_NUM + " .,;-_/:?@()", // SAFE_CHARS_DEFAULT
+    CHARS_ALPHA_NUM + " .,;-_?@", // SAFE_CHARS_UA_COMMENT
+    CHARS_ALPHA_NUM + ".-_", // SAFE_CHARS_FILENAME
+    CHARS_ALPHA_NUM + "!*'();:@&=+$,/?#[]-_.~%", // SAFE_CHARS_URI
+};
+
+std::string SanitizeString(std::string_view str, int rule)
+{
+    std::string result;
+    for (char c : str) {
+        if (SAFE_CHARS[rule].find(c) != std::string::npos) {
+            result.push_back(c);
+        }
+    }
+    return result;
+}
+
+bool IsHex(std::string_view str)
+{
+    for (char c : str) {
+        if (HexDigit(c) < 0) return false;
+    }
+    return (str.size() > 0) && (str.size()%2 == 0);
+}
+
+template <typename Byte>
+std::optional<std::vector<Byte>> TryParseHex(std::string_view str)
+{
+    std::vector<Byte> vch;
+    vch.reserve(str.size() / 2); // two hex characters form a single byte
+
+    auto it = str.begin();
+    while (it != str.end()) {
+        if (IsSpace(*it)) {
+            ++it;
+            continue;
+        }
+        auto c1 = HexDigit(*(it++));
+        if (it == str.end()) return std::nullopt;
+        auto c2 = HexDigit(*(it++));
+        if (c1 < 0 || c2 < 0) return std::nullopt;
+        vch.push_back(Byte(c1 << 4) | Byte(c2));
+    }
+    return vch;
+}
+template std::optional<std::vector<std::byte>> TryParseHex(std::string_view);
+template std::optional<std::vector<uint8_t>> TryParseHex(std::string_view);
+
+bool SplitHostPort(std::string_view in, uint16_t& portOut, std::string& hostOut)
+{
+    bool valid = false;
+    size_t colon = in.find_last_of(':');
+    // if a : is found, and it either follows a [...], or no other : is in the string, treat it as port separator
+    bool fHaveColon = colon != in.npos;
+    bool fBracketed = fHaveColon && (in[0] == '[' && in[colon - 1] == ']'); // if there is a colon, and in[0]=='[', colon is not 0, so in[colon-1] is safe
+    bool fMultiColon{fHaveColon && colon != 0 && (in.find_last_of(':', colon - 1) != in.npos)};
+    if (fHaveColon && (colon == 0 || fBracketed || !fMultiColon)) {
+        uint16_t n;
+        if (ParseUInt16(in.substr(colon + 1), &n)) {
+            in = in.substr(0, colon);
+            portOut = n;
+            valid = (portOut != 0);
+        }
+    } else {
+        valid = true;
+    }
+    if (in.size() > 0 && in[0] == '[' && in[in.size() - 1] == ']') {
+        hostOut = in.substr(1, in.size() - 2);
+    } else {
+        hostOut = in;
+    }
+
+    return valid;
+}
+
+std::string EncodeBase64(std::span<const unsigned char> input)
+{
+    static const char *pbase64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    std::string str;
+    str.reserve(((input.size() + 2) / 3) * 4);
+    ConvertBits<8, 6, true>([&](int v) { str += pbase64[v]; }, input.begin(), input.end());
+    while (str.size() % 4) str += '=';
+    return str;
+}
+
+std::optional<std::vector<unsigned char>> DecodeBase64(std::string_view str)
+{
+    static const int8_t decode64_table[256]{
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, 62, -1, -1, -1, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1,
+        -1, -1, -1, -1, -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1, -1, 26, 27, 28,
+        29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+        49, 50, 51, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+    };
+
+    if (str.size() % 4 != 0) return {};
+    /* One or two = characters at the end are permitted. */
+    if (str.size() >= 1 && str.back() == '=') str.remove_suffix(1);
+    if (str.size() >= 1 && str.back() == '=') str.remove_suffix(1);
+
+    std::vector<unsigned char> ret;
+    ret.reserve((str.size() * 3) / 4);
+    bool valid = ConvertBits<6, 8, false>(
+        [&](unsigned char c) { ret.push_back(c); },
+        str.begin(), str.end(),
+        [](char c) { return decode64_table[uint8_t(c)]; }
+    );
+    if (!valid) return {};
+
+    return ret;
+}
+
+std::string EncodeBase32(std::span<const unsigned char> input, bool pad)
+{
+    static const char *pbase32 = "abcdefghijklmnopqrstuvwxyz234567";
+
+    std::string str;
+    str.reserve(((input.size() + 4) / 5) * 8);
+    ConvertBits<8, 5, true>([&](int v) { str += pbase32[v]; }, input.begin(), input.end());
+    if (pad) {
+        while (str.size() % 8) {
+            str += '=';
+        }
+    }
+    return str;
+}
+
+std::string EncodeBase32(std::string_view str, bool pad)
+{
+    return EncodeBase32(MakeUCharSpan(str), pad);
+}
+
+std::optional<std::vector<unsigned char>> DecodeBase32(std::string_view str)
+{
+    static const int8_t decode32_table[256]{
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 26, 27, 28, 29, 30, 31, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1, -1,  0,  1,  2,
+         3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+        23, 24, 25, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+    };
+
+    if (str.size() % 8 != 0) return {};
+    /* 1, 3, 4, or 6 padding '=' suffix characters are permitted. */
+    if (str.size() >= 1 && str.back() == '=') str.remove_suffix(1);
+    if (str.size() >= 2 && str.substr(str.size() - 2) == "==") str.remove_suffix(2);
+    if (str.size() >= 1 && str.back() == '=') str.remove_suffix(1);
+    if (str.size() >= 2 && str.substr(str.size() - 2) == "==") str.remove_suffix(2);
+
+    std::vector<unsigned char> ret;
+    ret.reserve((str.size() * 5) / 8);
+    bool valid = ConvertBits<5, 8, false>(
+        [&](unsigned char c) { ret.push_back(c); },
+        str.begin(), str.end(),
+        [](char c) { return decode32_table[uint8_t(c)]; }
+    );
+
+    if (!valid) return {};
+
+    return ret;
+}
+
+namespace {
+template <typename T>
+bool ParseIntegral(std::string_view str, T* out)
+{
+    static_assert(std::is_integral_v<T>);
+    // Replicate the exact behavior of strtol/strtoll/strtoul/strtoull when
+    // handling leading +/- for backwards compatibility.
+    if (str.length() >= 2 && str[0] == '+' && str[1] == '-') {
+        return false;
+    }
+    const std::optional<T> opt_int = ToIntegral<T>((!str.empty() && str[0] == '+') ? str.substr(1) : str);
+    if (!opt_int) {
+        return false;
+    }
+    if (out != nullptr) {
+        *out = *opt_int;
+    }
+    return true;
+}
+}; // namespace
+
+bool ParseInt32(std::string_view str, int32_t* out)
+{
+    return ParseIntegral<int32_t>(str, out);
+}
+
+bool ParseInt64(std::string_view str, int64_t* out)
+{
+    return ParseIntegral<int64_t>(str, out);
+}
+
+bool ParseUInt8(std::string_view str, uint8_t* out)
+{
+    return ParseIntegral<uint8_t>(str, out);
+}
+
+bool ParseUInt16(std::string_view str, uint16_t* out)
+{
+    return ParseIntegral<uint16_t>(str, out);
+}
+
+bool ParseUInt32(std::string_view str, uint32_t* out)
+{
+    return ParseIntegral<uint32_t>(str, out);
+}
+
+bool ParseUInt64(std::string_view str, uint64_t* out)
+{
+    return ParseIntegral<uint64_t>(str, out);
+}
+
+std::string FormatParagraph(std::string_view in, size_t width, size_t indent)
+{
+    assert(width >= indent);
+    std::stringstream out;
+    size_t ptr = 0;
+    size_t indented = 0;
+    while (ptr < in.size())
+    {
+        size_t lineend = in.find_first_of('\n', ptr);
+        if (lineend == std::string::npos) {
+            lineend = in.size();
+        }
+        const size_t linelen = lineend - ptr;
+        const size_t rem_width = width - indented;
+        if (linelen <= rem_width) {
+            out << in.substr(ptr, linelen + 1);
+            ptr = lineend + 1;
+            indented = 0;
+        } else {
+            size_t finalspace = in.find_last_of(" \n", ptr + rem_width);
+            if (finalspace == std::string::npos || finalspace < ptr) {
+                // No place to break; just include the entire word and move on
+                finalspace = in.find_first_of("\n ", ptr);
+                if (finalspace == std::string::npos) {
+                    // End of the string, just add it and break
+                    out << in.substr(ptr);
+                    break;
+                }
+            }
+            out << in.substr(ptr, finalspace - ptr) << "\n";
+            if (in[finalspace] == '\n') {
+                indented = 0;
+            } else if (indent) {
+                out << std::string(indent, ' ');
+                indented = indent;
+            }
+            ptr = finalspace + 1;
+        }
+    }
+    return out.str();
+}
+
+/** Upper bound for mantissa.
+ * 10^18-1 is the largest arbitrary decimal that will fit in a signed 64-bit integer.
+ * Larger integers cannot consist of arbitrary combinations of 0-9:
+ *
+ *   999999999999999999  1^18-1
+ *  9223372036854775807  (1<<63)-1  (max int64_t)
+ *  9999999999999999999  1^19-1     (would overflow)
+ */
+static const int64_t UPPER_BOUND = 1000000000000000000LL - 1LL;
+
+/** Helper function for ParseFixedPoint */
+static inline bool ProcessMantissaDigit(char ch, int64_t &mantissa, int &mantissa_tzeros)
+{
+    if(ch == '0')
+        ++mantissa_tzeros;
+    else {
+        for (int i=0; i<=mantissa_tzeros; ++i) {
+            if (mantissa > (UPPER_BOUND / 10LL))
+                return false; /* overflow */
+            mantissa *= 10;
+        }
+        mantissa += ch - '0';
+        mantissa_tzeros = 0;
+    }
+    return true;
+}
+
+bool ParseFixedPoint(std::string_view val, int decimals, int64_t *amount_out)
+{
+    int64_t mantissa = 0;
+    int64_t exponent = 0;
+    int mantissa_tzeros = 0;
+    bool mantissa_sign = false;
+    bool exponent_sign = false;
+    int ptr = 0;
+    int end = val.size();
+    int point_ofs = 0;
+
+    if (ptr < end && val[ptr] == '-') {
+        mantissa_sign = true;
+        ++ptr;
+    }
+    if (ptr < end)
+    {
+        if (val[ptr] == '0') {
+            /* pass single 0 */
+            ++ptr;
+        } else if (val[ptr] >= '1' && val[ptr] <= '9') {
+            while (ptr < end && IsDigit(val[ptr])) {
+                if (!ProcessMantissaDigit(val[ptr], mantissa, mantissa_tzeros))
+                    return false; /* overflow */
+                ++ptr;
+            }
+        } else return false; /* missing expected digit */
+    } else return false; /* empty string or loose '-' */
+    if (ptr < end && val[ptr] == '.')
+    {
+        ++ptr;
+        if (ptr < end && IsDigit(val[ptr]))
+        {
+            while (ptr < end && IsDigit(val[ptr])) {
+                if (!ProcessMantissaDigit(val[ptr], mantissa, mantissa_tzeros))
+                    return false; /* overflow */
+                ++ptr;
+                ++point_ofs;
+            }
+        } else return false; /* missing expected digit */
+    }
+    if (ptr < end && (val[ptr] == 'e' || val[ptr] == 'E'))
+    {
+        ++ptr;
+        if (ptr < end && val[ptr] == '+')
+            ++ptr;
+        else if (ptr < end && val[ptr] == '-') {
+            exponent_sign = true;
+            ++ptr;
+        }
+        if (ptr < end && IsDigit(val[ptr])) {
+            while (ptr < end && IsDigit(val[ptr])) {
+                if (exponent > (UPPER_BOUND / 10LL))
+                    return false; /* overflow */
+                exponent = exponent * 10 + val[ptr] - '0';
+                ++ptr;
+            }
+        } else return false; /* missing expected digit */
+    }
+    if (ptr != end)
+        return false; /* trailing garbage */
+
+    /* finalize exponent */
+    if (exponent_sign)
+        exponent = -exponent;
+    exponent = exponent - point_ofs + mantissa_tzeros;
+
+    /* finalize mantissa */
+    if (mantissa_sign)
+        mantissa = -mantissa;
+
+    /* convert to one 64-bit fixed-point value */
+    exponent += decimals;
+    if (exponent < 0)
+        return false; /* cannot represent values smaller than 10^-decimals */
+    if (exponent >= 18)
+        return false; /* cannot represent values larger than or equal to 10^(18-decimals) */
+
+    for (int i=0; i < exponent; ++i) {
+        if (mantissa > (UPPER_BOUND / 10LL) || mantissa < -(UPPER_BOUND / 10LL))
+            return false; /* overflow */
+        mantissa *= 10;
+    }
+    if (mantissa > UPPER_BOUND || mantissa < -UPPER_BOUND)
+        return false; /* overflow */
+
+    if (amount_out)
+        *amount_out = mantissa;
+
+    return true;
+}
+
+std::string ToLower(std::string_view str)
+{
+    std::string r;
+    r.reserve(str.size());
+    for (auto ch : str) r += ToLower(ch);
+    return r;
+}
+
+std::string ToUpper(std::string_view str)
+{
+    std::string r;
+    r.reserve(str.size());
+    for (auto ch : str) r += ToUpper(ch);
+    return r;
+}
+
+std::string Capitalize(std::string str)
+{
+    if (str.empty()) return str;
+    str[0] = ToUpper(str.front());
+    return str;
+}
+
+std::optional<uint64_t> ParseByteUnits(std::string_view str, ByteUnit default_multiplier)
+{
+    if (str.empty()) {
+        return std::nullopt;
+    }
+    auto multiplier = default_multiplier;
+    char unit = str.back();
+    switch (unit) {
+    case 'k':
+        multiplier = ByteUnit::k;
+        break;
+    case 'K':
+        multiplier = ByteUnit::K;
+        break;
+    case 'm':
+        multiplier = ByteUnit::m;
+        break;
+    case 'M':
+        multiplier = ByteUnit::M;
+        break;
+    case 'g':
+        multiplier = ByteUnit::g;
+        break;
+    case 'G':
+        multiplier = ByteUnit::G;
+        break;
+    case 't':
+        multiplier = ByteUnit::t;
+        break;
+    case 'T':
+        multiplier = ByteUnit::T;
+        break;
+    default:
+        unit = 0;
+        break;
+    }
+
+    uint64_t unit_amount = static_cast<uint64_t>(multiplier);
+    auto parsed_num = ToIntegral<uint64_t>(unit ? str.substr(0, str.size() - 1) : str);
+    if (!parsed_num || parsed_num > std::numeric_limits<uint64_t>::max() / unit_amount) { // check overflow
+        return std::nullopt;
+    }
+    return *parsed_num * unit_amount;
+}

--- a/custommutator/utils/util/strencodings.h
+++ b/custommutator/utils/util/strencodings.h
@@ -1,0 +1,444 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/**
+ * Utilities for converting data from/to strings.
+ */
+#ifndef BITCOIN_UTIL_STRENCODINGS_H
+#define BITCOIN_UTIL_STRENCODINGS_H
+
+#include <crypto/hex_base.h> // IWYU pragma: export
+#include <span.h>
+#include <util/string.h>
+
+#include <array>
+#include <bit>
+#include <charconv>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <string>      // IWYU pragma: export
+#include <string_view> // IWYU pragma: export
+#include <system_error>
+#include <type_traits>
+#include <vector>
+
+/** Used by SanitizeString() */
+enum SafeChars
+{
+    SAFE_CHARS_DEFAULT, //!< The full set of allowed chars
+    SAFE_CHARS_UA_COMMENT, //!< BIP-0014 subset
+    SAFE_CHARS_FILENAME, //!< Chars allowed in filenames
+    SAFE_CHARS_URI, //!< Chars allowed in URIs (RFC 3986)
+};
+
+/**
+ * Used by ParseByteUnits()
+ * Lowercase base 1000
+ * Uppercase base 1024
+*/
+enum class ByteUnit : uint64_t {
+    NOOP = 1ULL,
+    k = 1000ULL,
+    K = 1024ULL,
+    m = 1'000'000ULL,
+    M = 1ULL << 20,
+    g = 1'000'000'000ULL,
+    G = 1ULL << 30,
+    t = 1'000'000'000'000ULL,
+    T = 1ULL << 40,
+};
+
+/**
+* Remove unsafe chars. Safe chars chosen to allow simple messages/URLs/email
+* addresses, but avoid anything even possibly remotely dangerous like & or >
+* @param[in] str    The string to sanitize
+* @param[in] rule   The set of safe chars to choose (default: least restrictive)
+* @return           A new string without unsafe chars
+*/
+std::string SanitizeString(std::string_view str, int rule = SAFE_CHARS_DEFAULT);
+/** Parse the hex string into bytes (uint8_t or std::byte). Ignores whitespace. Returns nullopt on invalid input. */
+template <typename Byte = std::byte>
+std::optional<std::vector<Byte>> TryParseHex(std::string_view str);
+/** Like TryParseHex, but returns an empty vector on invalid input. */
+template <typename Byte = uint8_t>
+std::vector<Byte> ParseHex(std::string_view hex_str)
+{
+    return TryParseHex<Byte>(hex_str).value_or(std::vector<Byte>{});
+}
+/* Returns true if each character in str is a hex character, and has an even
+ * number of hex digits.*/
+bool IsHex(std::string_view str);
+std::optional<std::vector<unsigned char>> DecodeBase64(std::string_view str);
+std::string EncodeBase64(std::span<const unsigned char> input);
+inline std::string EncodeBase64(std::span<const std::byte> input) { return EncodeBase64(MakeUCharSpan(input)); }
+inline std::string EncodeBase64(std::string_view str) { return EncodeBase64(MakeUCharSpan(str)); }
+std::optional<std::vector<unsigned char>> DecodeBase32(std::string_view str);
+
+/**
+ * Base32 encode.
+ * If `pad` is true, then the output will be padded with '=' so that its length
+ * is a multiple of 8.
+ */
+std::string EncodeBase32(std::span<const unsigned char> input, bool pad = true);
+
+/**
+ * Base32 encode.
+ * If `pad` is true, then the output will be padded with '=' so that its length
+ * is a multiple of 8.
+ */
+std::string EncodeBase32(std::string_view str, bool pad = true);
+
+/**
+ * Splits socket address string into host string and port value.
+ * Validates port value.
+ *
+ * @param[in] in        The socket address string to split.
+ * @param[out] portOut  Port-portion of the input, if found and parsable.
+ * @param[out] hostOut  Host-portion of the input, if found.
+ * @return              true if port-portion is absent or within its allowed range, otherwise false
+ */
+bool SplitHostPort(std::string_view in, uint16_t& portOut, std::string& hostOut);
+
+// LocaleIndependentAtoi is provided for backwards compatibility reasons.
+//
+// New code should use ToIntegral or the ParseInt* functions
+// which provide parse error feedback.
+//
+// The goal of LocaleIndependentAtoi is to replicate the defined behaviour of
+// std::atoi as it behaves under the "C" locale, and remove some undefined
+// behavior. If the parsed value is bigger than the integer type's maximum
+// value, or smaller than the integer type's minimum value, std::atoi has
+// undefined behavior, while this function returns the maximum or minimum
+// values, respectively.
+template <typename T>
+T LocaleIndependentAtoi(std::string_view str)
+{
+    static_assert(std::is_integral_v<T>);
+    T result;
+    // Emulate atoi(...) handling of white space and leading +/-.
+    std::string_view s = util::TrimStringView(str);
+    if (!s.empty() && s[0] == '+') {
+        if (s.length() >= 2 && s[1] == '-') {
+            return 0;
+        }
+        s = s.substr(1);
+    }
+    auto [_, error_condition] = std::from_chars(s.data(), s.data() + s.size(), result);
+    if (error_condition == std::errc::result_out_of_range) {
+        if (s.length() >= 1 && s[0] == '-') {
+            // Saturate underflow, per strtoll's behavior.
+            return std::numeric_limits<T>::min();
+        } else {
+            // Saturate overflow, per strtoll's behavior.
+            return std::numeric_limits<T>::max();
+        }
+    } else if (error_condition != std::errc{}) {
+        return 0;
+    }
+    return result;
+}
+
+/**
+ * Tests if the given character is a decimal digit.
+ * @param[in] c     character to test
+ * @return          true if the argument is a decimal digit; otherwise false.
+ */
+constexpr bool IsDigit(char c)
+{
+    return c >= '0' && c <= '9';
+}
+
+/**
+ * Tests if the given character is a whitespace character. The whitespace characters
+ * are: space, form-feed ('\f'), newline ('\n'), carriage return ('\r'), horizontal
+ * tab ('\t'), and vertical tab ('\v').
+ *
+ * This function is locale independent. Under the C locale this function gives the
+ * same result as std::isspace.
+ *
+ * @param[in] c     character to test
+ * @return          true if the argument is a whitespace character; otherwise false
+ */
+constexpr inline bool IsSpace(char c) noexcept {
+    return c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v';
+}
+
+/**
+ * Convert string to integral type T. Leading whitespace, a leading +, or any
+ * trailing character fail the parsing. The required format expressed as regex
+ * is `-?[0-9]+`. The minus sign is only permitted for signed integer types.
+ *
+ * @returns std::nullopt if the entire string could not be parsed, or if the
+ *   parsed value is not in the range representable by the type T.
+ */
+template <typename T>
+std::optional<T> ToIntegral(std::string_view str)
+{
+    static_assert(std::is_integral_v<T>);
+    T result;
+    const auto [first_nonmatching, error_condition] = std::from_chars(str.data(), str.data() + str.size(), result);
+    if (first_nonmatching != str.data() + str.size() || error_condition != std::errc{}) {
+        return std::nullopt;
+    }
+    return result;
+}
+
+/**
+ * Convert string to signed 32-bit integer with strict parse error feedback.
+ * @returns true if the entire string could be parsed as valid integer,
+ *   false if not the entire string could be parsed or when overflow or underflow occurred.
+ */
+[[nodiscard]] bool ParseInt32(std::string_view str, int32_t *out);
+
+/**
+ * Convert string to signed 64-bit integer with strict parse error feedback.
+ * @returns true if the entire string could be parsed as valid integer,
+ *   false if not the entire string could be parsed or when overflow or underflow occurred.
+ */
+[[nodiscard]] bool ParseInt64(std::string_view str, int64_t *out);
+
+/**
+ * Convert decimal string to unsigned 8-bit integer with strict parse error feedback.
+ * @returns true if the entire string could be parsed as valid integer,
+ *   false if not the entire string could be parsed or when overflow or underflow occurred.
+ */
+[[nodiscard]] bool ParseUInt8(std::string_view str, uint8_t *out);
+
+/**
+ * Convert decimal string to unsigned 16-bit integer with strict parse error feedback.
+ * @returns true if the entire string could be parsed as valid integer,
+ *   false if the entire string could not be parsed or if overflow or underflow occurred.
+ */
+[[nodiscard]] bool ParseUInt16(std::string_view str, uint16_t* out);
+
+/**
+ * Convert decimal string to unsigned 32-bit integer with strict parse error feedback.
+ * @returns true if the entire string could be parsed as valid integer,
+ *   false if not the entire string could be parsed or when overflow or underflow occurred.
+ */
+[[nodiscard]] bool ParseUInt32(std::string_view str, uint32_t *out);
+
+/**
+ * Convert decimal string to unsigned 64-bit integer with strict parse error feedback.
+ * @returns true if the entire string could be parsed as valid integer,
+ *   false if not the entire string could be parsed or when overflow or underflow occurred.
+ */
+[[nodiscard]] bool ParseUInt64(std::string_view str, uint64_t *out);
+
+/**
+ * Format a paragraph of text to a fixed width, adding spaces for
+ * indentation to any added line.
+ */
+std::string FormatParagraph(std::string_view in, size_t width = 79, size_t indent = 0);
+
+/**
+ * Timing-attack-resistant comparison.
+ * Takes time proportional to length
+ * of first argument.
+ */
+template <typename T>
+bool TimingResistantEqual(const T& a, const T& b)
+{
+    if (b.size() == 0) return a.size() == 0;
+    size_t accumulator = a.size() ^ b.size();
+    for (size_t i = 0; i < a.size(); i++)
+        accumulator |= size_t(a[i] ^ b[i%b.size()]);
+    return accumulator == 0;
+}
+
+/** Parse number as fixed point according to JSON number syntax.
+ * @returns true on success, false on error.
+ * @note The result must be in the range (-10^18,10^18), otherwise an overflow error will trigger.
+ */
+[[nodiscard]] bool ParseFixedPoint(std::string_view, int decimals, int64_t *amount_out);
+
+namespace {
+/** Helper class for the default infn argument to ConvertBits (just returns the input). */
+struct IntIdentity
+{
+    [[maybe_unused]] int operator()(int x) const { return x; }
+};
+
+} // namespace
+
+/** Convert from one power-of-2 number base to another. */
+template<int frombits, int tobits, bool pad, typename O, typename It, typename I = IntIdentity>
+bool ConvertBits(O outfn, It it, It end, I infn = {}) {
+    size_t acc = 0;
+    size_t bits = 0;
+    constexpr size_t maxv = (1 << tobits) - 1;
+    constexpr size_t max_acc = (1 << (frombits + tobits - 1)) - 1;
+    while (it != end) {
+        int v = infn(*it);
+        if (v < 0) return false;
+        acc = ((acc << frombits) | v) & max_acc;
+        bits += frombits;
+        while (bits >= tobits) {
+            bits -= tobits;
+            outfn((acc >> bits) & maxv);
+        }
+        ++it;
+    }
+    if (pad) {
+        if (bits) outfn((acc << (tobits - bits)) & maxv);
+    } else if (bits >= frombits || ((acc << (tobits - bits)) & maxv)) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Converts the given character to its lowercase equivalent.
+ * This function is locale independent. It only converts uppercase
+ * characters in the standard 7-bit ASCII range.
+ * This is a feature, not a limitation.
+ *
+ * @param[in] c     the character to convert to lowercase.
+ * @return          the lowercase equivalent of c; or the argument
+ *                  if no conversion is possible.
+ */
+constexpr char ToLower(char c)
+{
+    return (c >= 'A' && c <= 'Z' ? (c - 'A') + 'a' : c);
+}
+
+/**
+ * Returns the lowercase equivalent of the given string.
+ * This function is locale independent. It only converts uppercase
+ * characters in the standard 7-bit ASCII range.
+ * This is a feature, not a limitation.
+ *
+ * @param[in] str   the string to convert to lowercase.
+ * @returns         lowercased equivalent of str
+ */
+std::string ToLower(std::string_view str);
+
+/**
+ * Converts the given character to its uppercase equivalent.
+ * This function is locale independent. It only converts lowercase
+ * characters in the standard 7-bit ASCII range.
+ * This is a feature, not a limitation.
+ *
+ * @param[in] c     the character to convert to uppercase.
+ * @return          the uppercase equivalent of c; or the argument
+ *                  if no conversion is possible.
+ */
+constexpr char ToUpper(char c)
+{
+    return (c >= 'a' && c <= 'z' ? (c - 'a') + 'A' : c);
+}
+
+/**
+ * Returns the uppercase equivalent of the given string.
+ * This function is locale independent. It only converts lowercase
+ * characters in the standard 7-bit ASCII range.
+ * This is a feature, not a limitation.
+ *
+ * @param[in] str   the string to convert to uppercase.
+ * @returns         UPPERCASED EQUIVALENT OF str
+ */
+std::string ToUpper(std::string_view str);
+
+/**
+ * Capitalizes the first character of the given string.
+ * This function is locale independent. It only converts lowercase
+ * characters in the standard 7-bit ASCII range.
+ * This is a feature, not a limitation.
+ *
+ * @param[in] str   the string to capitalize.
+ * @returns         string with the first letter capitalized.
+ */
+std::string Capitalize(std::string str);
+
+/**
+ * Parse a string with suffix unit [k|K|m|M|g|G|t|T].
+ * Must be a whole integer, fractions not allowed (0.5t), no whitespace or +-
+ * Lowercase units are 1000 base. Uppercase units are 1024 base.
+ * Examples: 2m,27M,19g,41T
+ *
+ * @param[in] str                  the string to convert into bytes
+ * @param[in] default_multiplier   if no unit is found in str use this unit
+ * @returns                        optional uint64_t bytes from str or nullopt
+ *                                 if ToIntegral is false, str is empty, trailing whitespace or overflow
+ */
+std::optional<uint64_t> ParseByteUnits(std::string_view str, ByteUnit default_multiplier);
+
+namespace util {
+/** consteval version of HexDigit() without the lookup table. */
+consteval uint8_t ConstevalHexDigit(const char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 0xa;
+
+    throw "Only lowercase hex digits are allowed, for consistency";
+}
+
+namespace detail {
+template <size_t N>
+struct Hex {
+    std::array<std::byte, N / 2> bytes{};
+    consteval Hex(const char (&hex_str)[N])
+        // 2 hex digits required per byte + implicit null terminator
+        requires(N % 2 == 1)
+    {
+        if (hex_str[N - 1]) throw "null terminator required";
+        for (std::size_t i = 0; i < bytes.size(); ++i) {
+            bytes[i] = static_cast<std::byte>(
+                (ConstevalHexDigit(hex_str[2 * i]) << 4) |
+                 ConstevalHexDigit(hex_str[2 * i + 1]));
+        }
+    }
+};
+} // namespace detail
+
+/**
+ * ""_hex is a compile-time user-defined literal returning a
+ * `std::array<std::byte>`, equivalent to ParseHex(). Variants provided:
+ *
+ * - ""_hex_v: Returns `std::vector<std::byte>`, useful for heap allocation or
+ *   variable-length serialization.
+ *
+ * - ""_hex_u8: Returns `std::array<uint8_t>`, for cases where `std::byte` is
+ *   incompatible.
+ *
+ * - ""_hex_v_u8: Returns `std::vector<uint8_t>`, combining heap allocation with
+ *   `uint8_t`.
+ *
+ * @warning It could be necessary to use vector instead of array variants when
+ *   serializing, or vice versa, because vectors are assumed to be variable-
+ *   length and serialized with a size prefix, while arrays are considered fixed
+ *   length and serialized with no prefix.
+ *
+ * @warning It may be preferable to use vector variants to save stack space when
+ *   declaring local variables if hex strings are large. Alternatively variables
+ *   could be declared constexpr to avoid using stack space.
+ *
+ * @warning Avoid `uint8_t` variants when not necessary, as the codebase
+ *   migrates to use `std::byte` instead of `unsigned char` and `uint8_t`.
+ *
+ * @note One reason ""_hex uses `std::array` instead of `std::vector` like
+ *   ParseHex() does is because heap-based containers cannot cross the compile-
+ *   time/runtime barrier.
+ */
+inline namespace hex_literals {
+
+template <util::detail::Hex str>
+constexpr auto operator""_hex() { return str.bytes; }
+
+template <util::detail::Hex str>
+constexpr auto operator""_hex_u8() { return std::bit_cast<std::array<uint8_t, str.bytes.size()>>(str.bytes); }
+
+template <util::detail::Hex str>
+constexpr auto operator""_hex_v() { return std::vector<std::byte>{str.bytes.begin(), str.bytes.end()}; }
+
+template <util::detail::Hex str>
+inline auto operator""_hex_v_u8() { return std::vector<uint8_t>{UCharCast(str.bytes.data()), UCharCast(str.bytes.data() + str.bytes.size())}; }
+
+} // inline namespace hex_literals
+} // namespace util
+
+#endif // BITCOIN_UTIL_STRENCODINGS_H

--- a/custommutator/utils/util/string.cpp
+++ b/custommutator/utils/util/string.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2019-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/string.h>
+
+#include <regex>
+#include <string>
+
+namespace util {
+void ReplaceAll(std::string& in_out, const std::string& search, const std::string& substitute)
+{
+    if (search.empty()) return;
+    in_out = std::regex_replace(in_out, std::regex(search), substitute);
+}
+} // namespace util

--- a/custommutator/utils/util/string.h
+++ b/custommutator/utils/util/string.h
@@ -1,0 +1,265 @@
+// Copyright (c) 2019-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_STRING_H
+#define BITCOIN_UTIL_STRING_H
+
+#include <span.h>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <locale>
+#include <sstream>
+#include <string>      // IWYU pragma: export
+#include <string_view> // IWYU pragma: export
+#include <vector>
+
+namespace util {
+namespace detail {
+template <unsigned num_params>
+constexpr static void CheckNumFormatSpecifiers(const char* str)
+{
+    unsigned count_normal{0}; // Number of "normal" specifiers, like %s
+    unsigned count_pos{0};    // Max number in positional specifier, like %8$s
+    for (auto it{str}; *it != '\0'; ++it) {
+        if (*it != '%' || *++it == '%') continue; // Skip escaped %%
+
+        auto add_arg = [&] {
+            unsigned maybe_num{0};
+            while ('0' <= *it && *it <= '9') {
+                maybe_num *= 10;
+                maybe_num += *it - '0';
+                ++it;
+            }
+
+            if (*it == '$') {
+                ++it;
+                // Positional specifier, like %8$s
+                if (maybe_num == 0) throw "Positional format specifier must have position of at least 1";
+                count_pos = std::max(count_pos, maybe_num);
+            } else {
+                // Non-positional specifier, like %s
+                ++count_normal;
+            }
+        };
+
+        // Increase argument count and consume positional specifier, if present.
+        add_arg();
+
+        // Consume flags.
+        while (*it == '#' || *it == '0' || *it == '-' || *it == ' ' || *it == '+') ++it;
+
+        auto parse_size = [&] {
+            if (*it == '*') {
+                ++it;
+                add_arg();
+            } else {
+                while ('0' <= *it && *it <= '9') ++it;
+            }
+        };
+
+        // Consume dynamic or static width value.
+        parse_size();
+
+        // Consume dynamic or static precision value.
+        if (*it == '.') {
+            ++it;
+            parse_size();
+        }
+
+        if (*it == '\0') throw "Format specifier incorrectly terminated by end of string";
+
+        // Length and type in "[flags][width][.precision][length]type"
+        // is not checked. Parsing continues with the next '%'.
+    }
+    if (count_normal && count_pos) throw "Format specifiers must be all positional or all non-positional!";
+    unsigned count{count_normal | count_pos};
+    if (num_params != count) throw "Format specifier count must match the argument count!";
+}
+} // namespace detail
+
+/**
+ * @brief A wrapper for a compile-time partially validated format string
+ *
+ * This struct can be used to enforce partial compile-time validation of format
+ * strings, to reduce the likelihood of tinyformat throwing exceptions at
+ * run-time. Validation is partial to try and prevent the most common errors
+ * while avoiding re-implementing the entire parsing logic.
+ */
+template <unsigned num_params>
+struct ConstevalFormatString {
+    const char* const fmt;
+    consteval ConstevalFormatString(const char* str) : fmt{str} { detail::CheckNumFormatSpecifiers<num_params>(fmt); }
+};
+
+void ReplaceAll(std::string& in_out, const std::string& search, const std::string& substitute);
+
+/** Split a string on any char found in separators, returning a vector.
+ *
+ * If sep does not occur in sp, a singleton with the entirety of sp is returned.
+ *
+ * @param[in] include_sep Whether to include the separator at the end of the left side of the splits.
+ *
+ * Note that this function does not care about braces, so splitting
+ * "foo(bar(1),2),3) on ',' will return {"foo(bar(1)", "2)", "3)"}.
+ *
+ * If include_sep == true, splitting "foo(bar(1),2),3) on ','
+ * will return:
+ *  - foo(bar(1),
+ *  - 2),
+ *  - 3)
+ */
+template <typename T = std::span<const char>>
+std::vector<T> Split(const std::span<const char>& sp, std::string_view separators, bool include_sep = false)
+{
+    std::vector<T> ret;
+    auto it = sp.begin();
+    auto start = it;
+    while (it != sp.end()) {
+        if (separators.find(*it) != std::string::npos) {
+            if (include_sep) {
+                ret.emplace_back(start, it + 1);
+            } else {
+                ret.emplace_back(start, it);
+            }
+            start = it + 1;
+        }
+        ++it;
+    }
+    ret.emplace_back(start, it);
+    return ret;
+}
+
+/** Split a string on every instance of sep, returning a vector.
+ *
+ * If sep does not occur in sp, a singleton with the entirety of sp is returned.
+ *
+ * Note that this function does not care about braces, so splitting
+ * "foo(bar(1),2),3) on ',' will return {"foo(bar(1)", "2)", "3)"}.
+ */
+template <typename T = std::span<const char>>
+std::vector<T> Split(const std::span<const char>& sp, char sep, bool include_sep = false)
+{
+    return Split<T>(sp, std::string_view{&sep, 1}, include_sep);
+}
+
+[[nodiscard]] inline std::vector<std::string> SplitString(std::string_view str, char sep)
+{
+    return Split<std::string>(str, sep);
+}
+
+[[nodiscard]] inline std::vector<std::string> SplitString(std::string_view str, std::string_view separators)
+{
+    return Split<std::string>(str, separators);
+}
+
+[[nodiscard]] inline std::string_view TrimStringView(std::string_view str, std::string_view pattern = " \f\n\r\t\v")
+{
+    std::string::size_type front = str.find_first_not_of(pattern);
+    if (front == std::string::npos) {
+        return {};
+    }
+    std::string::size_type end = str.find_last_not_of(pattern);
+    return str.substr(front, end - front + 1);
+}
+
+[[nodiscard]] inline std::string TrimString(std::string_view str, std::string_view pattern = " \f\n\r\t\v")
+{
+    return std::string(TrimStringView(str, pattern));
+}
+
+[[nodiscard]] inline std::string_view RemoveSuffixView(std::string_view str, std::string_view suffix)
+{
+    if (str.ends_with(suffix)) {
+        return str.substr(0, str.size() - suffix.size());
+    }
+    return str;
+}
+
+[[nodiscard]] inline std::string_view RemovePrefixView(std::string_view str, std::string_view prefix)
+{
+    if (str.starts_with(prefix)) {
+        return str.substr(prefix.size());
+    }
+    return str;
+}
+
+[[nodiscard]] inline std::string RemovePrefix(std::string_view str, std::string_view prefix)
+{
+    return std::string(RemovePrefixView(str, prefix));
+}
+
+/**
+ * Join all container items. Typically used to concatenate strings but accepts
+ * containers with elements of any type.
+ *
+ * @param container The items to join
+ * @param separator The separator
+ * @param unary_op  Apply this operator to each item
+ */
+template <typename C, typename S, typename UnaryOp>
+// NOLINTNEXTLINE(misc-no-recursion)
+auto Join(const C& container, const S& separator, UnaryOp unary_op)
+{
+    decltype(unary_op(*container.begin())) ret;
+    bool first{true};
+    for (const auto& item : container) {
+        if (!first) ret += separator;
+        ret += unary_op(item);
+        first = false;
+    }
+    return ret;
+}
+
+template <typename C, typename S>
+auto Join(const C& container, const S& separator)
+{
+    return Join(container, separator, [](const auto& i) { return i; });
+}
+
+/**
+ * Create an unordered multi-line list of items.
+ */
+inline std::string MakeUnorderedList(const std::vector<std::string>& items)
+{
+    return Join(items, "\n", [](const std::string& item) { return "- " + item; });
+}
+
+/**
+ * Check if a string does not contain any embedded NUL (\0) characters
+ */
+[[nodiscard]] inline bool ContainsNoNUL(std::string_view str) noexcept
+{
+    for (auto c : str) {
+        if (c == 0) return false;
+    }
+    return true;
+}
+
+/**
+ * Locale-independent version of std::to_string
+ */
+template <typename T>
+std::string ToString(const T& t)
+{
+    std::ostringstream oss;
+    oss.imbue(std::locale::classic());
+    oss << t;
+    return oss.str();
+}
+
+/**
+ * Check whether a container begins with the given prefix.
+ */
+template <typename T1, size_t PREFIX_LEN>
+[[nodiscard]] inline bool HasPrefix(const T1& obj,
+                                const std::array<uint8_t, PREFIX_LEN>& prefix)
+{
+    return obj.size() >= PREFIX_LEN &&
+           std::equal(std::begin(prefix), std::end(prefix), std::begin(obj));
+}
+} // namespace util
+
+#endif // BITCOIN_UTIL_STRING_H

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,3 +272,19 @@ services:
     env_file: .env
     volumes:
       - ./docker:/app/data
+
+  bip32_deserialize_extended_key:
+    build:
+      context: .
+      tags:
+        - bitcoinfuzz:bip32_deserialize_extended_key
+      args:
+        CXXFLAGS: "-DBITCOIN_CORE -DRUST_BITCOIN -DNBITCOIN -DCUSTOM_MUTATOR_EXTENDED_KEY"
+        FUZZ: bip32_deserialize_extended_key
+    environment:
+      LIBFUZZ_DETECT_LEAKS: 0
+      ASAN_OPTIONS: detect_leaks=0
+    env_file: .env
+    volumes:
+      - ./docker:/app/data
+

--- a/driver.cpp
+++ b/driver.cpp
@@ -645,6 +645,32 @@ void Driver::SignSchnorrTarget(std::span<const uint8_t> buffer) const {
   }
 }
 
+void Driver::Bip32DeserializeExtendedKey(
+    std::span<const uint8_t> buffer) const {
+  std::optional<std::string> last_response{std::nullopt};
+  std::string last_module_name;
+
+  for (auto &module : modules) {
+    std::optional<std::string> res{
+        module.second->bip32_deserialize_extended_key(buffer)};
+    if (!res.has_value())
+      continue;
+    if (last_response.has_value()) {
+      if (*res != *last_response) {
+        std::cout << "BIP32 deserialize extended key failed" << std::endl;
+        std::cout << "Module: " << module.first << std::endl;
+        std::cout << "Result: " << *res << std::endl;
+        std::cout << "Module: " << last_module_name << std::endl;
+        std::cout << "Result: " << *last_response << std::endl;
+      }
+      assert(*res == *last_response);
+    }
+
+    last_response = res.value();
+    last_module_name = module.first;
+  }
+}
+
 void Driver::Run(const uint8_t *data, const size_t size,
                  const std::string &target) const {
   std::span<const uint8_t> buffer{data, size};
@@ -692,6 +718,8 @@ void Driver::Run(const uint8_t *data, const size_t size,
     this->ECDHTarget(buffer);
   } else if (target == "sign_schnorr") {
     this->SignSchnorrTarget(buffer);
+  } else if (target == "bip32_deserialize_extended_key") {
+    this->Bip32DeserializeExtendedKey(buffer);
   } else {
     std::cout << "Target not defined!" << std::endl;
     assert(false);

--- a/driver.h
+++ b/driver.h
@@ -44,5 +44,6 @@ public:
   void SignVerifyTarget(std::span<const uint8_t> buffer) const;
   void ECDHTarget(std::span<const uint8_t> buffer) const;
   void SignSchnorrTarget(std::span<const uint8_t> buffer) const;
+  void Bip32DeserializeExtendedKey(std::span<const uint8_t> buffer) const;
 };
 } // namespace bitcoinfuzz

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -122,4 +122,8 @@ BaseModule::sign_schnorr(std::span<const uint8_t> buffer,
   return std::nullopt;
 }
 
+std::optional<std::string> BaseModule::bip32_deserialize_extended_key(
+    std::span<const uint8_t> buffer) const {
+  return std::nullopt;
+}
 } // namespace bitcoinfuzz

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -61,6 +61,9 @@ public:
   sign_schnorr(std::span<const uint8_t> buffer, std::span<const uint8_t> hash,
                std::span<const uint8_t> aux) const;
 
+  virtual std::optional<std::string>
+  bip32_deserialize_extended_key(std::span<const uint8_t> buffer) const;
+
   virtual ~BaseModule() noexcept;
 };
 } // namespace bitcoinfuzz

--- a/main.cpp
+++ b/main.cpp
@@ -100,6 +100,10 @@
 #include <custommutator/mutators/secp256k1_signature.h>
 #endif
 
+#ifdef CUSTOM_MUTATOR_EXTENDED_KEY
+#include <custommutator/mutators/extended_key.h>
+#endif
+
 std::shared_ptr<bitcoinfuzz::Driver> driver = nullptr;
 
 static bitcoinfuzz::ModuleLogger module_logger;
@@ -185,6 +189,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
 #ifdef CUSTOM_MUTATOR_P2P_LIGHTNING_MESSAGE
   module_logger.addCustomMutator("Lightning P2P Message Custom Mutator");
+#endif
+
+#ifdef CUSTOM_MUTATOR_EXTENDED_KEY
+  module_logger.addCustomMutator("Extended Key Base58 Custom Mutator");
 #endif
 
   module_logger.logModules();

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -539,5 +539,54 @@ Bitcoin::bip32_master_keygen(std::span<const uint8_t> seed) const {
   return EncodeExtKey(master);
 }
 
+std::optional<std::string>
+Bitcoin::bip32_deserialize_extended_key(std::span<const uint8_t> buffer) const {
+  const std::string ext_str(reinterpret_cast<const char *>(buffer.data()),
+                            buffer.size());
+
+  if (ext_str[0] != 'x' && ext_str[0] != 't')
+    return "INVALID";
+  SelectParams(ext_str[0] == 't'
+                   ? ChainType::TESTNET
+                   : ChainType::MAIN); // needs to be done this way due to how
+                                       // Params() works
+
+  /* xprv / tprv */
+  try {
+    CExtKey ext_key = DecodeExtKey(ext_str);
+    if (ext_key.key.size() ==
+        0) { // if DecodeExtKey failed, it returns a CExtKey with empty key
+      throw std::runtime_error("DecodeExtKey failed");
+    }
+
+    std::string result = strprintf(
+        "depth=%02x;fp=%02x%02x%02x%02x;child=%08x;chaincode=%s;key=%s",
+        ext_key.nDepth, ext_key.vchFingerprint[0], ext_key.vchFingerprint[1],
+        ext_key.vchFingerprint[2], ext_key.vchFingerprint[3], ext_key.nChild,
+        HexStr(ext_key.chaincode), HexStr(ext_key.key));
+    return result;
+  } catch (...) {
+    /* fall through */
+  }
+
+  /* xpub / tpub */
+  try {
+    CExtPubKey ext_pubkey = DecodeExtPubKey(ext_str);
+    if ((ext_pubkey.pubkey.size() == 0)) {
+      throw std::runtime_error("DecodeExtPubKey failed");
+    }
+
+    std::string result = strprintf(
+        "depth=%02x;fp=%02x%02x%02x%02x;child=%08x;chaincode=%s;key=%s",
+        ext_pubkey.nDepth, ext_pubkey.vchFingerprint[0],
+        ext_pubkey.vchFingerprint[1], ext_pubkey.vchFingerprint[2],
+        ext_pubkey.vchFingerprint[3], ext_pubkey.nChild,
+        HexStr(ext_pubkey.chaincode), HexStr(ext_pubkey.pubkey));
+    return result;
+  } catch (...) {
+    return "INVALID";
+  }
+}
+
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/bitcoin/module.h
+++ b/modules/bitcoin/module.h
@@ -30,6 +30,8 @@ public:
   transaction_eval(std::span<const uint8_t> buffer) const override;
   std::optional<std::string>
   bip32_master_keygen(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string> bip32_deserialize_extended_key(
+      std::span<const uint8_t> buffer) const override;
   ~Bitcoin() noexcept override = default;
 };
 

--- a/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
+++ b/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
@@ -3,6 +3,7 @@ using System.Text;
 using NBitcoin.Scripting;
 using NBitcoin.WalletPolicies;
 
+
 namespace NBitcoin.CppBridge;
 
 public static class Bridge
@@ -170,6 +171,58 @@ public static class Bridge
         ExtKey sk = ExtKey.CreateFromSeed(seed);
         IntPtr strPtr = Marshal.StringToHGlobalAnsi(sk.GetWif(Network.Main).ToString());
         return strPtr;
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "nbitcoin_bip32_deserialize_extended_key")]
+    public static IntPtr BIP32DeserializeExtendedKeyTarget(IntPtr inputPtr)
+    {
+        if (inputPtr == IntPtr.Zero) return Marshal.StringToCoTaskMemUTF8("INVALID");
+
+        string input = Marshal.PtrToStringUTF8(inputPtr) ?? "";
+        string result;
+
+        if (TryParseXprv(input, Network.Main, out result) ||
+            TryParseXprv(input, Network.TestNet, out result) ||
+            TryParseXpub(input, Network.Main, out result) ||
+            TryParseXpub(input, Network.TestNet, out result))
+        {
+            return Marshal.StringToCoTaskMemUTF8(result);
+        }
+
+        return Marshal.StringToCoTaskMemUTF8("INVALID");
+    }
+
+    // Helpers
+    private static string Hex(byte[] data) => Convert.ToHexString(data).ToLower();
+
+    private static bool TryParseXprv(string input, Network network, out string result)
+    {
+        result = null;
+        try
+        {
+            var ext = NBitcoin.ExtKey.Parse(input, network);
+            result = $"depth={ext.Depth:x2};fp={Hex(ext.ParentFingerprint.ToBytes())};child={ext.Child:x8};chaincode={Hex(ext.ChainCode)};key={ext.PrivateKey.ToHex().ToLower()}";
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool TryParseXpub(string input, Network network, out string result)
+    {
+        result = null;
+        try
+        {
+            var ext = NBitcoin.ExtPubKey.Parse(input, network);
+            result = $"depth={ext.Depth:x2};fp={Hex(ext.ParentFingerprint.ToBytes())};child={ext.Child:x8};chaincode={Hex(ext.ChainCode)};key={ext.PubKey.ToHex().ToLower()}";
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     [UnmanagedCallersOnly(EntryPoint = "nbitcoin_free_c_string")]

--- a/modules/nbitcoin/NBitcoin/nbitcoin_lib.h
+++ b/modules/nbitcoin/NBitcoin/nbitcoin_lib.h
@@ -12,4 +12,7 @@ extern "C" char *nbitcoin_bip32_master_keygen(const uint8_t *data, size_t len);
 
 extern "C" char *nbitcoin_psbt_parse(const uint8_t *data, size_t len);
 
+extern "C" char *nbitcoin_bip32_deserialize_extended_key(const uint8_t *data,
+                                                         size_t len);
+
 extern "C" void nbitcoin_free_c_string(void *ptr);

--- a/modules/nbitcoin/module.cpp
+++ b/modules/nbitcoin/module.cpp
@@ -35,5 +35,15 @@ NBitcoin::psbt_parse(std::span<const uint8_t> buffer) const {
   nbitcoin_free_c_string(p);
   return s;
 }
+std::optional<std::string> NBitcoin::bip32_deserialize_extended_key(
+    std::span<const uint8_t> buffer) const {
+  char *p =
+      nbitcoin_bip32_deserialize_extended_key(buffer.data(), buffer.size());
+  if (!p)
+    return std::nullopt;
+  std::string s(p);
+  nbitcoin_free_c_string(p);
+  return s;
+}
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/nbitcoin/module.h
+++ b/modules/nbitcoin/module.h
@@ -19,6 +19,8 @@ public:
   bip32_master_keygen(std::span<const uint8_t> buffer) const override;
   std::optional<std::string>
   psbt_parse(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string> bip32_deserialize_extended_key(
+      std::span<const uint8_t> buffer) const override;
   ~NBitcoin() noexcept override = default;
 };
 } // namespace module

--- a/modules/rustbitcoin/module.cpp
+++ b/modules/rustbitcoin/module.cpp
@@ -76,10 +76,22 @@ Rustbitcoin::parse_p2p_message(std::span<const uint8_t> buffer) const {
   free_c_string(message);
   return result;
 }
+
 std::optional<std::string>
 Rustbitcoin::bip32_master_keygen(std::span<const uint8_t> buffer) const {
   auto result_ptr =
       rust_bitcoin_bip32_master_keygen(buffer.data(), buffer.size());
+  if (result_ptr == nullptr)
+    return std::nullopt;
+  std::string result(result_ptr);
+  free_c_string(result_ptr);
+  return result;
+}
+
+std::optional<std::string> Rustbitcoin::bip32_deserialize_extended_key(
+    std::span<const uint8_t> buffer) const {
+  auto result_ptr =
+      rust_bitcoin_bip32_deserialize_extended_key(buffer.data(), buffer.size());
   if (result_ptr == nullptr)
     return std::nullopt;
   std::string result(result_ptr);

--- a/modules/rustbitcoin/module.h
+++ b/modules/rustbitcoin/module.h
@@ -26,6 +26,8 @@ public:
   parse_p2p_message(std::span<const uint8_t> buffer) const override;
   std::optional<std::string>
   bip32_master_keygen(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string> bip32_deserialize_extended_key(
+      std::span<const uint8_t> buffer) const override;
   ~Rustbitcoin() noexcept override = default;
 };
 

--- a/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
+++ b/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
@@ -12,3 +12,5 @@ extern "C" char *rust_bitcoin_parse_p2p_message(const uint8_t *data,
                                                 size_t len);
 extern "C" char *rust_bitcoin_bip32_master_keygen(const uint8_t *data,
                                                   size_t len);
+extern "C" char *
+rust_bitcoin_bip32_deserialize_extended_key(const uint8_t *data, size_t len);

--- a/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
+++ b/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
@@ -1,7 +1,11 @@
 use bitcoin::absolute::Decodable;
 use bitcoin::address::Address;
 use bitcoin::bip152::HeaderAndShortIds;
+use bitcoin::bip32::ChainCode;
+use bitcoin::bip32::ChildNumber;
+use bitcoin::bip32::Fingerprint;
 use bitcoin::bip32::Xpriv;
+use bitcoin::bip32::Xpub;
 use bitcoin::block::BlockUncheckedExt;
 use bitcoin::consensus::{deserialize_partial, encode, serialize};
 use bitcoin::script::ScriptExt;
@@ -267,4 +271,66 @@ pub unsafe extern "C" fn rust_bitcoin_bip32_master_keygen(
 
 unsafe fn c_str_to_str<'a>(input: *const c_char) -> Result<&'a str, Utf8Error> {
     CStr::from_ptr(input).to_str()
+}
+
+//helper func
+fn format_ext_key_common(
+    depth: u8,
+    fingerprint: Fingerprint,
+    child_number: ChildNumber,
+    chain_code: ChainCode,
+    key_bytes: &[u8],
+) -> String {
+    let hex_key_bytes: String = key_bytes.iter().map(|b| format!("{:02x}", b)).collect();
+    let child_u32: u32 = child_number.into();
+    format!(
+        "depth={:02x};fp={:02x}{:02x}{:02x}{:02x};child={:08x};chaincode={};key={}",
+        depth,
+        fingerprint[0],
+        fingerprint[1],
+        fingerprint[2],
+        fingerprint[3],
+        child_u32,
+        chain_code,
+        hex_key_bytes
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_bitcoin_bip32_deserialize_extended_key(
+    data: *const u8,
+    len: usize,
+) -> *mut c_char {
+    let data_slice = slice::from_raw_parts(data, len);
+    let ext_str = match std::str::from_utf8(data_slice) {
+        Ok(s) => s,
+        Err(_) => return str_to_c_string("INVALID"),
+    };
+    if let Ok(xprv) = Xpriv::from_str(&ext_str) {
+        //format the result to string
+        let result = format_ext_key_common(
+            xprv.depth,
+            xprv.parent_fingerprint,
+            xprv.child_number,
+            xprv.chain_code,
+            &xprv.private_key.to_secret_bytes(), // as bytes
+        );
+        //return formatted string
+        str_to_c_string(&result)
+    } else {
+        if let Ok(xpub) = Xpub::from_str(&ext_str) {
+            //format the result to string
+            let result = format_ext_key_common(
+                xpub.depth,
+                xpub.parent_fingerprint,
+                xpub.child_number,
+                xpub.chain_code,
+                &xpub.public_key.serialize(), // as bytes
+            );
+            //return formatted string
+            str_to_c_string(&result)
+        } else {
+            str_to_c_string("INVALID")
+        }
+    }
 }


### PR DESCRIPTION
### NEW TARGET: Deserialization of a BIP32 extended key
This target accepts a Bip32 extended key in the base58check-encoded form (string of b58 chars), deserializes it, then returns it as a string (return may change to bool, or different parts of the key).
In order to make it even remotely possible to send a valid extkey, formatting of the random bytes is needed.

TLDR bip32 ExtKey serialization from [https://en.bitcoin.it/wiki/BIP_0032](https://en.bitcoin.it/wiki/BIP_0032)
> Extended public and private keys are serialized as follows:

> * 4 byte: version bytes (mainnet: 0x0488B21E public, 0x0488ADE4 private; testnet: 0x043587CF public, 0x04358394 private)
> * 1 byte: depth: 0x00 for master nodes, 0x01 for level-1 derived keys, ....
> * 4 bytes: the fingerprint of the parent's key (0x00000000 if master key)
> * 4 bytes: child number. This is ser32(i) for i in xi = xpar/i, with xi the key being serialized. (0x00000000 if master key)
> * 32 bytes: the chain code
> * 33 bytes: the public key or private key data (serP(K) for public keys, 0x00 || ser256(k) for private keys)

> This 78 byte structure can be encoded like other Bitcoin data in Base58, by first adding 32 checksum bits (derived from the double SHA-256 checksum), and then converting to the Base58 representation. This results in a Base58-encoded string of up to 112 characters. Because of the choice of the version bytes, the Base58 representation will start with "xprv" or  "xpub" on mainnet, "tprv" or "tpub" on testnet.

My idea was to create multiple custom mutators, each "helping the target" a bit more, to maximize the range tested.
(e.g. Mut1 - encode random bytes to b58, Mut2 - hardcode the first 4 version bytes + Mut1, Mut3 - fill to 78 bytes + Mut2, Mut4 - append correct checksum + Mut3, ...)

### I see 2 issues with this approach:

#### 1. Base58 utils access
For these mutations, base58 functions are needed, so far i only added a placeholder mutator that creates seemingly b58 looking, 78B long data.  I see 3 solutions:
* Custom implementation in main.cpp (similarly to bitcoin_double_sha256() in main.cpp)
* "Borrow" it from Core "modules/bitcoin/base58.h"
* Add the base58 utils to "modules/custommutator/" (similarly to how bech32 and sha256 are there) <- optimal?

#### 2. How mutators work
Please correct me if i am wrong:

As mutators are selected in the building process, running the fuzzer means that only an explicit set of them can be active for that running instance at a time....
Does that mean that if we e.g. want to fuzz "long-term", multiple instances of bitcoinfuzz need to be running to cover all targets? (each with a specified mutator?)
Is this something to avoid (shall I reavaluate the multi-mutator solution and instead e.g. implement multiple targets that begin with mutating the input?


Thanks.
