### PR TITLE
fix: skip wrong_funding TLV (type 100) in shutdown messages

### DIFF
--- a/modules/clightning/module.cpp
+++ b/modules/clightning/module.cpp
@@ -535,6 +535,16 @@ std::optional<std::string> clightning_parse_p2p_lightning_message(std::span<cons
             return "";
         }
 
+        if (tlvs->fields) {
+            for (size_t i = 0; i < tal_count(tlvs->fields); i++) {
+                // In case we receive a wrong_funding TLV, we must skip it.
+                // Since other implementations don't parse this even TLV.
+                if (tlvs->fields[i].numtype == 100) {
+                    return std::nullopt;
+                }
+            }
+        }
+
         result << "MSG_TYPE=shutdown;CHANNEL_ID=" << fmt_channel_id(tmpctx, &channel);
         result << ";SCRIPTPUBKEY=" << tal_hex(tmpctx, scriptpubkey);
     } else if (msg_type == WIRE_CLOSING_SIGNED) {


### PR DESCRIPTION
Core Lightning parses an even TLV type 100 (wrong_funding) in shutdown messages that other Lightning implementations don't recognize. Since even TLV types are required to be understood by all implementations, receiving this TLV from Core Lightning would cause parsing failures in other clients.

Skip messages containing this TLV to maintain compatibility across different Lightning Network implementations.

The crash:
```
Lightning P2P message parsing failed
Module: Ldk
Result:
Module: CLightning
Result: MSG_TYPE=shutdown;CHANNEL_ID=2172647600000aae5e5d5e02a102a1a1a1a1a114a1a1a105216424a10172bf76;SCRIPTPUBKEY=
bitcoinfuzz: driver.cpp:413: void bitcoinfuzz::Driver::ParseLightningP2pMessageTarget(std::span<const uint8_t>) const: Assertion `*res == *last_response' failed.
```