### PR TITLE
btcd: improve/fix Makefile

### DIFF
--- a/modules/btcd/Makefile
+++ b/modules/btcd/Makefile
@@ -2,11 +2,11 @@ CXXFLAGS += -Wall -Wextra -std=c++20 -I. -I ../../include -I./btcd_wrapper
 
 all: module.a
 
-module.a: golang module.o btcd_wrapper/libbtcd_wrapper.a
+module.a: module.o btcd_wrapper/libbtcd_wrapper.a
 	bash ../../merge.sh module.a btcd_wrapper/libbtcd_wrapper.a module.o
 	ranlib module.a
 
-golang:
+btcd_wrapper/libbtcd_wrapper.a:
 	cd btcd_wrapper && go build -o libbtcd_wrapper.a -buildmode=c-archive -tags=libfuzzer -gcflags=all=-d=libfuzzer wrapper.go
 
 module.o: module.cpp
@@ -14,3 +14,5 @@ module.o: module.cpp
 
 clean:
 	rm -f *.o *.a btcd_wrapper/*.a
+
+.PHONY: all clean


### PR DESCRIPTION
This PR updates the Makefile to make dependency tracking more accurate and avoid unnecessary rebuilds. It replaces the phony golang target with a real file target and update the module.a dependencies accordingly.