### PR TITLE
Add target for libbitcoinkernel bindings

### DIFF
--- a/.github/workflows/commit-by-commit-build.yml
+++ b/.github/workflows/commit-by-commit-build.yml
@@ -120,13 +120,13 @@ jobs:
       - name: Install build dependencies - macOS
         if: matrix.os == 'macos-14'
         run: |
-          brew install autoconf gnu-sed automake libtool gettext pkg-config protobuf libsodium lowdown
+          brew install autoconf gnu-sed automake libtool gettext pkg-config protobuf libsodium lowdown boost
 
       - name: Install build dependencies - Ubuntu
         if: matrix.os == 'ubuntu-24.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y lowdown libsodium-dev
+          sudo apt-get install -y lowdown libsodium-dev libboost-all-dev
 
       - name: Setup common environment - Ubuntu
         if: matrix.os == 'ubuntu-24.04'

--- a/.github/workflows/commit-by-commit-build.yml
+++ b/.github/workflows/commit-by-commit-build.yml
@@ -168,6 +168,25 @@ jobs:
           rustup default nightly
           cd modules/rustbitcoin && make cargo && make
 
+      - name: Build - rust-bitcoinkernel
+        timeout-minutes: 5
+        run: |
+          if [ -d "modules/rustbitcoinkernel" ]; then
+            rustup default nightly
+            cd modules/rustbitcoinkernel && make cargo && make
+          else
+            echo "Skipping rust-bitcoinkernel (not present in this commit)"
+          fi
+
+      - name: Build - pybitcoinkernel
+        timeout-minutes: 5
+        run: |
+          if [ -d "modules/pybitcoinkernel" ]; then
+            cd modules/pybitcoinkernel && make
+          else
+            echo "Skipping pybitcoinkernel (not present in this commit)"
+          fi
+
       - name: Build - rust miniscript
         timeout-minutes: 5
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -44,15 +44,6 @@ jobs:
         with:
           dotnet-version: "9.0.x"
 
-      - name: Setup Python and install embit
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - run: |
-          python -m pip install --upgrade pip
-          pip install -r modules/embit/requirements.txt
-          pip install mako
-
       - name: Install LLVM and Clang - macOS
         if: matrix.os == 'macos-14'
         run: |
@@ -95,6 +86,16 @@ jobs:
           echo "CC=$CC" >> build.env
           echo "CXX=$CXX" >> build.env
 
+      - name: Setup Python and install embit and pybitcoinkernel
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: |
+          python -m pip install --upgrade pip
+          pip install -r modules/embit/requirements.txt
+          pip install -r modules/pybitcoinkernel/requirements.txt
+          pip install mako
+
       - name: Build - Bitcoin Core
         timeout-minutes: 40
         run: |
@@ -134,6 +135,11 @@ jobs:
         timeout-minutes: 5
         run: |
           cd modules/embit && make
+
+      - name: Build - pybitcoinkernel
+        timeout-minutes: 5
+        run: |
+          cd modules/pybitcoinkernel && make
 
       - name: Build - lnd
         timeout-minutes: 5
@@ -222,6 +228,10 @@ jobs:
           - corpus: "psbt_parse_clean"
             target: "psbt_parse"
             cxxflags: "-DBITCOIN_CORE -DRUST_BITCOIN -DBTCD -DNBITCOIN"
+            asan_options: "detect_leaks=0:detect_container_overflow=0"
+          - corpus: "kernel_block"
+            target: "kernel_block"
+            cxxflags: "-DPYBITCOINKERNEL"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "cmpctblocks_parse"
             target: "cmpctblocks_parse"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -52,13 +52,13 @@ jobs:
       - name: Install build dependencies - macOS
         if: matrix.os == 'macos-14'
         run: |
-          brew install autoconf gnu-sed automake libtool gettext pkg-config protobuf libsodium lowdown
+          brew install autoconf gnu-sed automake libtool gettext pkg-config protobuf libsodium lowdown boost
 
       - name: Install build dependencies - Ubuntu
         if: matrix.os == 'ubuntu-24.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y lowdown libsodium-dev
+          sudo apt-get install -y lowdown libsodium-dev libboost-all-dev
 
       - name: Setup common environment - Ubuntu
         if: matrix.os == 'ubuntu-24.04'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -115,6 +115,12 @@ jobs:
           rustup default nightly
           cd modules/rustbitcoin && make cargo && make
 
+      - name: Build - rust-bitcoinkernel
+        timeout-minutes: 5
+        run: |
+          rustup default nightly
+          cd modules/rustbitcoinkernel && make cargo && make
+
       - name: Build - rust miniscript
         timeout-minutes: 5
         run: |
@@ -231,7 +237,7 @@ jobs:
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "kernel_block"
             target: "kernel_block"
-            cxxflags: "-DPYBITCOINKERNEL"
+            cxxflags: "-DPYBITCOINKERNEL -DRUSTBITCOINKERNEL"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "cmpctblocks_parse"
             target: "cmpctblocks_parse"

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ ifneq ($(findstring -DPYBITCOINKERNEL,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
 	MODULES += modules/pybitcoinkernel/module.a
 endif
 
+ifneq ($(findstring -DRUSTBITCOINKERNEL,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+	MODULES += modules/rustbitcoinkernel/module.a
+endif
+
 ifneq ($(findstring -DCLIGHTNING,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
 	MODULES += modules/clightning/module.a
 endif

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ ifneq ($(findstring -DEMBIT,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
 	MODULES += modules/embit/module.a
 endif
 
+ifneq ($(findstring -DPYBITCOINKERNEL,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+	MODULES += modules/pybitcoinkernel/module.a
+endif
+
 ifneq ($(findstring -DCLIGHTNING,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
 	MODULES += modules/clightning/module.a
 endif
@@ -99,6 +103,10 @@ SODIUM_LDLIBS = $(shell pkg-config --silence-errors --libs libsodium 2>/dev/null
 
 # Check for EMBIT define and add Python-related flags
 ifneq ($(findstring -DEMBIT,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+  PYTHON_LDFLAGS := $(shell python3-config --ldflags --embed)
+endif
+
+ifneq ($(findstring -DPYBITCOINKERNEL,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
   PYTHON_LDFLAGS := $(shell python3-config --ldflags --embed)
 endif
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,22 @@ If you prefer, you can still build the modules manually. Below are the steps for
     export CXXFLAGS="$CXXFLAGS -DEMBIT"
     ```
 
+- ### py-bitcoinkernel
+
+    To run the fuzzer with `py-bitcoinkernel` module, you need to install the `py-bitcoinkernel` library.
+
+    To install the `py-bitcoinkernel` library, you can use the following command:
+    ```bash
+    cd modules/pybitcoinkernel
+    pip install -r ./requirements.txt
+    ```
+
+    ```bash
+    cd modules/pybitcoinkernel
+    make
+    export CXXFLAGS="$CXXFLAGS -DPYBITCOINKERNEL"
+    ```
+
 - ### Bitcoin Core
 
     ```bash

--- a/README.md
+++ b/README.md
@@ -222,6 +222,13 @@ If you prefer, you can still build the modules manually. Below are the steps for
     export CXXFLAGS="$CXXFLAGS -DEMBIT"
     ```
 
+- ### rust-bitcoinkernel
+
+    ```bash
+    cd modules/rustbitcoinkernel
+    make cargo && make
+    export CXXFLAGS="$CXXFLAGS -DRUSTBITCOINKERNEL"
+
 - ### py-bitcoinkernel
 
     To run the fuzzer with `py-bitcoinkernel` module, you need to install the `py-bitcoinkernel` library.

--- a/auto_build.sh
+++ b/auto_build.sh
@@ -92,8 +92,16 @@ custom_mutator_p2p_message() {
     execute_in_module "custommutator" "$1"
 }
 
+rustbitcoinkernel() {
+    execute_in_module "modules/rustbitcoinkernel" "$1"
+}
+
+pybitcoinkernel() {
+    execute_in_module "modules/pybitcoinkernel" "$1"
+}
+
 # Define the list of modules
-modules="bitcoin_core rust_bitcoin rust_miniscript tiny_miniscript btcd nbitcoin embit lnd ldk nlightning clightning eclair lightning_kmp bitcoinj custom_mutator_bolt11 custom_mutator_bolt12_offer custom_mutator_p2p_message"
+modules="bitcoin_core rust_bitcoin rust_miniscript tiny_miniscript btcd nbitcoin embit lnd ldk nlightning clightning eclair lightning_kmp bitcoinj custom_mutator_bolt11 custom_mutator_bolt12_offer custom_mutator_p2p_message rustbitcoinkernel pybitcoinkernel"
 
 # Full clean: runs `make clean` in all module directories
 full_clean() {
@@ -149,7 +157,7 @@ for module in $modules; do
     module_name=$(echo "$module" | tr '[:lower:]' '[:upper:]')
     if echo "$CXXFLAGS" | grep -q "$module_name"; then
         case "$module" in
-            rust_bitcoin|rust_miniscript|ldk)
+            rust_bitcoin|rust_miniscript|ldk|rustbitcoinkernel)
                 $module "rustup default nightly && make cargo && make"
                 ;;
             *)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,18 @@ services:
     volumes:
       - ./docker/descriptor_parse:/app/data
 
+  kernel_block:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      <<: *common-env
+      CXXFLAGS: "-DPYBITCOINKERNEL"
+      FUZZ: kernel_block
+      ASAN_OPTIONS: detect_leaks=0
+    volumes:
+      - ./docker/kernel_block:/app/data
+
   miniscript_parse:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       dockerfile: Dockerfile
     environment:
       <<: *common-env
-      CXXFLAGS: "-DPYBITCOINKERNEL"
+      CXXFLAGS: "-DPYBITCOINKERNEL -DRUSTBITCOINKERNEL"
       FUZZ: kernel_block
       ASAN_OPTIONS: detect_leaks=0
     volumes:

--- a/driver.cpp
+++ b/driver.cpp
@@ -394,6 +394,31 @@ void Driver::TransactionEvalTarget(std::span<const uint8_t> buffer) const {
   }
 }
 
+void Driver::KernelBlockTarget(std::span<const uint8_t> buffer) const {
+  std::optional<std::string> last_response{std::nullopt};
+  std::string last_module_name;
+
+  for (auto &module : modules) {
+    std::optional<std::string> res{module.second->kernel_block(buffer)};
+    if (!res.has_value())
+      continue;
+    if (last_response.has_value()) {
+      if (*res != *last_response) {
+        std::cout << "Block parsing from libbitcoinkernel binding failed:"
+                  << std::endl;
+        std::cout << "Module: " << module.first << std::endl;
+        std::cout << "Result: " << *res << std::endl;
+        std::cout << "Module: " << last_module_name << std::endl;
+        std::cout << "Result: " << *last_response << std::endl;
+      }
+      assert(*res == *last_response);
+    }
+
+    last_response = res.value();
+    last_module_name = module.first;
+  }
+}
+
 void Driver::ParseLightningP2pMessageTarget(
     std::span<const uint8_t> buffer) const {
   std::optional<std::string> last_response{std::nullopt};
@@ -478,6 +503,8 @@ void Driver::Run(const uint8_t *data, const size_t size,
     this->TransactionEvalTarget(buffer);
   } else if (target == "bip32_master_keygen") {
     this->Bip32MasterKeygenTarget(buffer);
+  } else if (target == "kernel_block") {
+    this->KernelBlockTarget(buffer);
   } else {
     std::cout << "Target not defined!" << std::endl;
     assert(false);

--- a/driver.h
+++ b/driver.h
@@ -38,5 +38,6 @@ public:
   void ParseLightningP2pMessageTarget(std::span<const uint8_t> buffer) const;
   void TransactionEvalTarget(std::span<const uint8_t> buffer) const;
   void Bip32MasterKeygenTarget(std::span<const uint8_t> buffer) const;
+  void KernelBlockTarget(std::span<const uint8_t> buffer) const;
 };
 } // namespace bitcoinfuzz

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -37,6 +37,11 @@ BaseModule::script_asm(std::span<const uint8_t> buffer) const {
 }
 
 std::optional<std::string>
+BaseModule::kernel_block(std::span<const uint8_t> buffer) const {
+  return std::nullopt;
+}
+
+std::optional<std::string>
 BaseModule::deserialize_invoice(std::string str) const {
   return std::nullopt;
 }

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -43,6 +43,8 @@ public:
   transaction_eval(std::span<const uint8_t> buffer) const;
   virtual std::optional<std::string>
   bip32_master_keygen(std::span<const uint8_t> buffer) const;
+  virtual std::optional<std::string>
+  kernel_block(std::span<const uint8_t> buffer) const;
 
   virtual ~BaseModule() noexcept;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -48,6 +48,10 @@
 #include <modules/pybitcoinkernel/module.h>
 #endif
 
+#ifdef RUSTBITCOINKERNEL
+#include <modules/rustbitcoinkernel/module.h>
+#endif
+
 #ifdef EMBIT
 #include <modules/embit/module.h>
 #endif
@@ -119,6 +123,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 #endif
 #ifdef PYBITCOINKERNEL
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::Pybitcoinkernel>());
+#endif
+#ifdef RUSTBITCOINKERNEL
+  driver->LoadModule(
+      std::make_shared<bitcoinfuzz::module::Rustbitcoinkernel>());
 #endif
 #ifdef CLIGHTNING
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::CLightning>());

--- a/main.cpp
+++ b/main.cpp
@@ -44,6 +44,10 @@
 #include <modules/nlightning/module.h>
 #endif
 
+#ifdef PYBITCOINKERNEL
+#include <modules/pybitcoinkernel/module.h>
+#endif
+
 #ifdef EMBIT
 #include <modules/embit/module.h>
 #endif
@@ -112,6 +116,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 #endif
 #ifdef EMBIT
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::Embit>());
+#endif
+#ifdef PYBITCOINKERNEL
+  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Pybitcoinkernel>());
 #endif
 #ifdef CLIGHTNING
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::CLightning>());

--- a/modules/pybitcoinkernel/Makefile
+++ b/modules/pybitcoinkernel/Makefile
@@ -1,0 +1,23 @@
+all: module.a
+
+CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer -std=c++20 -I ../../include
+PYTHON_CFLAGS := $(shell python3-config --includes)
+
+module.a: module.o
+	$(AR) rcs $@ $^
+	ranlib $@
+	cp pybitcoinkernel_lib.py ../../main.py
+
+module.o: module.cpp module.h
+	$(CXX) $(CXXFLAGS) $(PYTHON_CFLAGS) -I . -fPIC -c $< -o $@
+
+format:
+	clang-format -i ./module.cpp ./module.h
+	black ./pybitcoinkernel_lib.py
+
+check-format:
+	clang-format -Werror --fail-on-incomplete-format -n ./module.cpp ./module.h
+	black --check ./pybitcoinkernel_lib.py
+
+clean:
+	rm -rf *.o *.a ./pybitcoinkernel_lib/pybitcoinkernel_lib.o ../../main.py

--- a/modules/pybitcoinkernel/module.cpp
+++ b/modules/pybitcoinkernel/module.cpp
@@ -1,0 +1,122 @@
+#include "module.h"
+#include <Python.h>
+#include <cstring>
+#include <iostream>
+#include <span>
+#include <string>
+
+template <typename InputType, typename ReturnType>
+static ReturnType
+call_python_function(const InputType input, size_t input_len,
+                     const char *function_name,
+                     PyObject *(*create_input_object)(const InputType, size_t),
+                     ReturnType (*convert_result)(PyObject *)) {
+  if (!Py_IsInitialized()) {
+    Py_Initialize();
+    PyRun_SimpleString("import sys; sys.path.append('.')");
+  }
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+
+  ReturnType return_value = {};
+  PyObject *main_module = NULL;
+  PyObject *parse_func = NULL;
+  PyObject *args = NULL;
+  PyObject *result = NULL;
+  PyObject *input_obj = NULL;
+
+  // Import the main Python module containing the parser function
+  main_module = PyImport_ImportModule("main");
+  if (!main_module) {
+    goto cleanup;
+  }
+
+  // Get the parser function from the module
+  parse_func = PyObject_GetAttrString(main_module, function_name);
+  if (!parse_func || !PyCallable_Check(parse_func)) {
+    goto cleanup;
+  }
+
+  // Create Python object from input
+  input_obj = create_input_object(input, input_len);
+  if (!input_obj) {
+    goto cleanup;
+  }
+
+  // Create arguments for the function call
+  args = PyTuple_New(1);
+  if (!args) {
+    goto cleanup;
+  }
+
+  // Add the input object to the tuple
+  if (PyTuple_SetItem(args, 0, input_obj) < 0) {
+    goto cleanup;
+  }
+  input_obj = NULL; // Ownership transferred to args
+
+  // Call the Python function
+  result = PyObject_CallObject(parse_func, args);
+  if (!result) {
+    goto cleanup;
+  }
+
+  // Convert the Python result to the C++ return type
+  return_value = convert_result(result);
+
+cleanup:
+  Py_XDECREF(result);
+  Py_XDECREF(args);
+  Py_XDECREF(parse_func);
+  Py_XDECREF(main_module);
+  Py_XDECREF(input_obj);
+
+  if (PyErr_Occurred()) {
+    PyObject *ptype, *pvalue, *ptraceback;
+    PyErr_Fetch(&ptype, &pvalue, &ptraceback);
+
+    Py_XDECREF(ptype);
+    Py_XDECREF(pvalue);
+    Py_XDECREF(ptraceback);
+  }
+
+  PyGILState_Release(gstate);
+
+  return return_value;
+}
+
+static PyObject *create_bytes_object(const uint8_t *data, size_t len) {
+  return PyBytes_FromStringAndSize((const char *)data, len);
+}
+
+static char *convert_to_string(PyObject *result) {
+  if (PyUnicode_Check(result)) {
+    const char *temp = PyUnicode_AsUTF8(result);
+    if (temp) {
+      return strdup(temp);
+    }
+  }
+  return NULL;
+}
+
+char *block_parse(const uint8_t *data, size_t len) {
+  return call_python_function<const uint8_t *, char *>(
+      data, len, "block_parse", create_bytes_object, convert_to_string);
+}
+
+namespace bitcoinfuzz {
+namespace module {
+Pybitcoinkernel::Pybitcoinkernel(void) : BaseModule("Pybitcoinkernel") {}
+
+std::optional<std::string>
+Pybitcoinkernel::kernel_block(std::span<const uint8_t> buffer) const {
+  auto result_ptr = block_parse(buffer.data(), buffer.size());
+  if (result_ptr == nullptr)
+    return std::nullopt;
+
+  std::string result(result_ptr);
+  free(result_ptr);
+  return result;
+}
+} // namespace module
+} // namespace bitcoinfuzz

--- a/modules/pybitcoinkernel/module.h
+++ b/modules/pybitcoinkernel/module.h
@@ -1,0 +1,19 @@
+#include <bitcoinfuzz/basemodule.h>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace bitcoinfuzz {
+namespace module {
+class Pybitcoinkernel : public BaseModule {
+public:
+  Pybitcoinkernel(void);
+  std::optional<std::string>
+  kernel_block(std::span<const uint8_t> buffer) const override;
+  ~Pybitcoinkernel() noexcept override = default;
+};
+
+} // namespace module
+} // namespace bitcoinfuzz

--- a/modules/pybitcoinkernel/pybitcoinkernel_lib.py
+++ b/modules/pybitcoinkernel/pybitcoinkernel_lib.py
@@ -1,0 +1,9 @@
+import pbk
+
+
+def block_parse(data: bytes):
+    try:
+        block = pbk.Block(data)
+        return str(block.block_hash)
+    except Exception as _:
+        return "0"

--- a/modules/pybitcoinkernel/pybitcoinkernel_lib.py
+++ b/modules/pybitcoinkernel/pybitcoinkernel_lib.py
@@ -4,6 +4,9 @@ import pbk
 def block_parse(data: bytes):
     try:
         block = pbk.Block(data)
-        return str(block.block_hash)
+        res = str(block.block_hash)
+        for tx in block.transactions:
+            res += "txid=" + str(tx.txid) + ";"
+        return res
     except Exception as _:
         return "0"

--- a/modules/pybitcoinkernel/requirements.txt
+++ b/modules/pybitcoinkernel/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/stickies-v/py-bitcoinkernel.git@main

--- a/modules/rustbitcoinkernel/Makefile
+++ b/modules/rustbitcoinkernel/Makefile
@@ -1,0 +1,34 @@
+all: module.a
+
+CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer-no-link -std=c++20 -I ../../include
+RUST_LIB_PATH := ./rustbitcoinkernel_lib/target/release/librustbitcoinkernel_lib.a
+
+cargo:
+	cd rustbitcoinkernel_lib && \
+	RUSTFLAGS="\
+		-Z sanitizer=address \
+		-C passes=sancov-module \
+		-C llvm-args=-sanitizer-coverage-inline-8bit-counters \
+		-C llvm-args=-sanitizer-coverage-trace-compares \
+		-C llvm-args=-sanitizer-coverage-pc-table \
+		-C llvm-args=-sanitizer-coverage-level=4 \
+		-C llvm-args=-simplifycfg-branch-fold-threshold=0" \
+	cargo +nightly build --release
+
+module.a: module.o $(RUST_LIB_PATH)
+	bash ../../merge.sh module.a $(RUST_LIB_PATH) module.o
+	ranlib module.a
+
+module.o: module.cpp module.h
+	$(CXX) $(CXXFLAGS) -I . -fPIC -c module.cpp -o module.o
+
+format:
+	clang-format -i ./module.cpp ./module.h ./rustbitcoinkernel_lib/rustbitcoinkernel_lib.h
+	cd rustbitcoinkernel_lib && cargo fmt
+
+check-format:
+	clang-format -Werror --fail-on-incomplete-format -n ./module.cpp ./module.h ./rustbitcoinkernel_lib/rustbitcoinkernel_lib.h
+	cd rustbitcoinkernel_lib && cargo fmt --check
+
+clean:
+	rm -rf *.o module.a

--- a/modules/rustbitcoinkernel/module.cpp
+++ b/modules/rustbitcoinkernel/module.cpp
@@ -1,0 +1,21 @@
+#include <span>
+
+#include "module.h"
+#include "rustbitcoinkernel_lib/rustbitcoinkernel_lib.h"
+
+namespace bitcoinfuzz {
+namespace module {
+Rustbitcoinkernel::Rustbitcoinkernel(void) : BaseModule("Rustbitcoinkernel") {}
+
+std::optional<std::string>
+Rustbitcoinkernel::kernel_block(std::span<const uint8_t> buffer) const {
+  auto result_ptr = rustbitcoinkernel_block(buffer.data(), buffer.size());
+  if (result_ptr == nullptr)
+    return std::nullopt;
+
+  std::string result(result_ptr);
+  free_c_string(result_ptr);
+  return result;
+}
+} // namespace module
+} // namespace bitcoinfuzz

--- a/modules/rustbitcoinkernel/module.h
+++ b/modules/rustbitcoinkernel/module.h
@@ -1,0 +1,20 @@
+#include <bitcoinfuzz/basemodule.h>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace bitcoinfuzz {
+namespace module {
+class Rustbitcoinkernel : public BaseModule {
+public:
+  Rustbitcoinkernel(void);
+  std::optional<std::string>
+  kernel_block(std::span<const uint8_t> buffer) const override;
+  ~Rustbitcoinkernel() noexcept override = default;
+};
+
+} // namespace module
+} // namespace bitcoinfuzz

--- a/modules/rustbitcoinkernel/rustbitcoinkernel_lib/Cargo.toml
+++ b/modules/rustbitcoinkernel/rustbitcoinkernel_lib/Cargo.toml
@@ -1,0 +1,11 @@
+[lib]
+name = "rustbitcoinkernel_lib"
+crate-type = ["staticlib"]
+
+[package]
+name = "rustbitcoinkernel_lib"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bitcoinkernel = "0.1.1"

--- a/modules/rustbitcoinkernel/rustbitcoinkernel_lib/rustbitcoinkernel_lib.h
+++ b/modules/rustbitcoinkernel/rustbitcoinkernel_lib/rustbitcoinkernel_lib.h
@@ -1,0 +1,4 @@
+#include <cstdint>
+
+extern "C" char *rustbitcoinkernel_block(const uint8_t *data, size_t len);
+extern "C" void free_c_string(char *ptr);

--- a/modules/rustbitcoinkernel/rustbitcoinkernel_lib/src/lib.rs
+++ b/modules/rustbitcoinkernel/rustbitcoinkernel_lib/src/lib.rs
@@ -1,9 +1,8 @@
+use bitcoinkernel::core::TransactionExt;
 use bitcoinkernel::Block;
-use std::ffi::CStr;
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::slice;
-use std::str::Utf8Error;
 
 extern crate bitcoinkernel;
 
@@ -33,9 +32,12 @@ pub unsafe extern "C" fn rustbitcoinkernel_block(data: *const u8, len: usize) ->
         return str_to_c_string("0");
     };
 
-    str_to_c_string(&block.hash().to_string())
-}
+    let mut result = String::new();
+    result.push_str(&block.hash().to_string());
 
-unsafe fn c_str_to_str<'a>(input: *const c_char) -> Result<&'a str, Utf8Error> {
-    CStr::from_ptr(input).to_str()
+    for tx in block.transactions() {
+        result.push_str(&format!("txid={};", tx.txid().to_string()));
+    }
+
+    str_to_c_string(&result)
 }

--- a/modules/rustbitcoinkernel/rustbitcoinkernel_lib/src/lib.rs
+++ b/modules/rustbitcoinkernel/rustbitcoinkernel_lib/src/lib.rs
@@ -1,0 +1,41 @@
+use bitcoinkernel::Block;
+use std::ffi::CStr;
+use std::ffi::CString;
+use std::os::raw::c_char;
+use std::slice;
+use std::str::Utf8Error;
+
+extern crate bitcoinkernel;
+
+unsafe fn str_to_c_string(input: &str) -> *mut c_char {
+    CString::new(input).unwrap().into_raw()
+}
+
+/// Frees a C string created by `str_to_c_string`.
+///
+/// # Safety
+/// The pointer must have been created by `str_to_c_string` and not yet freed.
+/// After calling this function, the pointer is invalid and must not be used.
+#[no_mangle]
+pub unsafe extern "C" fn free_c_string(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        // Convert the raw pointer back to a CString, which will be dropped
+        // and free the memory when it goes out of scope
+        let _ = CString::from_raw(ptr);
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rustbitcoinkernel_block(data: *const u8, len: usize) -> *mut c_char {
+    // Safety: Ensure that the data pointer is valid for the given length
+    let data_slice = slice::from_raw_parts(data, len);
+    let Ok(block) = Block::new(data_slice) else {
+        return str_to_c_string("0");
+    };
+
+    str_to_c_string(&block.hash().to_string())
+}
+
+unsafe fn c_str_to_str<'a>(input: *const c_char) -> Result<&'a str, Utf8Error> {
+    CStr::from_ptr(input).to_str()
+}


### PR DESCRIPTION
Fixes #347

This is just a skeleton of differential fuzzing of libbitcoinkernel bindings. This PR adds `rust-bitcoinkernel` and `pybitcoinkernel` as well as a simple target that deserializes a block and compares the block hash. In a follow-up PR, I will modify this target to deal with more informations (e.g. transaction data) and will add more bindings.