### PR TITLE
build: add missing secp256k1 dependencies to docker (autoconf, libtool)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     wget curl git build-essential sudo \
     libc6-dev libgcc-11-dev libasan6 \
+    autoconf libtool \
     cmake \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I was unable to run `bitcoin core` targets using docker ([see error](https://gist.github.com/kuliq23/459a2caacaa2267765f388b7bef52f10)). 

Adding libtool and autoconf to Dockerfile seems to fix the issue.