### PR TITLE
clightning: fix global-buffer-overflow by renaming R symbols

### DIFF
--- a/modules/clightning/Makefile
+++ b/modules/clightning/Makefile
@@ -44,17 +44,11 @@ libcln.a: $(LIGHTNING_DIR)/config.vars
 
 # Generate symbol redefine map for secp256k1 symbols only
 secp256k1_symbols.map: libcln.a
-	@echo "Generating symbol map for secp256k1 symbols..."
-	@nm -g libcln.a | grep ' T ' | awk '{print $$3}' | grep secp256k1 | sort -u | while read sym; do \
+	@echo "Generating symbol map for ALL secp256k1 symbols..."
+	@nm libcln.a | awk '/ [TDBR] / && /secp256k1/ {print $$3}' | sort -u | while read sym; do \
 		echo "$$sym $(SYMBOL_PREFIX)_$$sym"; \
 	done > $@
-	@nm -g libcln.a | grep ' D ' | awk '{print $$3}' | grep secp256k1 | sort -u | while read sym; do \
-		echo "$$sym $(SYMBOL_PREFIX)_$$sym"; \
-	done >> $@
-	@nm -g libcln.a | grep ' B ' | awk '{print $$3}' | grep secp256k1 | sort -u | while read sym; do \
-		echo "$$sym $(SYMBOL_PREFIX)_$$sym"; \
-	done >> $@
-	@echo "Generated $(shell wc -l < $@) symbol mappings"
+	@echo "Generated $$(wc -l < $@) symbol mappings"
 
 module.a: libcln.a secp256k1_symbols.map module.o
 	@echo "========================================"


### PR DESCRIPTION
The `secp256k1_ecmult_gen_prec_table` (read-only data) was not being renamed, causing ASan to detect a global-buffer-overflow when the unprefixed symbol collided with other global data in memory.

Adding 'R' to the symbol filter ensures read-only data symbols like precomputed tables are properly prefixed, preventing the collision.

Note: This might also be an issue in bitcoin core module but I couldn't replicate on my machine.

log:
```
#1 0x560767b6d6f1 in secp256k1_ec_pubkey_create (/home/erick/bitcoinfuzz/bitcoinfuzz+0xfbd6f1) (BuildId: 95bbf510af82c97d979ba27c105fd437a5940782)
    #2 0x5607671a2dbf in generate_keypair(unsigned char*, unsigned char*) main.cpp
    #3 0x56076719ecda in mutate_packet_keys(unsigned char*) main.cpp
    #4 0x56076719e2ee in LLVMFuzzerCustomMutator (/home/erick/bitcoinfuzz/bitcoinfuzz+0x5ee2ee) (BuildId: 95bbf510af82c97d979ba27c105fd437a5940782)
    #5 0x5607670af3d4 in fuzzer::MutationDispatcher::MutateImpl(unsigned char*, unsigned long, unsigned long, std::vector<fuzzer::MutationDispatcher::Mutator, std::allocator<fuzzer::MutationDispatcher::Mutator>>&) (/home/erick/bitcoinfuzz/bitcoinfuzz+0x4ff3d4) (BuildId: 95bbf510af82c97d979ba27c105fd437a5940782)
    #6 0x56076709c712 in fuzzer::Fuzzer::MutateAndTestOne() (/home/erick/bitcoinfuzz/bitcoinfuzz+0x4ec712) (BuildId: 95bbf510af82c97d979ba27c105fd437a5940782)
    #7 0x56076709d225 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile>>&) (/home/erick/bitcoinfuzz/bitcoinfuzz+0x4ed225) (BuildId: 95bbf510af82c97d979ba27c105fd437a5940782)
    #8 0x56076708a605 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/erick/bitcoinfuzz/bitcoinfuzz+0x4da605) (BuildId: 95bbf510af82c97d979ba27c105fd437a5940782)
    #9 0x5607670b5162 in main (/home/erick/bitcoinfuzz/bitcoinfuzz+0x505162) (BuildId: 95bbf510af82c97d979ba27c105fd437a5940782)
    #10 0x7f4fe863ed8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
    #11 0x7f4fe863ee3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 4f7b0c955c3d81d7cac1501a2498b69d1d82bfe7)
    #12 0x56076707f204 in _start (/home/erick/bitcoinfuzz/bitcoinfuzz+0x4cf204) (BuildId: 95bbf510af82c97d979ba27c105fd437a5940782)
0x560767ee0929 is located 0 bytes after global variable '.str' defined in '/home/erick/bitcoinfuzz/external/lightning/common/onionreply.c:15' (0x560767ee0900) of size 41
  '.str' is ascii string 'common/onionreply.c:15:struct onionreply'
SUMMARY: AddressSanitizer: global-buffer-overflow secp256k1.c in secp256k1_ecmult_gen
Shadow bytes around the buggy address:
  0x560767ee0680: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x560767ee0700: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x560767ee0780: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x560767ee0800: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x560767ee0880: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x560767ee0900: 00 00 00 00 00[01]f9 f9 f9 f9 f9 f9 00 00 00 00
  0x560767ee0980: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x560767ee0a00: 00 01 f9 f9 f9 f9 f9 f9 00 00 00 04 f9 f9 f9 f9
  0x560767ee0a80: 00 00 00 00 00 01 f9 f9 f9 f9 f9 f9 00 00 00 04
  0x560767ee0b00: f9 f9 f9 f9 00 00 00 00 00 00 06 f9 f9 f9 f9 f9
  0x560767ee0b80: 00 00 00 00 00 00 00 00 03 f9 f9 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==282056==ABORTING
MS: 6 Custom-Custom-CMP-Custom-CopyPart-Custom- DE: "addrv2"-; base unit: 73a61065b4036621de722cb0048798119af4fb60
artifact_prefix='./'; Test unit written to ./crash-da39a3ee5e6b4b0d3255bfef95601890afd80709
Base64:

INFO: found LLVMFuzzerCustomMutator (0x56076719df50). Disabling -len_control by default.
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 1617150955
INFO: Loaded 1 modules   (153426 inline 8-bit counters): 153426 [0x560768064e80, 0x56076808a5d2),
INFO: Loaded 1 PC tables (153426 PCs): 153426 [0x56076808a5d8,0x5607682e1af8),
INFO:     7848 files found in ../corpora/decode_onion/
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
=== BitcoinFuzz Module Activation Log ===
Target: decode_onion
Loaded Modules (2):
  [1] Ldk
  [2] CLightning
Active Custom Mutators:
  - Onion Custom Mutator
=========================================
INFO: seed corpus: files: 7848 min: 1398b max: 1398b total: 10971504b rss: 50Mb
#7850   INITED cov: 1432 ft: 2448 corp: 185/252Kb exec/s: 2616 rss: 278Mb
=================================================================
==282056==ERROR: AddressSanitizer: global-buffer-overflow on address 0x560767ee0928 at pc 0x560767bb967a bp 0x7ffc7aec65f0 sp 0x7ffc7aec65e8
READ of size 8 at 0x560767ee0928 thread T0
    #0 0x560767bb9679 in secp256k1_ecmult_gen secp256k1.c
```