### PR TITLE
addrv2: update string return format

### DIFF
--- a/modules/rustbitcoin/rust_bitcoin_lib/Cargo.lock
+++ b/modules/rustbitcoin/rust_bitcoin_lib/Cargo.lock
@@ -157,6 +157,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hex-conservative"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +251,7 @@ version = "0.1.0"
 dependencies = [
  "bitcoin",
  "bitcoin-p2p-messages",
+ "hex",
 ]
 
 [[package]]

--- a/modules/rustbitcoin/rust_bitcoin_lib/Cargo.toml
+++ b/modules/rustbitcoin/rust_bitcoin_lib/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2021"
 [dependencies]
 bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin.git", rev = "1ac48a55da04c83506f9933fe757a3989ec04e93" }
 p2p = { git = "https://github.com/rust-bitcoin/rust-bitcoin.git", rev = "1ac48a55da04c83506f9933fe757a3989ec04e93", package = "bitcoin-p2p-messages" }
+hex = "0.4"

--- a/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
+++ b/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
@@ -195,42 +195,44 @@ pub unsafe extern "C" fn rust_bitcoin_psbt_parse(data: *const u8, len: usize) ->
     }
 }
 
+/// # Safety
+/// The caller must ensure that `data` points to a valid memory region of at least `len` bytes.
 #[no_mangle]
 pub unsafe extern "C" fn rust_bitcoin_addrv2(data: *const u8, len: usize) -> *mut c_char {
-    // Safety: Ensure that the data pointer is valid for the given length
     let data_slice = slice::from_raw_parts(data, len);
 
     let addr: Result<(AddrV2Payload, usize), _> = encode::deserialize_partial(data_slice);
-    let mut clearnet: u64 = 0;
-    let mut tor: u64 = 0;
-    let mut i2p: u64 = 0;
-    let mut cjdns: u64 = 0;
     match addr {
-        Err(_) => str_to_c_string("clearnet=0tor=0cjdns=0i2p=0"),
+        Err(_) => str_to_c_string("[]"),
         Ok(vec_addr) => {
-            for a in vec_addr.0 .0 {
-                if matches!(a.addr, AddrV2::Ipv4(_)) {
-                    clearnet += 1;
-                } else if matches!(a.addr, AddrV2::Ipv6(_)) {
-                    clearnet += 1;
-                } else if matches!(a.addr, AddrV2::TorV3(_)) {
-                    tor += 1;
-                } else if matches!(a.addr, AddrV2::Cjdns(_)) {
-                    cjdns += 1;
-                } else if matches!(a.addr, AddrV2::I2p(_)) {
-                    i2p += 1;
-                }
-            }
-            let res = "clearnet=".to_string()
-                + &clearnet.to_string()
-                + "tor="
-                + &tor.to_string()
-                + "cjdns="
-                + &cjdns.to_string()
-                + "i2p="
-                + &i2p.to_string();
-            return str_to_c_string(&res);
+            let entries: Vec<String> = vec_addr.0 .0.iter().map(format_addrv2_message).collect();
+            let res = format!("[{}]", entries.join(","));
+            str_to_c_string(&res)
         }
+    }
+}
+
+/// Formats an AddrV2Message into a structured string representation.
+fn format_addrv2_message(msg: &p2p::address::AddrV2Message) -> String {
+    let addr_hex = addr_to_hex(&msg.addr);
+    format!(
+        "{{\"addr\":\"{}\",\"time\":{},\"services\":\"{:#x}\",\"port\":{}}}",
+        addr_hex,
+        msg.time,
+        msg.services.to_u64(),
+        msg.port
+    )
+}
+
+/// Converts an AddrV2 address to its hexadecimal representation.
+fn addr_to_hex(addr: &AddrV2) -> String {
+    match addr {
+        AddrV2::Ipv4(ip) => format!("0x{}", hex::encode(ip.octets())),
+        AddrV2::Ipv6(ip) => format!("0x{}", hex::encode(ip.octets())),
+        AddrV2::TorV3(bytes) => format!("0x{}", hex::encode(bytes)),
+        AddrV2::I2p(bytes) => format!("0x{}", hex::encode(bytes)),
+        AddrV2::Cjdns(ip) => format!("0x{}", hex::encode(ip.octets())),
+        AddrV2::Unknown(net_id, bytes) => format!("0x{:02x}{}", net_id, hex::encode(bytes)),
     }
 }
 
@@ -267,4 +269,36 @@ pub unsafe extern "C" fn rust_bitcoin_bip32_master_keygen(
 
 unsafe fn c_str_to_str<'a>(input: *const c_char) -> Result<&'a str, Utf8Error> {
     CStr::from_ptr(input).to_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn test_addr_to_hex_ipv4() {
+        let addr = AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1));
+        let hex = addr_to_hex(&addr);
+        assert_eq!(hex, "0x7f000001");
+    }
+
+    #[test]
+    fn test_format_addrv2_message() {
+        use p2p::address::AddrV2Message;
+        use p2p::ServiceFlags;
+
+        let msg = AddrV2Message {
+            time: 1700000000,
+            services: ServiceFlags::NETWORK,
+            addr: AddrV2::Ipv4(Ipv4Addr::new(192, 168, 1, 1)),
+            port: 8333,
+        };
+
+        let formatted = format_addrv2_message(&msg);
+        assert!(formatted.contains("\"addr\":\"0xc0a80101\""));
+        assert!(formatted.contains("\"time\":1700000000"));
+        assert!(formatted.contains("\"services\":\"0x1\""));
+        assert!(formatted.contains("\"port\":8333"));
+    }
 }

--- a/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
+++ b/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
@@ -195,6 +195,20 @@ pub unsafe extern "C" fn rust_bitcoin_psbt_parse(data: *const u8, len: usize) ->
     }
 }
 
+/// Parses addrv2 message data and returns a JSON-like array string.
+///
+/// # Output Format
+/// Returns a JSON-like array of address objects. Note: the output format is structured
+/// for parseability but is not guaranteed to be strictly valid JSON. Since address values
+/// are hex-encoded, no special character escaping is needed.
+///
+/// Example output:
+/// ```text
+/// [{"addr":"0x7f000001","time":1700000000,"services":"0x1","port":8333}]
+/// ```
+///
+/// On parse error, returns an empty array: `[]`
+///
 /// # Safety
 /// The caller must ensure that `data` points to a valid memory region of at least `len` bytes.
 #[no_mangle]
@@ -274,13 +288,52 @@ unsafe fn c_str_to_str<'a>(input: *const c_char) -> Result<&'a str, Utf8Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, Ipv6Addr};
 
     #[test]
     fn test_addr_to_hex_ipv4() {
         let addr = AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1));
         let hex = addr_to_hex(&addr);
         assert_eq!(hex, "0x7f000001");
+    }
+
+    #[test]
+    fn test_addr_to_hex_ipv6() {
+        let addr = AddrV2::Ipv6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1));
+        let hex = addr_to_hex(&addr);
+        assert_eq!(hex, "0x20010db8000000000000000000000001");
+    }
+
+    #[test]
+    fn test_addr_to_hex_torv3() {
+        let bytes: [u8; 32] = [0x01; 32];
+        let addr = AddrV2::TorV3(bytes);
+        let hex = addr_to_hex(&addr);
+        assert!(hex.starts_with("0x"));
+        assert_eq!(hex.len(), 66); // "0x" + 64 hex chars
+    }
+
+    #[test]
+    fn test_addr_to_hex_i2p() {
+        let bytes: [u8; 32] = [0xab; 32];
+        let addr = AddrV2::I2p(bytes);
+        let hex = addr_to_hex(&addr);
+        assert!(hex.starts_with("0x"));
+        assert_eq!(hex.len(), 66);
+    }
+
+    #[test]
+    fn test_addr_to_hex_cjdns() {
+        let addr = AddrV2::Cjdns(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1));
+        let hex = addr_to_hex(&addr);
+        assert_eq!(hex, "0xfc000000000000000000000000000001");
+    }
+
+    #[test]
+    fn test_addr_to_hex_unknown() {
+        let addr = AddrV2::Unknown(0x99, vec![0xde, 0xad, 0xbe, 0xef]);
+        let hex = addr_to_hex(&addr);
+        assert_eq!(hex, "0x99deadbeef");
     }
 
     #[test]
@@ -300,5 +353,29 @@ mod tests {
         assert!(formatted.contains("\"time\":1700000000"));
         assert!(formatted.contains("\"services\":\"0x1\""));
         assert!(formatted.contains("\"port\":8333"));
+    }
+
+    #[test]
+    fn test_rust_bitcoin_addrv2_invalid_data() {
+        // Test that invalid data returns empty array
+        let invalid_data: [u8; 4] = [0xff, 0xff, 0xff, 0xff];
+        unsafe {
+            let result = rust_bitcoin_addrv2(invalid_data.as_ptr(), invalid_data.len());
+            let result_str = CStr::from_ptr(result).to_str().unwrap();
+            assert_eq!(result_str, "[]");
+            free_c_string(result);
+        }
+    }
+
+    #[test]
+    fn test_rust_bitcoin_addrv2_empty_data() {
+        // Test that empty payload returns empty array
+        let empty_data: [u8; 1] = [0x00]; // varint 0 = empty list
+        unsafe {
+            let result = rust_bitcoin_addrv2(empty_data.as_ptr(), empty_data.len());
+            let result_str = CStr::from_ptr(result).to_str().unwrap();
+            assert_eq!(result_str, "[]");
+            free_c_string(result);
+        }
     }
 }


### PR DESCRIPTION
Fixes #385

This updates the addrv2 string output to return a structured array-style
format containing address, time, service bits, and port.

Addresses remain in hexadecimal form to ensure consistency across
libraries and platforms.

This change improves parseability while keeping behavior deterministic.