### PR TITLE
Add gocoin module for script_eval target (Issue #375)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ ifneq ($(findstring -DBTCD,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
 	MODULES += modules/btcd/module.a
 endif
 
+ifneq ($(findstring -DGOCOIN,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+	MODULES += modules/gocoin/module.a
+endif
+
 ifneq ($(filter -DNBITCOIN,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
 	MODULES += modules/nbitcoin/module.a
 endif

--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ If you prefer, you can still build the modules manually. Below are the steps for
     export CXXFLAGS="$CXXFLAGS -DBTCD"
     ```
 
+- ### gocoin
+
+    [gocoin](https://github.com/piotrnar/gocoin) is a full Bitcoin node implementation written in Go.
+
+    ```bash
+    cd modules/gocoin
+    make
+    export CXXFLAGS="$CXXFLAGS -DGOCOIN"
+    ```
+
+    **Note:** gocoin cannot be used together with btcd in the same build due to cgo symbol conflicts (both embed the Go runtime).
+
 - ### NBitcoin
 
     ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     volumes:
       - ./docker:/app/data
 
+  # Note: gocoin module not included here due to cgo symbol conflicts with btcd
+  # (both are Go modules that embed the Go runtime, causing linker errors)
   script_eval:
     build:
       context: .

--- a/main.cpp
+++ b/main.cpp
@@ -24,6 +24,10 @@
 #include <modules/btcd/module.h>
 #endif
 
+#ifdef GOCOIN
+#include <modules/gocoin/module.h>
+#endif
+
 #ifdef NBITCOIN
 #include <modules/nbitcoin/module.h>
 #endif
@@ -125,6 +129,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 #endif
 #ifdef BTCD
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::Btcd>());
+#endif
+#ifdef GOCOIN
+  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Gocoin>());
 #endif
 #ifdef NBITCOIN
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::NBitcoin>());

--- a/modules/gocoin/Makefile
+++ b/modules/gocoin/Makefile
@@ -1,0 +1,26 @@
+CXXFLAGS += -Wall -Wextra -std=c++20 -I. -I ../../include -I./gocoin_wrapper
+
+all: module.a
+
+module.a: module.o gocoin_wrapper/libgocoin_wrapper.a
+	bash ../../merge.sh module.a gocoin_wrapper/libgocoin_wrapper.a module.o
+	ranlib module.a
+
+gocoin_wrapper/libgocoin_wrapper.a:
+	cd gocoin_wrapper && go mod tidy && go build -o libgocoin_wrapper.a -buildmode=c-archive -tags=libfuzzer -gcflags=all=-d=libfuzzer wrapper.go
+
+module.o: module.cpp gocoin_wrapper/libgocoin_wrapper.a
+	$(CXX) $(CXXFLAGS) -fPIC -c module.cpp -o module.o
+
+format:
+	clang-format -i ./module.cpp ./module.h
+	cd gocoin_wrapper && go fmt
+
+check-format:
+	clang-format -Werror --fail-on-incomplete-format -n ./module.cpp ./module.h
+	cd gocoin_wrapper && files=$$(gofmt -l .); if [ -n "$$files" ]; then echo "Unformatted files:"; echo "$$files"; exit 1; fi
+
+clean:
+	rm -f *.o *.a gocoin_wrapper/*.a gocoin_wrapper/*.h
+
+.PHONY: all clean format check-format

--- a/modules/gocoin/gocoin_wrapper/go.mod
+++ b/modules/gocoin/gocoin_wrapper/go.mod
@@ -1,0 +1,7 @@
+module gocoin_wrapper
+
+go 1.21
+
+require github.com/piotrnar/gocoin v0.0.0-20251223213912-807b4986e017
+
+replace github.com/piotrnar/gocoin => github.com/brunoerg/gocoin v0.0.0-20260115203511-06993e5123d2

--- a/modules/gocoin/gocoin_wrapper/wrapper.go
+++ b/modules/gocoin/gocoin_wrapper/wrapper.go
@@ -1,0 +1,104 @@
+package main
+
+/*
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+    char* data;
+    int length;
+} ByteArray;
+*/
+import "C"
+import (
+	"unsafe"
+
+	"github.com/piotrnar/gocoin/lib/btc"
+	"github.com/piotrnar/gocoin/lib/script"
+)
+
+// GocoinEvalScript evaluates a Bitcoin script using gocoin's script engine.
+// This is exported to C/C++ and will be called by the fuzzer.
+//
+// Parameters:
+//   - scriptData: The raw script bytes to evaluate
+//   - flags: Script verification flags (like VER_P2SH, VER_WITNESS, etc.)
+//   - version: Signature version (0 = base, 1 = witness v0)
+//
+// Returns:
+//   - 1 if script evaluation succeeded
+//   - 0 if script is empty
+//   - 2 if script evaluation failed
+//
+//export GocoinEvalScript
+func GocoinEvalScript(scriptData C.ByteArray, flags C.uint32_t, version C.size_t) C.int {
+	// Convert C byte array to Go slice
+	scriptBytes := C.GoBytes(unsafe.Pointer(scriptData.data), C.int(scriptData.length))
+	if len(scriptBytes) == 0 {
+		return 0
+	}
+
+	// Create a minimal dummy transaction for script evaluation context
+	tx := createDummyTransaction(scriptBytes)
+
+	// Create the SigChecker which gocoin uses for script verification
+	// Based on gocoin's lib/script package
+	checker := &script.SigChecker{
+		Tx:     tx,
+		Idx:    0,    // We're checking input 0
+		Amount: 1000, // Dummy amount (needed for witness verification)
+	}
+
+	// Call gocoin's EvalScript function directly
+	var stack script.ScrStack
+	var execdata btc.ScriptExecutionData
+	result := script.EvalScript(scriptBytes, &stack, checker, uint32(flags), script.SIGVERSION_BASE, &execdata)
+
+	if result {
+		return 1
+	}
+	return 2
+}
+
+// createDummyTransaction creates a minimal transaction structure
+// that gocoin needs for script evaluation context.
+func createDummyTransaction(pkScript []byte) *btc.Tx {
+	// Create a minimal transaction with one input and one output
+	tx := new(btc.Tx)
+	tx.Version = 1
+	tx.Lock_time = 0
+
+	// Create dummy hash (32 bytes of zeros)
+	var dummyHash [32]byte
+
+	// Add one input (the one we're "spending" with our script)
+	tx.TxIn = make([]*btc.TxIn, 1)
+	tx.TxIn[0] = &btc.TxIn{
+		Input: btc.TxPrevOut{
+			Hash: dummyHash, // [32]byte, not Uint256
+			Vout: 0,
+		},
+		ScriptSig: []byte{}, // Empty signature script for now
+		Sequence:  0xffffffff,
+	}
+
+	// Add one output
+	tx.TxOut = make([]*btc.TxOut, 1)
+	tx.TxOut[0] = &btc.TxOut{
+		Value:     0,
+		Pk_script: []byte{},
+	}
+
+	return tx
+}
+
+// GocoinFreeString frees a C string that was allocated by Go.
+// Must be called to prevent memory leaks.
+//
+//export GocoinFreeString
+func GocoinFreeString(ptr *C.char) {
+	C.free(unsafe.Pointer(ptr))
+}
+
+// main is required for cgo but does nothing
+func main() {}

--- a/modules/gocoin/module.cpp
+++ b/modules/gocoin/module.cpp
@@ -1,0 +1,30 @@
+#include <cstring>
+#include <span>
+
+#include "gocoin_wrapper/libgocoin_wrapper.h"
+#include "module.h"
+
+namespace bitcoinfuzz {
+namespace module {
+Gocoin::Gocoin(void) : BaseModule("Gocoin") {}
+
+std::optional<bool> Gocoin::script_eval(const std::vector<uint8_t> &input_data,
+                                        unsigned int flags,
+                                        size_t version) const {
+  ByteArray script_data{.data = reinterpret_cast<char *>(
+                            const_cast<uint8_t *>(input_data.data())),
+                        .length = static_cast<int>(input_data.size())};
+
+  int result = GocoinEvalScript(script_data, /*flags=*/0, version);
+
+  if (result == 1) {
+    return true;
+  } else if (result == 2) {
+    return false;
+  }
+
+  return std::nullopt;
+}
+
+} // namespace module
+} // namespace bitcoinfuzz

--- a/modules/gocoin/module.h
+++ b/modules/gocoin/module.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <bitcoinfuzz/basemodule.h>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace bitcoinfuzz {
+namespace module {
+
+class Gocoin : public BaseModule {
+public:
+  Gocoin(void);
+
+  std::optional<bool> script_eval(const std::vector<uint8_t> &input_data,
+                                  unsigned int flags,
+                                  size_t version) const override;
+
+  ~Gocoin() noexcept override = default;
+};
+
+} // namespace module
+} // namespace bitcoinfuzz


### PR DESCRIPTION
Implements Issue #375 - adds gocoin (Go Bitcoin implementation) to the script_eval differential fuzzing target.

## Changes
- modules/gocoin/: New Go wrapper and C++ interface for gocoin's script evaluation
- main.cpp: Register gocoin module
- Makefile: Add gocoin module linking
- README.md: Add gocoin documentation

## Notes
- Cannot test gocoin + btcd together due to cgo symbol conflicts (both embed Go runtime)

Fixes #375