### PR TITLE
feat: add tinyminiscript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ ifneq ($(findstring -DRUST_MINISCRIPT,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
 	MODULES += modules/rustminiscript/module.a
 endif
 
+ifneq ($(findstring -DTINY_MINISCRIPT,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+	MODULES += modules/tinyminiscript/module.a
+endif
+
 ifneq ($(findstring -DBTCD,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
 	MODULES += modules/btcd/module.a
 endif
@@ -69,24 +73,23 @@ ifeq ($(UNAME_S), Darwin)
 	LDFLAGS = -framework CoreFoundation -Wl,-ld_classic
 endif
 
+ifeq ($(UNAME_S), Darwin)
+	LIB_EXT := dylib
+else
+	LIB_EXT := so
+endif
+
 ifneq ($(findstring -DNBITCOIN,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
-	ifeq ($(UNAME_S), Darwin)
-		NBITCOIN_LIB_EXT := dylib
-	else
-		NBITCOIN_LIB_EXT := so
-	endif
-  NBITCOIN_DYLIB := ./NBitcoin.CppBridge.$(NBITCOIN_LIB_EXT)
+  NBITCOIN_LIB := ./NBitcoin.CppBridge.$(LIB_EXT)
 endif
 
 ifneq ($(findstring -DNLIGHTNING,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
-	ifeq ($(UNAME_S), Darwin)
-		NBITCOIN_LIB_EXT := dylib
-	else
-		NBITCOIN_LIB_EXT := so
-	endif
-  NBITCOIN_DYLIB := ./NLightning.CppBridge.$(NBITCOIN_LIB_EXT)
+  NLIGHTNING_LIB := ./NLightning.CppBridge.$(LIB_EXT)
 endif
 
+ifneq ($(findstring -DTINY_MINISCRIPT,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+  TINY_MINISCRIPT_LIB := ./libtiny_miniscript_lib.$(LIB_EXT)
+endif
 
 SODIUM_LDLIBS = $(shell pkg-config --silence-errors --libs libsodium 2>/dev/null)
 
@@ -110,7 +113,7 @@ endif
 CXXFLAGS := $(BASE_CXXFLAGS) $(JAVA_CXXFLAGS) $(CXXFLAGS) $(PYTHON_LDFLAGS)
 
 bitcoinfuzz: main.cpp driver.o $(BITCOINFUZZ_OBJS) $(JVM_LOADER)
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp $(MODULES) driver.o $(BITCOINFUZZ_OBJS) $(NBITCOIN_DYLIB) -o bitcoinfuzz $(PYTHON_LDFLAGS) $(SODIUM_LDLIBS) $(JVM_LOADER)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp $(MODULES) driver.o $(BITCOINFUZZ_OBJS) $(NBITCOIN_LIB) $(NLIGHTNING_LIB) $(TINY_MINISCRIPT_LIB) -o bitcoinfuzz $(PYTHON_LDFLAGS) $(SODIUM_LDLIBS) $(JVM_LOADER)
 
 driver.o: driver.cpp driver.h
 	$(CXX) $(CXXFLAGS) -c driver.cpp -o driver.o

--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ If you prefer, you can still build the modules manually. Below are the steps for
     export CXXFLAGS="$CXXFLAGS -DRUST_BITCOIN"
     ```
 
+- ### tinyminiscript
+
+    ```bash
+    cd modules/tinyminiscript
+    make cargo && make
+    export CXXFLAGS="$CXXFLAGS -DTINY_MINISCRIPT"
+    ```
+
 - ### rust-miniscript
 
     ```bash

--- a/README.md
+++ b/README.md
@@ -340,3 +340,4 @@ Once the modules are compiled, you can compile `bitcoinfuzz` an execute it:
 - btcd: https://github.com/btcsuite/btcd/issues/2431
 - LND: https://github.com/lightningnetwork/lnd/pull/10249
 - NBitcoin: https://github.com/MetacoSA/NBitcoin/issues/1283
+- tinyminiscript: https://github.com/unldenis/tinyminiscript/issues/54

--- a/auto_build.sh
+++ b/auto_build.sh
@@ -36,6 +36,10 @@ rust_miniscript() {
     execute_in_module "modules/rustminiscript" "$1"
 }
 
+tiny_miniscript() {
+    execute_in_module "modules/tinyminiscript" "$1"
+}
+
 btcd() {
     execute_in_module "modules/btcd" "$1"
 }
@@ -85,7 +89,7 @@ custom_mutator_p2p_message() {
 }
 
 # Define the list of modules
-modules="bitcoin_core rust_bitcoin rust_miniscript btcd nbitcoin embit lnd ldk nlightning clightning eclair lightning_kmp custom_mutator_bolt11 custom_mutator_bolt12_offer custom_mutator_p2p_message"
+modules="bitcoin_core rust_bitcoin rust_miniscript tiny_miniscript btcd nbitcoin embit lnd ldk nlightning clightning eclair lightning_kmp custom_mutator_bolt11 custom_mutator_bolt12_offer custom_mutator_p2p_message"
 
 # Full clean: runs `make clean` in all module directories
 full_clean() {

--- a/main.cpp
+++ b/main.cpp
@@ -16,6 +16,10 @@
 #include <modules/rustminiscript/module.h>
 #endif
 
+#ifdef TINY_MINISCRIPT
+#include <modules/tinyminiscript/module.h>
+#endif
+
 #ifdef BTCD
 #include <modules/btcd/module.h>
 #endif
@@ -526,6 +530,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 #endif
 #ifdef RUST_MINISCRIPT
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::Rustminiscript>());
+#endif
+#ifdef TINY_MINISCRIPT
+  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Tinyminiscript>());
 #endif
 #ifdef BTCD
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::Btcd>());

--- a/modules/tinyminiscript/Makefile
+++ b/modules/tinyminiscript/Makefile
@@ -1,0 +1,34 @@
+all: module.a
+
+CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer -std=c++20 -I ../../include
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S), Darwin)
+  TINY_LIB_EXT := dylib
+else
+  TINY_LIB_EXT := so
+endif
+
+TINY_MINISCRIPT_LIB_PATH := ./tiny_miniscript_lib/target/release/libtiny_miniscript_lib.so
+
+cargo:
+	cd tiny_miniscript_lib && \
+	RUSTFLAGS="\
+		-Z sanitizer=address \
+		-C passes=sancov-module \
+		-C llvm-args=-sanitizer-coverage-inline-8bit-counters \
+		-C llvm-args=-sanitizer-coverage-trace-compares \
+		-C llvm-args=-sanitizer-coverage-pc-table \
+		-C llvm-args=-sanitizer-coverage-level=4 \
+		-C llvm-args=-simplifycfg-branch-fold-threshold=0" \
+	cargo +nightly build --release
+	cp $(TINY_MINISCRIPT_LIB_PATH) ../../libtiny_miniscript_lib.so
+
+module.a: module.o $(TINY_MINISCRIPT_LIB_PATH)
+	ar rcs module.a module.o
+
+module.o: module.cpp module.h
+	$(CXX) $(CXXFLAGS) -I . -fPIC -c module.cpp -o module.o
+
+clean:
+	rm -rf *.o module.a

--- a/modules/tinyminiscript/module.cpp
+++ b/modules/tinyminiscript/module.cpp
@@ -1,0 +1,16 @@
+#include <span>
+#include "module.h"
+#include "./tiny_miniscript_lib/tiny_miniscript_lib.h"
+
+namespace bitcoinfuzz
+{
+    namespace module
+    {
+        Tinyminiscript::Tinyminiscript(void) : BaseModule("Tinyminiscript") {}
+
+        std::optional<bool> Tinyminiscript::descriptor_parse(std::string str) const
+        {
+            return tiny_miniscript_descriptor_parse(str.c_str());
+        }
+    }
+}

--- a/modules/tinyminiscript/module.h
+++ b/modules/tinyminiscript/module.h
@@ -1,0 +1,21 @@
+#include <optional>
+#include <span>
+#include <vector>
+#include <cstddef>
+#include <cstdint>
+#include <bitcoinfuzz/basemodule.h>
+
+namespace bitcoinfuzz
+{
+    namespace module
+    {
+        class Tinyminiscript : public BaseModule
+        {
+        public:
+            Tinyminiscript(void);
+            std::optional<bool> descriptor_parse(std::string str) const override;
+            ~Tinyminiscript() noexcept override = default;
+        };
+
+    }
+}

--- a/modules/tinyminiscript/tiny_miniscript_lib/Cargo.toml
+++ b/modules/tinyminiscript/tiny_miniscript_lib/Cargo.toml
@@ -1,0 +1,11 @@
+[lib]
+name = "tiny_miniscript_lib"
+crate-type = ["cdylib"]
+
+[package]
+name = "tiny_miniscript_lib"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tinyminiscript = { git = "https://github.com/unldenis/tinyminiscript", rev = "109851742af9e609ad44924e45d43fbd7a0ea9a5" }

--- a/modules/tinyminiscript/tiny_miniscript_lib/src/lib.rs
+++ b/modules/tinyminiscript/tiny_miniscript_lib/src/lib.rs
@@ -1,0 +1,22 @@
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::str::Utf8Error;
+
+use tinyminiscript::Context;
+
+unsafe fn c_str_to_str<'a>(input: *const c_char) -> Result<&'a str, Utf8Error> {
+    CStr::from_ptr(input).to_str()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn tiny_miniscript_descriptor_parse(input: *const c_char) -> bool {
+    let Ok(desc) = c_str_to_str(input) else {
+        return false;
+    };
+
+    let ts_descriptor = Context::try_from(desc);
+    match ts_descriptor {
+        Err(_) => false,
+        Ok(_) => true,
+    }
+}

--- a/modules/tinyminiscript/tiny_miniscript_lib/tiny_miniscript_lib.h
+++ b/modules/tinyminiscript/tiny_miniscript_lib/tiny_miniscript_lib.h
@@ -1,0 +1,3 @@
+#include <cstdint>
+
+extern "C" bool tiny_miniscript_descriptor_parse(const char* input);


### PR DESCRIPTION
To avoid the annoying static library link error due to secp256k1 (#90), I chose to compile the Tiny Miniscript Library as a shared library. This makes it possible to perform differential fuzzing between Rust-Miniscript and Tiny Miniscript.

The shared library works very well. It is instrumented and has coverage sanitizers, so I don't think there are any side effects of using a shared library instead of a static library.

Closes #313