### PR TITLE
bitcoin/clightning: use symbol prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ corpus/
 docker/
 *.log
 .env
+*.map

--- a/modules/bitcoin/Makefile
+++ b/modules/bitcoin/Makefile
@@ -1,18 +1,25 @@
 all: module.a
 
+SYMBOL_PREFIX ?= bitcoin_core
+
+# Detect objcopy command
+OBJCOPY := $(shell command -v objcopy 2> /dev/null)
+ifeq ($(OBJCOPY),)
+$(error objcopy not found. Install with: apt-get install binutils)
+endif
+
 CXXFLAGS += -Wall -Wextra -std=c++20 \
             -fsanitize=fuzzer,address \
             -I . \
             -I ../../include \
-            -I /opt/homebrew/include \
             -I ./secp256k1/include \
             -I ./univalue/include \
             -I ./consensus \
             -I ./primitives \
             -I ./script
 
-SECP256K1_LIB = ../secp256k1/.libs/libsecp256k1.a
-UNIVALUE_LIB = ../univalue/build/libunivalue.a
+SECP256K1_LIB = secp256k1/.libs/libsecp256k1.a
+UNIVALUE_LIB = univalue/build/libunivalue.a
 MAKE = make
 
 # Automatically find all .cpp files
@@ -27,6 +34,7 @@ $(SECP256K1_LIB):
 		--enable-module-recovery \
 		--enable-experimental \
 		--enable-module-schnorrsig \
+		--enable-module-musig \
 		--disable-shared \
 		--with-pic \
 		CFLAGS="-fsanitize=address,fuzzer-no-link" && \
@@ -40,17 +48,64 @@ $(UNIVALUE_LIB):
 	cd build && \
 	$(MAKE) univalue
 
-module.a: $(SECP256K1_LIB) $(UNIVALUE_LIB) module.o cleanse.o $(BITCOIN_OBJS)
+# Generate symbol redefine map for ONLY secp256k1 symbols (exclude ASAN/sanitizer symbols)
+secp256k1_symbols.map: $(SECP256K1_LIB)
+	@echo "Generating comprehensive symbol map..."
+	@nm -g $(SECP256K1_LIB) | awk '{print $$3}' | grep '^secp256k1' | sort -u | while read sym; do \
+		echo "$$sym $(SYMBOL_PREFIX)_$$sym"; \
+	done > $@
+	@echo "Generated $(shell wc -l < $@) symbol mappings"
+
+# Compile all object files first (without dependencies to avoid recompilation)
+.PHONY: compile_objects
+compile_objects: module.o cleanse.o $(BITCOIN_OBJS)
+
+module.a: $(SECP256K1_LIB) $(UNIVALUE_LIB) secp256k1_symbols.map compile_objects
+	@echo "========================================"
+	@echo "Building module.a with symbol prefix: $(SYMBOL_PREFIX)"
+	@echo "========================================"
+
+	# Now rename symbols in all compiled object files
+	@echo "Renaming secp256k1 symbols in Bitcoin object files..."
+	@for obj in module.o cleanse.o $(BITCOIN_OBJS); do \
+		if [ -f "$$obj" ]; then \
+			echo "  Renaming symbols in $$obj..."; \
+			$(OBJCOPY) --redefine-syms=secp256k1_symbols.map $$obj; \
+		fi \
+	done
+
+	@echo "Verifying renamed symbols in pubkey.o:"
+	@nm pubkey.o | grep secp256k1 | head -3
+
+	# Create archive with renamed Bitcoin objects
+	@echo "Creating archive with renamed objects..."
 	$(AR) rcs $@ module.o cleanse.o $(BITCOIN_OBJS)
+
 	mkdir -p tmp_obj
-	# Extract and add secp256k1
-	cd tmp_obj && $(AR) x "$(SECP256K1_LIB)"
+	# Extract secp256k1 objects and rename ONLY secp256k1_* symbols
+	cd tmp_obj && $(AR) x ../$(SECP256K1_LIB)
+	@echo "Renaming only secp256k1_* symbols (preserving ASAN/sanitizer symbols)..."
+	cd tmp_obj && for obj in *.o; do \
+		for sym in $$(nm $$obj | grep ' T secp256k1' | awk '{print $$3}'); do \
+			$(OBJCOPY) --redefine-sym $$sym=$(SYMBOL_PREFIX)_$$sym $$obj 2>/dev/null || true; \
+		done; \
+		for sym in $$(nm $$obj | grep ' D secp256k1' | awk '{print $$3}'); do \
+			$(OBJCOPY) --redefine-sym $$sym=$(SYMBOL_PREFIX)_$$sym $$obj 2>/dev/null || true; \
+		done; \
+		for sym in $$(nm $$obj | grep ' B secp256k1' | awk '{print $$3}'); do \
+			$(OBJCOPY) --redefine-sym $$sym=$(SYMBOL_PREFIX)_$$sym $$obj 2>/dev/null || true; \
+		done; \
+	done
 	$(AR) rcs $@ tmp_obj/*.o
 	rm -rf tmp_obj/*
-	# Extract and add univalue
-	cd tmp_obj && $(AR) x "$(UNIVALUE_LIB)"
+
+	# Extract and add univalue WITHOUT prefixing (no conflicts)
+	cd tmp_obj && $(AR) x ../$(UNIVALUE_LIB)
+	@echo "Adding univalue symbols (no renaming needed)..."
 	$(AR) rcs $@ tmp_obj/*.o
 	rm -rf tmp_obj
+	@echo ""
+	@echo "✓ module.a built successfully with prefix: $(SYMBOL_PREFIX)"
 
 module.o: module.cpp module.h
 	$(CXX) $(CXXFLAGS) -I . -fPIC -c module.cpp -o module.o
@@ -63,14 +118,14 @@ cleanse.o: support/cleanse.cpp
 	$(CXX) $(CXXFLAGS) -fPIC -c $< -o $@
 
 clean:
-	rm -rf *.o **/*.o module.a tmp_obj/ *_combined.o
+	rm -rf *.o **/*.o module.a tmp_obj/ secp256k1_symbols.map
 	cd secp256k1 && $(MAKE) clean || true
 	cd univalue && rm -rf build || true
 
-format: 
+format:
 	clang-format -i ./module.cpp ./module.h
 
 check-format:
 	clang-format -Werror --fail-on-incomplete-format -n ./module.cpp ./module.h
 
-.PHONY: clean
+.PHONY: clean all format check-format compile_objects

--- a/modules/clightning/Makefile
+++ b/modules/clightning/Makefile
@@ -1,5 +1,4 @@
 CXXFLAGS += -Wall -Wextra -std=c++20 -fPIC
-
 INCLUDE_DIRS += -I.
 INCLUDE_DIRS += -I../../include
 INCLUDE_DIRS += -I../../external/lightning
@@ -7,8 +6,16 @@ INCLUDE_DIRS += -I../../external/lightning/ccan
 INCLUDE_DIRS += -I../../external/lightning/external/libwally-core/src/secp256k1/include
 INCLUDE_DIRS += -I../../external/lightning/external/libwally-core/include
 INCLUDE_DIRS += -I../../external/lightning/external/libsodium/src/libsodium/include
-
 CXXFLAGS += $(INCLUDE_DIRS)
+
+# Set default prefix, but allow user to override
+SYMBOL_PREFIX ?= clightning
+
+# Detect objcopy command
+OBJCOPY := $(shell command -v objcopy 2> /dev/null)
+ifeq ($(OBJCOPY),)
+$(error objcopy not found. Install with: apt-get install binutils)
+endif
 
 ROOT_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
 LIGHTNING_DIR := $(ROOT_DIR)/external/lightning
@@ -30,25 +37,66 @@ libcln.a: $(LIGHTNING_DIR)/config.vars
 	else \
 		echo "Makefile already includes clightning makefile content."; \
 	fi
-
 	@echo "Building lightning in $(LIGHTNING_DIR)..."
 	cd $(LIGHTNING_DIR) && make libcln.a
-
 	@echo "Copying static library in $(LIGHTNING_DIR)..."
 	cp $(LIGHTNING_DIR)/libcln.a $(LIBCLIGHTNING_WRAPPER)
 
-module.a: libcln.a module.o
-	bash ../../merge.sh module.a libcln.a module.o
+# Generate symbol redefine map for secp256k1 symbols only
+secp256k1_symbols.map: libcln.a
+	@echo "Generating symbol map for secp256k1 symbols..."
+	@nm -g libcln.a | grep ' T ' | awk '{print $$3}' | grep secp256k1 | sort -u | while read sym; do \
+		echo "$$sym $(SYMBOL_PREFIX)_$$sym"; \
+	done > $@
+	@nm -g libcln.a | grep ' D ' | awk '{print $$3}' | grep secp256k1 | sort -u | while read sym; do \
+		echo "$$sym $(SYMBOL_PREFIX)_$$sym"; \
+	done >> $@
+	@nm -g libcln.a | grep ' B ' | awk '{print $$3}' | grep secp256k1 | sort -u | while read sym; do \
+		echo "$$sym $(SYMBOL_PREFIX)_$$sym"; \
+	done >> $@
+	@echo "Generated $(shell wc -l < $@) symbol mappings"
+
+module.a: libcln.a secp256k1_symbols.map module.o
+	@echo "========================================"
+	@echo "Building module.a with symbol prefix: $(SYMBOL_PREFIX)"
+	@echo "========================================"
+
+	# First merge using the existing script
+	bash ../../merge.sh module_temp.a libcln.a module.o
+
+	# Apply selective symbol renaming (only secp256k1 symbols)
+	@echo "Extracting objects..."
+	mkdir -p tmp_obj
+	cd tmp_obj && ar x ../module_temp.a
+
+	@echo "Renaming secp256k1 symbols with $(SYMBOL_PREFIX)_ prefix..."
+	cd tmp_obj && for obj in *.o; do \
+		$(OBJCOPY) --redefine-syms=../secp256k1_symbols.map $$obj 2>/dev/null || true; \
+	done
+
+	# Create final archive
+	@echo "Creating final archive..."
+	ar rcs module.a tmp_obj/*.o
+	ranlib module.a
+
+	# Cleanup
+	rm -rf tmp_obj module_temp.a
+	@echo ""
+	@echo "✓ module.a built successfully with prefix: $(SYMBOL_PREFIX)"
+	@echo "Verifying renamed symbols (first 5):"
+	@nm module.a | grep secp256k1 | head -5
 
 module.o: module.cpp module.h
 	$(CXX) $(CXXFLAGS) -fPIC -c module.cpp -o module.o
 
-
-format: 
+format:
 	clang-format -i ./module.cpp ./module.h
 
 check-format:
 	clang-format -Werror --fail-on-incomplete-format -n ./module.cpp ./module.h
 
 clean:
-	rm -f *.o *.a
+	rm -f *.o *.a module_temp.a secp256k1_symbols.map
+	rm -rf tmp_obj
+
+.PHONY: all format check-format clean


### PR DESCRIPTION
This PR adds a symbol prefix to avoid having conflicts due to the secp library when building bitcoinfuzz with both clightning and Bitcoin Core.