### PR TITLE
add MODULES environment variable for selective module loading

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 **/obj/
 **/bin/
 **/target/
+**/build/
 **.dylib
 **.zip
 **.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,6 +128,9 @@ COPY --from=builder \
     /usr/lib/llvm-18/bin/llvm-symbolizer /usr/bin/llvm-symbolizer
 ENV ASAN_SYMBOLIZER_PATH /usr/bin/llvm-symbolizer
 
+# Comma-separated list of modules to load (empty = all modules)
+ENV MODULES=""
+
 # interpreted language sources
 COPY --from=builder --parents \
     --exclude=modules/bitcoin/secp256k1/tools \

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ If you prefer, you can still build the modules manually. Below are the steps for
     cd modules/rustbitcoinkernel
     make cargo && make
     export CXXFLAGS="$CXXFLAGS -DRUSTBITCOINKERNEL"
+    ```
 
 - ### py-bitcoinkernel
 
@@ -271,16 +272,47 @@ If you prefer, you can still build the modules manually. Below are the steps for
     ```
 
 ## Final Build and Execution
-Once the modules are compiled, you can compile `bitcoinfuzz` an execute it:
-- ### Automatic Method:
-    ```bash
-    FUZZ=target_name ./bitcoinfuzz
-    ```
-- ### Manual Method:
-    ```bash
-    make
-    FUZZ=target_name ./bitcoinfuzz
-    ```
+Once the modules are compiled, you can compile `bitcoinfuzz` and execute it:
+
+```bash
+make
+FUZZ=target_name ./bitcoinfuzz
+```
+
+## Selective Module Loading
+
+By default, all compiled modules are loaded when running the fuzzer. You can use the `MODULES` environment variable to load only specific modules at runtime, **without needing to recompile**.
+
+### Usage
+
+Set the `MODULES` environment variable to a comma-separated list of module names:
+
+```bash
+MODULES="BITCOIN_CORE,RUST_BITCOIN" FUZZ=target_name ./bitcoinfuzz
+```
+
+### Examples
+
+Load only Bitcoin Core and rust-bitcoin for comparison:
+```bash
+MODULES="BITCOIN_CORE,RUST_BITCOIN" FUZZ=bip32_master_keygen ./bitcoinfuzz
+```
+
+Load Lightning implementations only:
+```bash
+MODULES="LDK,LND,CLIGHTNING" FUZZ=deserialize_invoice ./bitcoinfuzz
+```
+
+Load all compiled modules (default behavior):
+```bash
+FUZZ=target_name ./bitcoinfuzz
+```
+
+### Notes
+
+- If `MODULES` is unset or empty, all compiled modules are loaded (existing behavior)
+- The fuzzer will abort with an error if you request a module that was not compiled
+- Whitespace around module names is trimmed (e.g., `"BTCD, LND"` works)
 
 -------------------------------------------
 ### Bugs/inconsistences/mismatches found by Bitcoinfuzz

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -97,6 +97,27 @@ docker run --rm \
 > [!NOTE]
 > Replace the bind mount with a named volume if preferred: `docker run ... -v bitcoinfuzz-data:/app/data ...`. Be aware that folder will be created.
 
+### Selective Module Loading
+
+You can use the `MODULES` environment variable to load only specific modules at runtime, without rebuilding the image:
+
+```bash
+# Load only Bitcoin Core and rust-bitcoin
+docker run --rm \
+  -e MODULES="BITCOIN_CORE,RUST_BITCOIN" \
+  -v "$(pwd)/docker":/app/data \
+  bitcoinfuzz:script
+
+# Load only Lightning implementations
+docker run --rm \
+  -e MODULES="LDK,LND,CLIGHTNING" \
+  -v "$(pwd)/docker":/app/data \
+  bitcoinfuzz:deserialize_invoice
+
+# With docker compose
+MODULES="BITCOIN_CORE,RUST_BITCOIN" docker compose up deserialize_block
+```
+
 ### Option 4 – Running from Source
 
 To build outside of Docker (useful for local debugging), execute `auto_build.py` with the required flags:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
         CXXFLAGS: "-DBITCOIN_CORE -DRUST_BITCOIN"
         FUZZ: script
     env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
     volumes:
       - ./docker:/app/data
 
@@ -20,6 +22,8 @@ services:
         CXXFLAGS: "-DBITCOIN_CORE -DRUST_BITCOIN -DBTCD"
         FUZZ: deserialize_block
     env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
     volumes:
       - ./docker:/app/data
 
@@ -32,6 +36,8 @@ services:
         CXXFLAGS: "-DBITCOIN_CORE -DBTCD"
         FUZZ: script_eval
     env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
     volumes:
       - ./docker:/app/data
 
@@ -45,6 +51,7 @@ services:
         FUZZ: descriptor_parse
     env_file: .env
     environment:
+      MODULES: ${MODULES:-}
       LIBFUZZ_DETECT_LEAKS: 0
       ASAN_OPTIONS: detect_leaks=0
     volumes:
@@ -60,6 +67,7 @@ services:
         FUZZ: kernel_block
     env_file: .env
     environment:
+      MODULES: ${MODULES:-}
       LIBFUZZ_DETECT_LEAKS: 0
       ASAN_OPTIONS: detect_leaks=0
     volumes:
@@ -75,8 +83,8 @@ services:
         FUZZ: miniscript_parse
     env_file: .env
     environment:
+      MODULES: ${MODULES:-}
       LIBFUZZ_DETECT_LEAKS: 0
-
       ASAN_OPTIONS: detect_leaks=0
     volumes:
       - ./docker:/app/data
@@ -91,6 +99,7 @@ services:
         FUZZ: deserialize_invoice
     env_file: .env
     environment:
+      MODULES: ${MODULES:-}
       LIBFUZZ_DETECT_LEAKS: 0
       ASAN_OPTIONS: detect_leaks=0
     volumes:
@@ -105,6 +114,8 @@ services:
         CXXFLAGS: "-DBITCOIN_CORE -DRUST_BITCOIN"
         FUZZ: address_parse
     env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
     volumes:
       - ./docker:/app/data
 
@@ -117,6 +128,8 @@ services:
         CXXFLAGS: "-DBITCOIN_CORE -DRUST_BITCOIN -DBTCD"
         FUZZ: addrv2
     env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
     volumes:
       - ./docker:/app/data
 
@@ -129,6 +142,8 @@ services:
         CXXFLAGS: "-DBITCOIN_CORE -DBTCD"
         FUZZ: transaction_eval
     env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
     volumes:
       - ./docker:/app/data
 
@@ -141,6 +156,8 @@ services:
         CXXFLAGS: "-DRUST_BITCOIN -DBTCD -DCUSTOM_MUTATOR_P2P_MESSAGE"
         FUZZ: parse_p2p_message
     env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
     volumes:
       - ./docker:/app/data
 
@@ -154,6 +171,7 @@ services:
         FUZZ: psbt_parse
     env_file: .env
     environment:
+      MODULES: ${MODULES:-}
       LIBFUZZ_DETECT_LEAKS: 0
       ASAN_OPTIONS: detect_leaks=0
     volumes:
@@ -169,6 +187,7 @@ services:
         FUZZ: deserialize_offer
     env_file: .env
     environment:
+      MODULES: ${MODULES:-}
       LIBFUZZ_DETECT_LEAKS: 0
       ASAN_OPTIONS: detect_leaks=0
     volumes:
@@ -183,6 +202,8 @@ services:
         CXXFLAGS: "-DLDK -DCLIGHTNING -DLND"
         FUZZ: parse_p2p_lightning_message
     env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
     volumes:
       - ./docker:/app/data
 
@@ -195,6 +216,7 @@ services:
         CXXFLAGS: "-DRUST_BITCOIN -DNBITCOIN -DBITCOIN_CORE -DBTCD -DBITCOINJ"
         FUZZ: bip32_master_keygen
     environment:
+      MODULES: ${MODULES:-}
       LIBFUZZ_DETECT_LEAKS: 0
       ASAN_OPTIONS: detect_leaks=0
     env_file: .env
@@ -210,6 +232,8 @@ services:
         CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1"
         FUZZ: private_to_public_key
     env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
     volumes:
       - ./docker:/app/data
 
@@ -222,6 +246,8 @@ services:
         CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1"
         FUZZ: sign_compact
     env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
     volumes:
       - ./docker:/app/data
 
@@ -234,6 +260,8 @@ services:
         CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1"
         FUZZ: sign_der
     env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
     volumes:
       - ./docker:/app/data
 
@@ -246,6 +274,8 @@ services:
         CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1 -DCUSTOM_MUTATOR_SECP256K1_SIGNATURE"
         FUZZ: sign_verify
     env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
     volumes:
       - ./docker:/app/data
 
@@ -258,6 +288,8 @@ services:
         CXXFLAGS: "-DDECRED_SECP256K1 -DSECP256K1 -DNBITCOIN_SECP256K1"
         FUZZ: ecdh
     env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
     volumes:
       - ./docker:/app/data
 
@@ -270,5 +302,7 @@ services:
         CXXFLAGS: "-DSECP256K1 -DBTCD"
         FUZZ: sign_schnorr
     env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
     volumes:
       - ./docker:/app/data

--- a/driver.cpp
+++ b/driver.cpp
@@ -10,6 +10,7 @@
 
 #include "driver.h"
 #include <bitcoinfuzz/basemodule.h>
+#include <bitcoinfuzz/module_registry.h>
 
 namespace bitcoinfuzz {
 void Driver::LoadModule(std::shared_ptr<BaseModule> module) {
@@ -67,10 +68,12 @@ void Driver::ScriptEvalTarget(std::span<const uint8_t> buffer) const {
       provider.ConsumeIntegralInRange<size_t>(0, 1024));
 
 #ifdef BTCD
-  if (std::ranges::find(input_data, 0xAC) != input_data.end() ||
-      std::ranges::find(input_data, 0xAE) != input_data.end() ||
-      std::ranges::find(input_data, 0xAF) != input_data.end())
-    return;
+  if (ModuleRegistry::instance().isEnabled("BTCD")) {
+    if (std::ranges::find(input_data, 0xAC) != input_data.end() ||
+        std::ranges::find(input_data, 0xAE) != input_data.end() ||
+        std::ranges::find(input_data, 0xAF) != input_data.end())
+      return;
+  }
 #endif
 
   auto flags = provider.ConsumeIntegral<unsigned int>();
@@ -214,9 +217,11 @@ void Driver::PSBTParseTarget(std::span<const uint8_t> buffer) const {
       continue;
 
 #ifdef NBITCOIN
-    if (res->find("in=0") != std::string::npos ||
-        res->find("out=0") != std::string::npos)
-      return;
+    if (ModuleRegistry::instance().isEnabled("NBITCOIN")) {
+      if (res->find("in=0") != std::string::npos ||
+          res->find("out=0") != std::string::npos)
+        return;
+    }
 #endif
 
     if (last_response.has_value()) {

--- a/helpers/jvmloader.cpp
+++ b/helpers/jvmloader.cpp
@@ -1,5 +1,6 @@
 #include "jvmloader.h"
 
+#include <bitcoinfuzz/module_registry.h>
 #include <filesystem>
 #include <iostream>
 #include <sstream>
@@ -54,17 +55,24 @@ void JvmLoader::init() {
   JavaVMOption options[7];
 
   std::vector<std::string> lib_dirs;
+  auto &registry = bitcoinfuzz::ModuleRegistry::instance();
 #ifdef LIGHTNING_KMP
-  lib_dirs.push_back(
-      (BITCOINFUZZ_ROOT / "modules" / "lightningkmp" / "lib").string());
+  if (registry.isEnabled("LIGHTNING_KMP")) {
+    lib_dirs.push_back(
+        (BITCOINFUZZ_ROOT / "modules" / "lightningkmp" / "lib").string());
+  }
 #endif
 #ifdef ECLAIR
-  lib_dirs.push_back(
-      (BITCOINFUZZ_ROOT / "modules" / "eclair" / "lib").string());
+  if (registry.isEnabled("ECLAIR")) {
+    lib_dirs.push_back(
+        (BITCOINFUZZ_ROOT / "modules" / "eclair" / "lib").string());
+  }
 #endif
 #ifdef BITCOINJ
-  lib_dirs.push_back(
-      (BITCOINFUZZ_ROOT / "modules" / "bitcoinj" / "lib").string());
+  if (registry.isEnabled("BITCOINJ")) {
+    lib_dirs.push_back(
+        (BITCOINFUZZ_ROOT / "modules" / "bitcoinj" / "lib").string());
+  }
 #endif
   std::string classpathStr = build_classpath(lib_dirs);
 

--- a/include/bitcoinfuzz/module_registry.h
+++ b/include/bitcoinfuzz/module_registry.h
@@ -1,0 +1,173 @@
+#pragma once
+
+#include <cstdlib>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace bitcoinfuzz {
+
+// Singleton registry to track which modules are enabled at runtime
+class ModuleRegistry {
+public:
+  static ModuleRegistry &instance() {
+    static ModuleRegistry reg;
+    return reg;
+  }
+
+  // Initialize from MODULES environment variable
+  // Returns empty string on success, or error message on failure
+  std::string initialize() {
+    if (initialized_)
+      return "";
+    initialized_ = true;
+
+    const char *modules_env = std::getenv("MODULES");
+    std::vector<std::string> requested = parseModuleList(modules_env);
+
+    if (requested.empty()) {
+      all_enabled_ = true;
+      return "";
+    }
+
+    all_enabled_ = false;
+    enabled_ = std::set<std::string>(requested.begin(), requested.end());
+
+    // Validate that all requested modules are compiled
+    std::set<std::string> compiled = getCompiledModules();
+    for (const auto &module : requested) {
+      if (compiled.find(module) == compiled.end()) {
+        std::string error = "ERROR: Module '" + module +
+                            "' was requested but is not compiled.\n"
+                            "Compiled modules: ";
+        bool first = true;
+        for (const auto &m : compiled) {
+          if (!first)
+            error += ", ";
+          error += m;
+          first = false;
+        }
+        if (compiled.empty()) {
+          error += "(none)";
+        }
+        return error;
+      }
+    }
+
+    return "";
+  }
+
+  // Check if a specific module is enabled at runtime
+  bool isEnabled(const std::string &name) const {
+    return all_enabled_ || enabled_.count(name) > 0;
+  }
+
+private:
+  ModuleRegistry() = default;
+  ModuleRegistry(const ModuleRegistry &) = delete;
+  ModuleRegistry &operator=(const ModuleRegistry &) = delete;
+
+  // Returns the list of all module names that were compiled into this binary
+  static std::set<std::string> getCompiledModules() {
+    std::set<std::string> compiled;
+
+#ifdef BITCOIN_CORE
+    compiled.insert("BITCOIN_CORE");
+#endif
+#ifdef RUST_BITCOIN
+    compiled.insert("RUST_BITCOIN");
+#endif
+#ifdef RUST_MINISCRIPT
+    compiled.insert("RUST_MINISCRIPT");
+#endif
+#ifdef TINY_MINISCRIPT
+    compiled.insert("TINY_MINISCRIPT");
+#endif
+#ifdef BTCD
+    compiled.insert("BTCD");
+#endif
+#ifdef NBITCOIN
+    compiled.insert("NBITCOIN");
+#endif
+#ifdef LND
+    compiled.insert("LND");
+#endif
+#ifdef LDK
+    compiled.insert("LDK");
+#endif
+#ifdef NLIGHTNING
+    compiled.insert("NLIGHTNING");
+#endif
+#ifdef EMBIT
+    compiled.insert("EMBIT");
+#endif
+#ifdef PYBITCOINKERNEL
+    compiled.insert("PYBITCOINKERNEL");
+#endif
+#ifdef RUSTBITCOINKERNEL
+    compiled.insert("RUSTBITCOINKERNEL");
+#endif
+#ifdef CLIGHTNING
+    compiled.insert("CLIGHTNING");
+#endif
+#ifdef ECLAIR
+    compiled.insert("ECLAIR");
+#endif
+#ifdef LIGHTNING_KMP
+    compiled.insert("LIGHTNING_KMP");
+#endif
+#ifdef BITCOINJ
+    compiled.insert("BITCOINJ");
+#endif
+#ifdef DECRED_SECP256K1
+    compiled.insert("DECRED_SECP256K1");
+#endif
+#ifdef SECP256K1
+    compiled.insert("SECP256K1");
+#endif
+#ifdef NBITCOIN_SECP256K1
+    compiled.insert("NBITCOIN_SECP256K1");
+#endif
+
+    return compiled;
+  }
+
+  // Parse comma-separated module names from environment variable
+  static std::vector<std::string> parseModuleList(const char *modules_env) {
+    std::vector<std::string> result;
+    if (!modules_env || modules_env[0] == '\0') {
+      return result;
+    }
+
+    std::string modules_str(modules_env);
+    size_t start = 0;
+    size_t end = 0;
+
+    while ((end = modules_str.find(',', start)) != std::string::npos) {
+      std::string module = modules_str.substr(start, end - start);
+      // Trim whitespace
+      size_t first = module.find_first_not_of(" \t");
+      size_t last = module.find_last_not_of(" \t");
+      if (first != std::string::npos) {
+        result.push_back(module.substr(first, last - first + 1));
+      }
+      start = end + 1;
+    }
+
+    // Last token
+    std::string module = modules_str.substr(start);
+    size_t first = module.find_first_not_of(" \t");
+    size_t last = module.find_last_not_of(" \t");
+    if (first != std::string::npos) {
+      result.push_back(module.substr(first, last - first + 1));
+    }
+
+    return result;
+  }
+
+  std::set<std::string> enabled_;
+  bool all_enabled_ = true;
+  bool initialized_ = false;
+};
+
+} // namespace bitcoinfuzz

--- a/main.cpp
+++ b/main.cpp
@@ -1,7 +1,8 @@
 #include "driver.h"
-#include <algorithm>
 #include <bitcoinfuzz/basemodule.h>
-#include <cstring>
+#include <bitcoinfuzz/module_registry.h>
+#include <cstdlib>
+#include <iostream>
 #include <memory>
 
 #ifdef BITCOIN_CORE
@@ -104,67 +105,101 @@ std::shared_ptr<bitcoinfuzz::Driver> driver = nullptr;
 
 static bitcoinfuzz::ModuleLogger module_logger;
 
+static void InitializeRegistryOnce() {
+  std::string error = bitcoinfuzz::ModuleRegistry::instance().initialize();
+  if (!error.empty()) {
+    std::cerr << error << std::endl;
+    std::abort();
+  }
+}
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  InitializeRegistryOnce();
+
   const char *target = std::getenv("FUZZ");
   driver = std::make_shared<bitcoinfuzz::Driver>(module_logger);
+
+  auto &registry = bitcoinfuzz::ModuleRegistry::instance();
+
 #ifdef BITCOIN_CORE
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Bitcoin>());
+  if (registry.isEnabled("BITCOIN_CORE"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::Bitcoin>());
 #endif
 #ifdef RUST_BITCOIN
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Rustbitcoin>());
+  if (registry.isEnabled("RUST_BITCOIN"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::Rustbitcoin>());
 #endif
 #ifdef RUST_MINISCRIPT
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Rustminiscript>());
+  if (registry.isEnabled("RUST_MINISCRIPT"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::Rustminiscript>());
 #endif
 #ifdef TINY_MINISCRIPT
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Tinyminiscript>());
+  if (registry.isEnabled("TINY_MINISCRIPT"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::Tinyminiscript>());
 #endif
 #ifdef BTCD
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Btcd>());
+  if (registry.isEnabled("BTCD"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::Btcd>());
 #endif
 #ifdef NBITCOIN
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::NBitcoin>());
+  if (registry.isEnabled("NBITCOIN"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::NBitcoin>());
 #endif
 #ifdef LND
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Lnd>());
+  if (registry.isEnabled("LND"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::Lnd>());
 #endif
 #ifdef LDK
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Ldk>());
+  if (registry.isEnabled("LDK"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::Ldk>());
 #endif
 #ifdef NLIGHTNING
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::NLightning>());
+  if (registry.isEnabled("NLIGHTNING"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::NLightning>());
 #endif
 #ifdef EMBIT
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Embit>());
+  if (registry.isEnabled("EMBIT"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::Embit>());
 #endif
 #ifdef PYBITCOINKERNEL
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Pybitcoinkernel>());
+  if (registry.isEnabled("PYBITCOINKERNEL"))
+    driver->LoadModule(
+        std::make_shared<bitcoinfuzz::module::Pybitcoinkernel>());
 #endif
 #ifdef RUSTBITCOINKERNEL
-  driver->LoadModule(
-      std::make_shared<bitcoinfuzz::module::Rustbitcoinkernel>());
+  if (registry.isEnabled("RUSTBITCOINKERNEL"))
+    driver->LoadModule(
+        std::make_shared<bitcoinfuzz::module::Rustbitcoinkernel>());
 #endif
 #ifdef CLIGHTNING
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::CLightning>());
+  if (registry.isEnabled("CLIGHTNING"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::CLightning>());
 #endif
 #ifdef ECLAIR
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Eclair>());
+  if (registry.isEnabled("ECLAIR"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::Eclair>());
 #endif
 #ifdef LIGHTNING_KMP
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::LightningKmp>());
+  if (registry.isEnabled("LIGHTNING_KMP"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::LightningKmp>());
 #endif
 #ifdef BITCOINJ
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::BitcoinJ>());
+  if (registry.isEnabled("BITCOINJ"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::BitcoinJ>());
 #endif
 #ifdef DECRED_SECP256K1
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Decred_secp256k1>());
+  if (registry.isEnabled("DECRED_SECP256K1"))
+    driver->LoadModule(
+        std::make_shared<bitcoinfuzz::module::Decred_secp256k1>());
 #endif
 #ifdef SECP256K1
-  driver->LoadModule(std::make_shared<bitcoinfuzz::module::Secp256k1>());
+  if (registry.isEnabled("SECP256K1"))
+    driver->LoadModule(std::make_shared<bitcoinfuzz::module::Secp256k1>());
 #endif
 #ifdef NBITCOIN_SECP256K1
-  driver->LoadModule(
-      std::make_shared<bitcoinfuzz::module::NBitcoin_secp256k1>());
+  if (registry.isEnabled("NBITCOIN_SECP256K1"))
+    driver->LoadModule(
+        std::make_shared<bitcoinfuzz::module::NBitcoin_secp256k1>());
 #endif
 
 #ifdef CUSTOM_MUTATOR_BOLT11


### PR DESCRIPTION
Introduce a ModuleRegistry singleton that allows users to specify which
modules to load at runtime via the MODULES environment variable.

Changes:
- Add include/bitcoinfuzz/module_registry.h with ModuleRegistry class:
  - Singleton pattern with lazy initialization
  - initialize(): parses MODULES env var, validates against compiled modules
  - isEnabled(): checks if a module should be loaded at runtime
  - getCompiledModules(): returns set of all compiled module names
  - parseModuleList(): parses comma-separated module names with whitespace trimming

- Update main.cpp:
  - Call InitializeRegistryOnce() at start of each fuzzer invocation
  - Abort with error if requesting modules that weren't compiled
  - Gate each LoadModule() call with registry.isEnabled() check

- Update driver.cpp and helpers/jvmloader.cpp:
  - Add runtime isEnabled() checks for module-specific workarounds and paths
  - Allows module-specific code to be skipped when that module is disabled

Usage: MODULES="BITCOIN_CORE,RUST_BITCOIN" FUZZ=bip32_master_keygen ./bitcoinfuzz
If MODULES is unset or empty, all compiled modules are loaded (existing behavior).