### PR TITLE
Add differential fuzzing for nbitcoin-secp256k1 module

### DIFF
--- a/.github/workflows/commit-by-commit-build.yml
+++ b/.github/workflows/commit-by-commit-build.yml
@@ -223,6 +223,11 @@ jobs:
         run: |
           cd modules/secp256k1 && make
 
+      - name: Build - nbitcoinsecp256k1
+        timeout-minutes: 5
+        run: |
+          cd modules/nbitcoinsecp256k1 && make
+
       - name: Report build success
         run: |
           echo "✅ Successfully built commit ${{ steps.commit-info.outputs.short-sha }}: ${{ steps.commit-info.outputs.subject }}"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -89,6 +89,7 @@ jobs:
           -DECLAIR \
           -DDECRED_SECP256K1 \
           -DSECP256K1 \
+          -DNBITCOIN_SECP256K1 \
           -DCUSTOM_MUTATOR_P2P_MESSAGE" \
           ONLY_MODULES=1 \
           ./auto_build.py
@@ -172,23 +173,23 @@ jobs:
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "private_to_public_key"
             target: "private_to_public_key"
-            cxxflags: "-DDECRED_SECP256K1 -DSECP256K1"
+            cxxflags: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "sign_compact"
             target: "sign_compact"
-            cxxflags: "-DDECRED_SECP256K1 -DSECP256K1"
+            cxxflags: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "sign_der"
             target: "sign_der"
-            cxxflags: "-DDECRED_SECP256K1 -DSECP256K1"
+            cxxflags: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "sign_verify"
             target: "sign_verify"
-            cxxflags: "-DDECRED_SECP256K1 -DSECP256K1 -DCUSTOM_MUTATOR_SECP256K1_SIGNATURE"
+            cxxflags: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1 -DCUSTOM_MUTATOR_SECP256K1_SIGNATURE"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "ecdh"
             target: "ecdh"
-            cxxflags: "-DDECRED_SECP256K1 -DSECP256K1"
+            cxxflags: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ifneq ($(findstring -DBTCD,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
 	MODULES += modules/btcd/module.a
 endif
 
-ifneq ($(findstring -DNBITCOIN,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+ifneq ($(filter -DNBITCOIN,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
 	MODULES += modules/nbitcoin/module.a
 endif
 
@@ -89,6 +89,10 @@ ifneq ($(findstring -DSECP256K1,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
 	MODULES += modules/secp256k1/module.a
 endif
 
+ifneq ($(filter -DNBITCOIN_SECP256K1,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+	MODULES += modules/nbitcoinsecp256k1/module.a
+endif
+
 ifeq ($(UNAME_S), Darwin)
 	LDFLAGS = -framework CoreFoundation -Wl,-ld_classic
 endif
@@ -99,12 +103,16 @@ else
 	LIB_EXT := so
 endif
 
-ifneq ($(findstring -DNBITCOIN,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+ifneq ($(filter -DNBITCOIN,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
   NBITCOIN_LIB := ./NBitcoin.CppBridge.$(LIB_EXT)
 endif
 
 ifneq ($(findstring -DNLIGHTNING,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
   NLIGHTNING_LIB := ./NLightning.CppBridge.$(LIB_EXT)
+endif
+
+ifneq ($(filter -DNBITCOIN_SECP256K1,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+  NBITCOIN_SECP256K1_LIB := ./NBitcoinSecp256k1.CppBridge.$(LIB_EXT)
 endif
 
 ifneq ($(findstring -DTINY_MINISCRIPT,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
@@ -137,7 +145,7 @@ endif
 CXXFLAGS := $(BASE_CXXFLAGS) $(JAVA_CXXFLAGS) $(CXXFLAGS) $(PYTHON_LDFLAGS)
 
 bitcoinfuzz: main.cpp driver.o $(BITCOINFUZZ_OBJS) $(JVM_LOADER)
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp $(MODULES) driver.o $(BITCOINFUZZ_OBJS) $(NBITCOIN_LIB) $(NLIGHTNING_LIB) $(TINY_MINISCRIPT_LIB) -o bitcoinfuzz $(PYTHON_LDFLAGS) $(SODIUM_LDLIBS) $(JVM_LOADER)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) main.cpp $(MODULES) driver.o $(BITCOINFUZZ_OBJS) $(NBITCOIN_LIB) $(NLIGHTNING_LIB) $(NBITCOIN_SECP256K1_LIB) $(TINY_MINISCRIPT_LIB) -o bitcoinfuzz $(PYTHON_LDFLAGS) $(SODIUM_LDLIBS) $(JVM_LOADER)
 
 driver.o: driver.cpp driver.h
 	$(CXX) $(CXXFLAGS) -c driver.cpp -o driver.o

--- a/README.md
+++ b/README.md
@@ -262,6 +262,14 @@ If you prefer, you can still build the modules manually. Below are the steps for
     export CXXFLAGS="$CXXFLAGS -DSECP256K1"
     ```
 
+- ### NBitcoin-Secp256k1
+
+    ```bash
+    cd modules/nbitcoinsecp256k1
+    make
+    export CXXFLAGS="$CXXFLAGS -DNBITCOIN_SECP256K1"
+    ```
+
 ## Final Build and Execution
 Once the modules are compiled, you can compile `bitcoinfuzz` an execute it:
 - ### Automatic Method:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,7 +207,7 @@ services:
       tags:
         - bitcoinfuzz:private_to_public_key
       args:
-        CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1"
+        CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1"
         FUZZ: private_to_public_key
     env_file: .env
     volumes:
@@ -219,7 +219,7 @@ services:
       tags:
         - bitcoinfuzz:sign_compact
       args:
-        CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1"
+        CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1"
         FUZZ: sign_compact
     env_file: .env
     volumes:
@@ -231,7 +231,7 @@ services:
       tags:
         - bitcoinfuzz:sign_der
       args:
-        CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1"
+        CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1"
         FUZZ: sign_der
     env_file: .env
     volumes:
@@ -243,7 +243,7 @@ services:
       tags:
         - bitcoinfuzz:sign_verify
       args:
-        CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1 -DCUSTOM_MUTATOR_SECP256K1_SIGNATURE"
+        CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1 -DCUSTOM_MUTATOR_SECP256K1_SIGNATURE"
         FUZZ: sign_verify
     env_file: .env
     volumes:
@@ -255,7 +255,7 @@ services:
       tags:
         - bitcoinfuzz:ecdh
       args:
-        CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1"
+        CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1"
         FUZZ: ecdh
     env_file: .env
     volumes:

--- a/main.cpp
+++ b/main.cpp
@@ -76,6 +76,10 @@
 #include <modules/secp256k1/module.h>
 #endif
 
+#ifdef NBITCOIN_SECP256K1
+#include <modules/nbitcoinsecp256k1/module.h>
+#endif
+
 #ifdef CUSTOM_MUTATOR_BOLT12_OFFER
 #include <custommutator/mutators/bolt12_offer.h>
 #endif
@@ -157,6 +161,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 #endif
 #ifdef SECP256K1
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::Secp256k1>());
+#endif
+#ifdef NBITCOIN_SECP256K1
+  driver->LoadModule(
+      std::make_shared<bitcoinfuzz::module::NBitcoin_secp256k1>());
 #endif
 
 #ifdef CUSTOM_MUTATOR_BOLT11

--- a/modules/nbitcoinsecp256k1/Makefile
+++ b/modules/nbitcoinsecp256k1/Makefile
@@ -1,0 +1,43 @@
+all: module.a
+
+CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer -std=c++20 -I ../../include
+
+UNAME_S := $(shell uname -s)
+RUNTIME_ID := $(shell echo $(UNAME_S)  | tr '[:upper:]' '[:lower:]' | sed 's/darwin/osx/')-$(shell uname -m | sed 's/x86_64/x64/; s/aarch64/arm64/')
+ifeq ($(UNAME_S), Darwin)
+  NBITCOIN_SECP256K1_LIB_EXT := dylib
+else
+  NBITCOIN_SECP256K1_LIB_EXT := so
+endif
+
+NBITCOIN_SECP256K1_LIB_PATH := ./bin/Release/net9.0/$(RUNTIME_ID)/native/NBitcoinSecp256k1.CppBridge.$(NBITCOIN_SECP256K1_LIB_EXT)
+
+$(NBITCOIN_SECP256K1_LIB_PATH):
+	dotnet publish -c Release -r $(RUNTIME_ID) --self-contained
+	# Fix the dylib's install name on macOS: .NET embeds a relative path like
+  # "bin/Release/net9.0/osx-arm64/native/NBitcoinSecp256k1.CppBridge.dylib" inside the library,
+  # but we're copying it to the project root, so we need to update the internal
+  # reference to match the new location where the runtime loader will find it
+	@if [ "$(UNAME_S)" = "Darwin" ]; then \
+		llvm-install-name-tool -id ./NBitcoinSecp256k1.CppBridge.$(NBITCOIN_SECP256K1_LIB_EXT)  $(NBITCOIN_SECP256K1_LIB_PATH); \
+	fi
+	cp $(NBITCOIN_SECP256K1_LIB_PATH) ../../NBitcoinSecp256k1.CppBridge.$(NBITCOIN_SECP256K1_LIB_EXT)
+
+module.a: module.o $(NBITCOIN_SECP256K1_LIB_PATH)
+	ar rcs module.a module.o
+
+module.o: module.cpp module.h
+	$(CXX) $(CXXFLAGS) -I . -fPIC -c module.cpp -o module.o
+
+format:
+	clang-format -i module.h module.cpp NBitcoinSecp256k1/nbitcoinsecp256k1_lib.h
+	dotnet format
+
+check-format:
+	clang-format -Werror --fail-on-incomplete-format -n module.h module.cpp NBitcoinSecp256k1/nbitcoinsecp256k1_lib.h
+	dotnet format --verify-no-changes
+
+clean:
+	rm -rf *.o module.a ./bin ./obj
+
+.PHONY: $(NBITCOIN_SECP256K1_LIB_PATH)

--- a/modules/nbitcoinsecp256k1/NBitcoinSecp256k1.CppBridge.csproj
+++ b/modules/nbitcoinsecp256k1/NBitcoinSecp256k1.CppBridge.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>NBitcoinSecp256k1.CppBridge</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Enable Native AOT compilation -->
+    <PublishAot>true</PublishAot>
+    <UseNativeAot>true</UseNativeAot>
+    <NativeLib>Shared</NativeLib>
+    <InvariantGlobalization>true</InvariantGlobalization>
+
+    <!-- Make it self-contained so you don't need a separate runtime installed -->
+    <SelfContained>true</SelfContained>
+
+    <!-- (Optional) Keep debugging symbols unstripped -->
+    <StripSymbols>false</StripSymbols>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NBitcoin.Secp256k1" Version="3.2.0" />
+  </ItemGroup>
+</Project>

--- a/modules/nbitcoinsecp256k1/NBitcoinSecp256k1/NBitcoinSecp256k1Bridge.cs
+++ b/modules/nbitcoinsecp256k1/NBitcoinSecp256k1/NBitcoinSecp256k1Bridge.cs
@@ -1,0 +1,179 @@
+using System.Runtime.InteropServices;
+using NBitcoin.Secp256k1;
+namespace NBitcoinSecp256k1.CppBridge;
+
+public static unsafe class Bridge
+{
+    private const int BufferLength = 32;
+
+    // Disposable struct that forces GC cleanup when disposed.
+    private readonly struct GCScope : IDisposable
+    {
+        public void Dispose()
+        {
+            // We force a GC here to clean up managed wrappers holding native resources.
+            // Normally the GC's finalizer thread takes care of this, but during fuzzing
+            // the GC may not run often enough and the leaks start to accumulate.
+            //
+            // This does add GC pressure and will slow fuzzing down.
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "nbitcoinsecp256k1_private_to_public_key")]
+    public static IntPtr PrivateToPublicKey(IntPtr bufferPtr)
+    {
+        using var gcScope = new GCScope();
+        try
+        {
+            Context ctx = Context.Instance;
+            var privKeySpan = new ReadOnlySpan<byte>((void*)bufferPtr, BufferLength);
+            if (!ctx.TryCreateECPrivKey(privKeySpan, out var privKey))
+            {
+                return IntPtr.Zero;
+            }
+
+            var pubKey = privKey.CreatePubKey().ToBytes();
+
+            return HexEncode(pubKey);
+        }
+        catch
+        {
+            return Marshal.StringToHGlobalAnsi(string.Empty);
+        }
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "nbitcoinsecp256k1_sign_compact")]
+    public static IntPtr SignCompact(IntPtr bufferPtr, IntPtr hashPtr)
+    {
+        using var gcScope = new GCScope();
+        try
+        {
+            Context ctx = Context.Instance;
+            var privKeySpan = new ReadOnlySpan<byte>((void*)bufferPtr, BufferLength);
+            var hashSpan = NormalizeHashToCurveOrder(new ReadOnlySpan<byte>((void*)hashPtr, BufferLength));
+            if (!ctx.TryCreateECPrivKey(privKeySpan, out var privKey))
+            {
+                return IntPtr.Zero;
+            }
+
+            var signature = privKey.SignECDSARFC6979(hashSpan);
+            var compactSign = new byte[64];
+            signature.WriteCompactToSpan(compactSign);
+
+            return HexEncode(compactSign);
+        }
+        catch
+        {
+            return Marshal.StringToHGlobalAnsi(string.Empty);
+        }
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "nbitcoinsecp256k1_sign_der")]
+    public static IntPtr SignDER(IntPtr bufferPtr, IntPtr hashPtr)
+    {
+        using var gcScope = new GCScope();
+        try
+        {
+            Context ctx = Context.Instance;
+            var privKeySpan = new ReadOnlySpan<byte>((void*)bufferPtr, BufferLength);
+            var hashSpan = NormalizeHashToCurveOrder(new ReadOnlySpan<byte>((void*)hashPtr, BufferLength));
+            if (!ctx.TryCreateECPrivKey(privKeySpan, out var privKey))
+            {
+                return IntPtr.Zero;
+            }
+
+            var derSign = privKey.SignECDSARFC6979(hashSpan).ToDER();
+
+            return HexEncode(derSign);
+        }
+        catch
+        {
+            return Marshal.StringToHGlobalAnsi(string.Empty);
+        }
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "nbitcoinsecp256k1_sign_verify")]
+    public static bool SignVerify(IntPtr bufferPtr, IntPtr hashPtr, IntPtr signPtr, uint signLen)
+    {
+        using var gcScope = new GCScope();
+        try
+        {
+            Context ctx = Context.Instance;
+            var privKeySpan = new ReadOnlySpan<byte>((void*)bufferPtr, BufferLength);
+            var hashSpan = new ReadOnlySpan<byte>((void*)hashPtr, BufferLength);
+            var signSpan = new ReadOnlySpan<byte>((void*)signPtr, (int)signLen);
+            if (!ctx.TryCreateECPrivKey(privKeySpan, out var privKey))
+            {
+                return false;
+            }
+
+            if (!SecpECDSASignature.TryCreateFromDer(signSpan, out var signature))
+            {
+                return false;
+            }
+
+            var pubKey = privKey.CreatePubKey();
+
+            return pubKey.SigVerify(signature, hashSpan);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "nbitcoinsecp256k1_ecdh")]
+    public static IntPtr ECDH(IntPtr bufferPtr, IntPtr pubKeyPtr)
+    {
+        using var gcScope = new GCScope();
+        try
+        {
+            Context ctx = Context.Instance;
+            var privKeySpan = new ReadOnlySpan<byte>((void*)bufferPtr, BufferLength);
+            var pubKeySpan = new ReadOnlySpan<byte>((void*)pubKeyPtr, 33);
+            if (!ctx.TryCreateECPrivKey(privKeySpan, out var privKey))
+            {
+                return IntPtr.Zero;
+            }
+
+            if (!ctx.TryCreatePubKey(pubKeySpan, out var pubKey))
+            {
+                return IntPtr.Zero;
+            }
+
+            var sharedSecret = pubKey.GetSharedPubkey(privKey);
+            var hashedSecret = System.Security.Cryptography.SHA256.HashData(sharedSecret.ToBytes());
+
+            return HexEncode(hashedSecret);
+        }
+        catch
+        {
+            return Marshal.StringToHGlobalAnsi(string.Empty);
+        }
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "nbitcoinsecp256k1_free_c_string")]
+    public static void FreeString(IntPtr ptr)
+    {
+        if (ptr != IntPtr.Zero)
+        {
+            Marshal.FreeHGlobal(ptr);
+        }
+    }
+
+    private static IntPtr HexEncode(byte[] data)
+    {
+        string hex = Convert.ToHexString(data).ToLowerInvariant();
+        return Marshal.StringToHGlobalAnsi(hex);
+    }
+
+    private static ReadOnlySpan<byte> NormalizeHashToCurveOrder(ReadOnlySpan<byte> hashSpan)
+    {
+        // Normalizes a hash to the secp256k1 curve order.
+        // Ensures compatibility with libsecp256k1, which automatically performs
+        // modular reduction on message hashes before deterministic nonce generation.
+        return new Scalar(hashSpan).ToBytes();
+    }
+}

--- a/modules/nbitcoinsecp256k1/NBitcoinSecp256k1/nbitcoinsecp256k1_lib.h
+++ b/modules/nbitcoinsecp256k1/NBitcoinSecp256k1/nbitcoinsecp256k1_lib.h
@@ -1,0 +1,19 @@
+#include <cstdint>
+
+extern "C" char *nbitcoinsecp256k1_private_to_public_key(const uint8_t *buffer);
+
+extern "C" char *nbitcoinsecp256k1_sign_compact(const uint8_t *buffer,
+                                                const uint8_t *hash);
+
+extern "C" char *nbitcoinsecp256k1_sign_der(const uint8_t *buffer,
+                                            const uint8_t *hash);
+
+extern "C" bool nbitcoinsecp256k1_sign_verify(const uint8_t *buffer,
+                                              const uint8_t *hash,
+                                              const uint8_t *sign,
+                                              uint32_t signLen);
+
+extern "C" char *nbitcoinsecp256k1_ecdh(const uint8_t *buffer,
+                                        const uint8_t *pubkey);
+
+extern "C" void nbitcoinsecp256k1_free_c_string(void *ptr);

--- a/modules/nbitcoinsecp256k1/module.cpp
+++ b/modules/nbitcoinsecp256k1/module.cpp
@@ -1,0 +1,56 @@
+#include "module.h"
+#include "NBitcoinSecp256k1/nbitcoinsecp256k1_lib.h"
+#include <span>
+
+namespace bitcoinfuzz {
+namespace module {
+NBitcoin_secp256k1::NBitcoin_secp256k1(void)
+    : BaseModule("NBitcoin_secp256k1") {}
+std::optional<std::string> NBitcoin_secp256k1::private_to_public_key(
+    std::span<const uint8_t> buffer) const {
+  char *p = nbitcoinsecp256k1_private_to_public_key(buffer.data());
+  if (!p)
+    return std::nullopt;
+  std::string s(p);
+  nbitcoinsecp256k1_free_c_string(p);
+  return s;
+}
+std::optional<std::string>
+NBitcoin_secp256k1::sign_compact(std::span<const uint8_t> buffer,
+                                 std::span<const uint8_t> hash) const {
+  char *p = nbitcoinsecp256k1_sign_compact(buffer.data(), hash.data());
+  if (!p)
+    return std::nullopt;
+  std::string s(p);
+  nbitcoinsecp256k1_free_c_string(p);
+  return s;
+}
+std::optional<std::string>
+NBitcoin_secp256k1::sign_der(std::span<const uint8_t> buffer,
+                             std::span<const uint8_t> hash) const {
+  char *p = nbitcoinsecp256k1_sign_der(buffer.data(), hash.data());
+  if (!p)
+    return std::nullopt;
+  std::string s(p);
+  nbitcoinsecp256k1_free_c_string(p);
+  return s;
+}
+std::optional<bool>
+NBitcoin_secp256k1::sign_verify(std::span<const uint8_t> buffer,
+                                std::span<const uint8_t> hash,
+                                std::span<const uint8_t> sign) const {
+  return nbitcoinsecp256k1_sign_verify(buffer.data(), hash.data(), sign.data(),
+                                       sign.size());
+}
+std::optional<std::string>
+NBitcoin_secp256k1::ecdh(std::span<const uint8_t> buffer,
+                         std::span<const uint8_t> pubkey) const {
+  char *p = nbitcoinsecp256k1_ecdh(buffer.data(), pubkey.data());
+  if (!p)
+    return std::nullopt;
+  std::string s(p);
+  nbitcoinsecp256k1_free_c_string(p);
+  return s;
+}
+} // namespace module
+} // namespace bitcoinfuzz

--- a/modules/nbitcoinsecp256k1/module.h
+++ b/modules/nbitcoinsecp256k1/module.h
@@ -1,0 +1,27 @@
+#include <bitcoinfuzz/basemodule.h>
+#include <optional>
+#include <span>
+
+namespace bitcoinfuzz {
+namespace module {
+class NBitcoin_secp256k1 : public BaseModule {
+public:
+  NBitcoin_secp256k1(void);
+  std::optional<std::string>
+  private_to_public_key(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  sign_compact(std::span<const uint8_t> buffer,
+               std::span<const uint8_t> hash) const override;
+  std::optional<std::string>
+  sign_der(std::span<const uint8_t> buffer,
+           std::span<const uint8_t> hash) const override;
+  std::optional<bool> sign_verify(std::span<const uint8_t> buffer,
+                                  std::span<const uint8_t> hash,
+                                  std::span<const uint8_t> sign) const override;
+  std::optional<std::string>
+  ecdh(std::span<const uint8_t> buffer,
+       std::span<const uint8_t> pubkey) const override;
+  ~NBitcoin_secp256k1() noexcept override = default;
+};
+} // namespace module
+} // namespace bitcoinfuzz

--- a/modules/secp256k1/module.cpp
+++ b/modules/secp256k1/module.cpp
@@ -138,10 +138,12 @@ secp256k1_ecdh_generate(std::span<const uint8_t> buffer,
     return std::nullopt;
   }
 
-  ret = ret = secp256k1_ec_pubkey_parse(secp256k1_ctx, &pubkey,
-                                        pubkey_buf.data(), pubkey_buf.size());
-  ret = ret && secp256k1_ecdh(secp256k1_ctx, shared_secret.data(), &pubkey,
-                              privkey, nullptr, nullptr);
+  if (!secp256k1_ec_pubkey_parse(secp256k1_ctx, &pubkey, pubkey_buf.data(),
+                                 pubkey_buf.size())) {
+    return std::nullopt;
+  }
+  ret = secp256k1_ecdh(secp256k1_ctx, shared_secret.data(), &pubkey, privkey,
+                       nullptr, nullptr);
   if (!ret) {
     return "";
   }


### PR DESCRIPTION
ref: #331 

Add differential fuzzing between the nbitcoin-secp256k1 (C#) implementation and the existing secp256k1 modules. This implementation covers all existing functions including private to public key operations, signing (both compact and DER formats), signature verification and ECDH operations.

The only point to discuss is that there were some memory leak issues which were addressed by forcing garbage collection. However, this makes the fuzzing slightly slower. The choice is therefore between accepting slower fuzzing with the current approach or suppressing the leaks on the libFuzzer side using -detect_leaks=0. I would appreciate any suggestions on improving this further or guidance on which of these options would be preferred.

Also, the file modules/nbitcoinsecp256k1/Makefile is mostly taken from the existing modules/nbitcoin/Makefile. Although I understand that macOS support has been removed the nbitcoinsecp256k1/Makefile still contains some macOS specific targets. Please let me know whether this is acceptable or if those targets should be removed.