### PR TITLE
Add Schnorr signing fuzz target to secp256k1 module

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -190,6 +190,9 @@ jobs:
             target: "ecdh"
             cxxflags: "-DDECRED_SECP256K1 -DSECP256K1"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
+          - corpus: "sign_schnorr"
+            target: "sign_schnorr"
+            cxxflags: "-DBTCD -DSECP256K1"
 
     steps:
       - name: Checkout repo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,3 +260,15 @@ services:
     env_file: .env
     volumes:
       - ./docker:/app/data
+
+  sign_schnorr:
+    build:
+      context: .
+      tags:
+        - bitcoinfuzz:sign_schnorr
+      args:
+        CXXFLAGS: "-DSECP256K1 -DBTCD"
+        FUZZ: sign_schnorr
+    env_file: .env
+    volumes:
+      - ./docker:/app/data

--- a/driver.cpp
+++ b/driver.cpp
@@ -612,6 +612,38 @@ void Driver::ECDHTarget(std::span<const uint8_t> buffer) const {
   }
 }
 
+void Driver::SignSchnorrTarget(std::span<const uint8_t> buffer) const {
+  FuzzedDataProvider provider(buffer.data(), buffer.size());
+  if (buffer.size() < 96)
+    return;
+
+  std::vector<uint8_t> privkey_buffer = provider.ConsumeBytes<uint8_t>(32);
+  std::vector<uint8_t> hash_buffer = provider.ConsumeBytes<uint8_t>(32);
+  std::vector<uint8_t> aux_buffer = provider.ConsumeBytes<uint8_t>(32);
+  std::optional<std::string> last_response{std::nullopt};
+  std::string last_module_name;
+
+  for (auto &module : modules) {
+    std::optional<std::string> res{
+        module.second->sign_schnorr(privkey_buffer, hash_buffer, aux_buffer)};
+    if (!res.has_value())
+      continue;
+    if (last_response.has_value()) {
+      if (*res != *last_response) {
+        std::cout << "SignSchnorr Target failed" << std::endl;
+        std::cout << "Module: " << module.first << std::endl;
+        std::cout << "Result: " << *res << std::endl;
+        std::cout << "Module: " << last_module_name << std::endl;
+        std::cout << "Result: " << *last_response << std::endl;
+      }
+      assert(*res == *last_response);
+    }
+
+    last_response = res.value();
+    last_module_name = module.first;
+  }
+}
+
 void Driver::Run(const uint8_t *data, const size_t size,
                  const std::string &target) const {
   std::span<const uint8_t> buffer{data, size};
@@ -657,6 +689,8 @@ void Driver::Run(const uint8_t *data, const size_t size,
     this->SignVerifyTarget(buffer);
   } else if (target == "ecdh") {
     this->ECDHTarget(buffer);
+  } else if (target == "sign_schnorr") {
+    this->SignSchnorrTarget(buffer);
   } else {
     std::cout << "Target not defined!" << std::endl;
     assert(false);

--- a/driver.h
+++ b/driver.h
@@ -43,5 +43,6 @@ public:
   void SignDerTarget(std::span<const uint8_t> buffer) const;
   void SignVerifyTarget(std::span<const uint8_t> buffer) const;
   void ECDHTarget(std::span<const uint8_t> buffer) const;
+  void SignSchnorrTarget(std::span<const uint8_t> buffer) const;
 };
 } // namespace bitcoinfuzz

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -115,4 +115,11 @@ BaseModule::ecdh(std::span<const uint8_t> buffer,
   return std::nullopt;
 }
 
+std::optional<std::string>
+BaseModule::sign_schnorr(std::span<const uint8_t> buffer,
+                         std::span<const uint8_t> hash,
+                         std::span<const uint8_t> aux) const {
+  return std::nullopt;
+}
+
 } // namespace bitcoinfuzz

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -57,6 +57,10 @@ public:
   virtual std::optional<std::string>
   ecdh(std::span<const uint8_t> buffer, std::span<const uint8_t> pubkey) const;
 
+  virtual std::optional<std::string>
+  sign_schnorr(std::span<const uint8_t> buffer, std::span<const uint8_t> hash,
+               std::span<const uint8_t> aux) const;
+
   virtual ~BaseModule() noexcept;
 };
 } // namespace bitcoinfuzz

--- a/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
+++ b/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
@@ -95,6 +95,7 @@ extern char* BTCDTransactionEval(ByteArray data);
 extern char* BTCDParsePSBT(ByteArray data);
 extern char* BTCDAddress(ByteArray data);
 extern char* BTCDBip32MasterKeygen(ByteArray data);
+extern char* BTCDSignSchnorr(ByteArray privKey, ByteArray hash, ByteArray aux);
 
 #ifdef __cplusplus
 }

--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -19,8 +19,12 @@ import (
 	"strings"
 	"unsafe"
 
+	"encoding/hex"
+
 	"github.com/btcsuite/btcd/addrmgr"
 	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/btcutil/psbt"
@@ -296,4 +300,26 @@ func BTCDBip32MasterKeygen(data C.ByteArray) *C.char {
 	}
 	return C.CString(masterKey.String())
 }
+
+//export BTCDSignSchnorr
+func BTCDSignSchnorr(privKey C.ByteArray, hash C.ByteArray, aux C.ByteArray) *C.char {
+	privKeyBytes := C.GoBytes(unsafe.Pointer(privKey.data), privKey.length)
+	hashBytes := C.GoBytes(unsafe.Pointer(hash.data), hash.length)
+	auxBytes := C.GoBytes(unsafe.Pointer(aux.data), aux.length)
+
+	// Ensure we have exactly 32 bytes for the aux data
+	var auxArray [32]byte
+	copy(auxArray[:], auxBytes)
+
+	priv, _ := btcec.PrivKeyFromBytes(privKeyBytes)
+
+	// Use CustomNonce to force determinism with the provided aux data
+	sig, err := schnorr.Sign(priv, hashBytes, schnorr.CustomNonce(auxArray))
+	if err != nil {
+		return C.CString("")
+	}
+
+	return C.CString(hex.EncodeToString(sig.Serialize()))
+}
+
 func main() {}

--- a/modules/btcd/module.cpp
+++ b/modules/btcd/module.cpp
@@ -125,5 +125,30 @@ Btcd::bip32_master_keygen(std::span<const uint8_t> buffer) const {
   return res;
 }
 
+std::optional<std::string>
+Btcd::sign_schnorr(std::span<const uint8_t> buffer,
+                   std::span<const uint8_t> hash,
+                   std::span<const uint8_t> aux) const {
+  ByteArray privKey;
+  privKey.data = (char *)buffer.data();
+  privKey.length = buffer.size();
+
+  ByteArray msgHash;
+  msgHash.data = (char *)hash.data();
+  msgHash.length = hash.size();
+
+  ByteArray auxData;
+  auxData.data = reinterpret_cast<char *>(const_cast<uint8_t *>(aux.data()));
+  auxData.length = aux.size();
+
+  char *result = BTCDSignSchnorr(privKey, msgHash, auxData);
+  if (!result)
+    return std::nullopt;
+
+  std::string res(result);
+  BTCDFreeString(result);
+  return res;
+}
+
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/btcd/module.h
+++ b/modules/btcd/module.h
@@ -26,6 +26,9 @@ public:
   transaction_eval(std::span<const uint8_t> buffer) const override;
   std::optional<std::string>
   bip32_master_keygen(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  sign_schnorr(std::span<const uint8_t> buffer, std::span<const uint8_t> hash,
+               std::span<const uint8_t> aux) const override;
   ~Btcd() noexcept override = default;
 };
 

--- a/modules/secp256k1/module.cpp
+++ b/modules/secp256k1/module.cpp
@@ -3,6 +3,8 @@
 extern "C" {
 #include <secp256k1.h>
 #include <secp256k1_ecdh.h>
+#include <secp256k1_extrakeys.h>
+#include <secp256k1_schnorrsig.h>
 }
 
 #undef template
@@ -149,6 +151,33 @@ secp256k1_ecdh_generate(std::span<const uint8_t> buffer,
   return hex_encode(shared_secret.data(), SECP256K1_SHARED_SECRET_LEN);
 }
 
+std::optional<std::string>
+secp256k1_sign_schnorr(std::span<const uint8_t> buffer,
+                       std::span<const uint8_t> hash,
+                       std::span<const uint8_t> aux) {
+  int ret = 0;
+  secp256k1_keypair keypair;
+  std::vector<uint8_t> signature(64);
+  const uint8_t *privkey = buffer.data();
+
+  if (!secp256k1_ec_seckey_verify(secp256k1_ctx, privkey)) {
+    return std::nullopt;
+  }
+
+  ret = secp256k1_keypair_create(secp256k1_ctx, &keypair, privkey);
+  if (!ret)
+    return "";
+
+  ret = secp256k1_schnorrsig_sign32(secp256k1_ctx, signature.data(),
+                                    hash.data(), &keypair, aux.data());
+
+  if (!ret) {
+    return "";
+  }
+
+  return hex_encode(signature.data(), 64);
+}
+
 namespace bitcoinfuzz {
 namespace module {
 Secp256k1::Secp256k1(void) : BaseModule("Secp256k1") { init(nullptr, nullptr); }
@@ -181,6 +210,13 @@ std::optional<std::string>
 Secp256k1::ecdh(std::span<const uint8_t> buffer,
                 std::span<const uint8_t> pubkey) const {
   return secp256k1_ecdh_generate(buffer, pubkey);
+}
+
+std::optional<std::string>
+Secp256k1::sign_schnorr(std::span<const uint8_t> buffer,
+                        std::span<const uint8_t> hash,
+                        std::span<const uint8_t> aux) const {
+  return secp256k1_sign_schnorr(buffer, hash, aux);
 }
 
 } // namespace module

--- a/modules/secp256k1/module.h
+++ b/modules/secp256k1/module.h
@@ -22,6 +22,9 @@ public:
   std::optional<std::string>
   ecdh(std::span<const uint8_t> buffer,
        std::span<const uint8_t> pubkey) const override;
+  std::optional<std::string>
+  sign_schnorr(std::span<const uint8_t> buffer, std::span<const uint8_t> hash,
+               std::span<const uint8_t> aux) const override;
   ~Secp256k1() noexcept override = default;
 };
 } // namespace module


### PR DESCRIPTION
Fixes https://github.com/bitcoinfuzz/bitcoinfuzz/issues/365.

It adds a new fuzzing target for Schnorr signatures (BIP340). Although the
secp256k1 library already supports Schnorr signing and is built with the required
module enabled, the functionality was not previously exposed through the fuzzing
harness, so those code paths were not being exercised. This change introduces a
new sign_schnorr target, wires it through the driver and base module, and
implements the signing logic in the secp256k1 module using
secp256k1_schnorrsig_sign. As a result, the fuzzer can now feed arbitrary inputs
into the Schnorr signing implementation, improving coverage for
Taproot-related cryptographic code.

The target was tested locally using just run sign_schnorr. The fuzzer starts
successfully, reports new coverage (NEW_FUNC entries), and runs through tens of
thousands of iterations without crashes.
<img width="1055" height="322" alt="Screenshot from 2025-12-30 12-46-16" src="https://github.com/user-attachments/assets/fd5976d1-2037-4ec7-b3b6-cb711a215f82" />
