### PR TITLE
BIP32: Add BTCD module to masterkeygen target

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -233,7 +233,7 @@ jobs:
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "bip32_master_keygen"
             target: "bip32_master_keygen"
-            cxxflags: "-DNBITCOIN -DRUST_BITCOIN -DBITCOIN_CORE"
+            cxxflags: "-DNBITCOIN -DRUST_BITCOIN -DBITCOIN_CORE -DBTCD"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     wget curl git build-essential sudo \
     libc6-dev libgcc-11-dev libasan6 \
+    autoconf libtool \
     cmake \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,7 +167,7 @@ services:
       dockerfile: Dockerfile
     environment:
       <<: *common-env
-      CXXFLAGS: "-DRUST_BITCOIN -DNBITCOIN -DBITCOIN_CORE"
+      CXXFLAGS: "-DRUST_BITCOIN -DNBITCOIN -DBITCOIN_CORE -DBTCD"
       FUZZ: bip32_master_keygen
     volumes:
       - ./docker/bip32_master_keygen:/app/data

--- a/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
+++ b/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
@@ -94,6 +94,7 @@ extern void BTCDFreeString(char* ptr);
 extern char* BTCDTransactionEval(ByteArray data);
 extern char* BTCDParsePSBT(ByteArray data);
 extern char* BTCDAddress(ByteArray data);
+extern char* BTCDBip32MasterKeygen(ByteArray data);
 
 #ifdef __cplusplus
 }

--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/btcsuite/btcd/addrmgr"
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
@@ -281,4 +282,18 @@ func BTCDAddress(data C.ByteArray) *C.char {
 	return C.CString(prefix + addr.EncodeAddress())
 }
 
+//export BTCDBip32MasterKeygen
+func BTCDBip32MasterKeygen(data C.ByteArray) *C.char {
+	seed := C.GoBytes(unsafe.Pointer(data.data), data.length)
+	masterKey, err := hdkeychain.NewMaster(seed, &chaincfg.MainNetParams)
+	if err != nil {
+		// Skip seed length validation errors (128-512 bits requirement) as other
+		// implementations don't enforce this constraint.
+		if err.Error() == "seed length must be between 128 and 512 bits" {
+			return nil
+		}
+		return C.CString("")
+	}
+	return C.CString(masterKey.String())
+}
 func main() {}

--- a/modules/btcd/module.cpp
+++ b/modules/btcd/module.cpp
@@ -122,6 +122,19 @@ namespace bitcoinfuzz
             BTCDFreeString(result);
             return res;
         }
+        std::optional<std::string> Btcd::bip32_master_keygen(std::span<const uint8_t> buffer) const
+        {
+            ByteArray seed;
+            seed.data = (char*)buffer.data();
+            seed.length = buffer.size();
+
+            char* result = BTCDBip32MasterKeygen(seed);
+            if (!result) return std::nullopt;
+
+            std::string res(result);
+            BTCDFreeString(result);
+            return res;
+        }
 
     } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/btcd/module.h
+++ b/modules/btcd/module.h
@@ -21,6 +21,7 @@ namespace bitcoinfuzz
             std::optional<std::string> addrv2_parse(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> parse_p2p_message(std::span<const uint8_t> buffer) const override;
             std::optional<std::string> transaction_eval(std::span<const uint8_t> buffer) const override;
+            std::optional<std::string> bip32_master_keygen(std::span<const uint8_t> buffer) const override;
             ~Btcd() noexcept override = default;
         };
 


### PR DESCRIPTION
BTCD [master keygen func](https://github.com/btcsuite/btcd/blob/9ff0780da683ec1fa88ce9b9f2f4fd39d5592221/btcutil/hdkeychain/extendedkey.go#L652) differs from other modules by accepting only 16-64 bytes long sequence as input. Bitcoin Core, NBitcoin and Rustbitcoin don't check this. This is why the fuzzing fails now.

[BIP32 docs](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) MK Generation step in question:

* Generate a seed byte sequence S of a chosen length (between 128 and 512 bits; 256 bits is advised) from a (P)RNG. 

**I suppose correct solution would be to feed only byte sequences of this specified length to this target?**

I will try to investigate possible problems and implications of not checking the length in mentioned modules as well as possible mishaps in handling bits (in spec) vs bytes.