### PR TITLE
Add decode_ellswift differential fuzzing target

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -204,6 +204,9 @@ jobs:
             target: "bip32_deserialize_extended_key"
             cxxflags: "-DNBITCOIN -DRUST_BITCOIN -DBITCOIN_CORE -DCUSTOM_MUTATOR_EXTENDED_KEY"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
+          - corpus: "decode_ellswift"
+            target: "decode_ellswift"
+            cxxflags: "-DBTCD -DSECP256K1"
 
     steps:
       - name: Checkout repo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,3 +302,15 @@ services:
     env_file: .env
     volumes:
       - ./docker:/app/data
+
+  decode_ellswift:
+    build:
+      context: .
+      tags:
+        - bitcoinfuzz:decode_ellswift
+      args:
+        CXXFLAGS: "-DSECP256K1 -DBTCD"
+        FUZZ: decode_ellswift
+    env_file: .env
+    volumes:
+      - ./docker:/app/data

--- a/driver.cpp
+++ b/driver.cpp
@@ -696,6 +696,34 @@ void Driver::Bip32DeserializeExtendedKey(
   }
 }
 
+void Driver::DecodeEllswiftTarget(std::span<const uint8_t> buffer) const {
+  FuzzedDataProvider provider(buffer.data(), buffer.size());
+  if (buffer.size() != 64)
+    return;
+
+  std::optional<std::string> last_response{std::nullopt};
+  std::string last_module_name;
+
+  for (auto &module : modules) {
+    std::optional<std::string> res{module.second->decode_ellswift(buffer)};
+    if (!res.has_value())
+      continue;
+    if (last_response.has_value()) {
+      if (*res != *last_response) {
+        std::cout << "DecodeEllswiftTarget Target failed" << std::endl;
+        std::cout << "Module: " << module.first << std::endl;
+        std::cout << "Result: " << *res << std::endl;
+        std::cout << "Module: " << last_module_name << std::endl;
+        std::cout << "Result: " << *last_response << std::endl;
+      }
+      assert(*res == *last_response);
+    }
+
+    last_response = res.value();
+    last_module_name = module.first;
+  }
+}
+
 void Driver::Run(const uint8_t *data, const size_t size,
                  const std::string &target) const {
   std::span<const uint8_t> buffer{data, size};
@@ -747,6 +775,8 @@ void Driver::Run(const uint8_t *data, const size_t size,
     this->SignSchnorrTarget(buffer);
   } else if (target == "bip32_deserialize_extended_key") {
     this->Bip32DeserializeExtendedKey(buffer);
+  } else if (target == "decode_ellswift") {
+    this->DecodeEllswiftTarget(buffer);
   } else {
     std::cout << "Target not defined!" << std::endl;
     assert(false);

--- a/driver.h
+++ b/driver.h
@@ -46,5 +46,6 @@ public:
   void ECDHTarget(std::span<const uint8_t> buffer) const;
   void SignSchnorrTarget(std::span<const uint8_t> buffer) const;
   void Bip32DeserializeExtendedKey(std::span<const uint8_t> buffer) const;
+  void DecodeEllswiftTarget(std::span<const uint8_t> buffer) const;
 };
 } // namespace bitcoinfuzz

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -131,4 +131,10 @@ std::optional<std::string> BaseModule::bip32_deserialize_extended_key(
     std::span<const uint8_t> buffer) const {
   return std::nullopt;
 }
+
+std::optional<std::string>
+BaseModule::decode_ellswift(std::span<const uint8_t> buffer) const {
+  return std::nullopt;
+}
+
 } // namespace bitcoinfuzz

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -58,10 +58,11 @@ public:
                                           std::span<const uint8_t> sign) const;
   virtual std::optional<std::string>
   ecdh(std::span<const uint8_t> buffer, std::span<const uint8_t> pubkey) const;
-
   virtual std::optional<std::string>
   sign_schnorr(std::span<const uint8_t> buffer, std::span<const uint8_t> hash,
                std::span<const uint8_t> aux) const;
+  virtual std::optional<std::string>
+  decode_ellswift(std::span<const uint8_t> buffer) const;
 
   virtual std::optional<std::string>
   bip32_deserialize_extended_key(std::span<const uint8_t> buffer) const;

--- a/modules/btcd/Makefile
+++ b/modules/btcd/Makefile
@@ -6,10 +6,10 @@ module.a: module.o btcd_wrapper/libbtcd_wrapper.a
 	bash ../../merge.sh module.a btcd_wrapper/libbtcd_wrapper.a module.o
 	ranlib module.a
 
-btcd_wrapper/libbtcd_wrapper.a:
+btcd_wrapper/libbtcd_wrapper.a: btcd_wrapper/wrapper.go
 	cd btcd_wrapper && go build -o libbtcd_wrapper.a -buildmode=c-archive -tags=libfuzzer -gcflags=all=-d=libfuzzer wrapper.go
 
-module.o: module.cpp
+module.o: module.cpp module.h
 	$(CXX) $(CXXFLAGS) -fPIC -c module.cpp -o module.o
 
 format:

--- a/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
+++ b/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
@@ -12,6 +12,8 @@
 
 #ifndef GO_CGO_GOSTRING_TYPEDEF
 typedef struct { const char *p; ptrdiff_t n; } _GoString_;
+extern size_t _GoStringLen(_GoString_ s);
+extern const char *_GoStringPtr(_GoString_ s);
 #endif
 
 #endif
@@ -55,9 +57,15 @@ typedef size_t GoUintptr;
 typedef float GoFloat32;
 typedef double GoFloat64;
 #ifdef _MSC_VER
+#if !defined(__cplusplus) || _MSVC_LANG <= 201402L
 #include <complex.h>
 typedef _Fcomplex GoComplex64;
 typedef _Dcomplex GoComplex128;
+#else
+#include <complex>
+typedef std::complex<float> GoComplex64;
+typedef std::complex<double> GoComplex128;
+#endif
 #else
 typedef float _Complex GoComplex64;
 typedef double _Complex GoComplex128;
@@ -96,6 +104,7 @@ extern char* BTCDParsePSBT(ByteArray data);
 extern char* BTCDAddress(ByteArray data);
 extern char* BTCDBip32MasterKeygen(ByteArray data);
 extern char* BTCDSignSchnorr(ByteArray privKey, ByteArray hash, ByteArray aux);
+extern char* BTCDDecodeEllswift(ByteArray buffer);
 
 #ifdef __cplusplus
 }

--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/btcsuite/btcd/addrmgr"
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ellswift"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
@@ -320,6 +321,36 @@ func BTCDSignSchnorr(privKey C.ByteArray, hash C.ByteArray, aux C.ByteArray) *C.
 	}
 
 	return C.CString(hex.EncodeToString(sig.Serialize()))
+}
+
+//export BTCDDecodeEllswift
+func BTCDDecodeEllswift(buffer C.ByteArray) *C.char {
+	ell64 := C.GoBytes(unsafe.Pointer(buffer.data), buffer.length)
+	u := new(btcec.FieldVal)
+	t := new(btcec.FieldVal)
+	u.SetBytes((*[32]byte)(ell64[0:32]))
+	t.SetBytes((*[32]byte)(ell64[32:64]))
+
+	tIsOdd := t.Normalize().IsOdd()
+
+	x, err := ellswift.XSwiftEC(u, t)
+	if err != nil {
+		panic(fmt.Sprintf("XSwiftEC failed unexpectedly: %v", err))
+	}
+
+	ySqr := new(btcec.FieldVal).SquareVal(x).Mul(x).AddInt(7)
+	y := new(btcec.FieldVal)
+	if !y.SquareRootVal(ySqr) {
+		panic("SquareRootVal failed: x from XSwiftEC should always be on curve")
+	}
+
+	// y parity should match original t parity
+	if y.IsOdd() != tIsOdd {
+		y.Negate(1).Normalize()
+	}
+	pubkey := btcec.NewPublicKey(x, y)
+
+	return C.CString(hex.EncodeToString(pubkey.SerializeCompressed()))
 }
 
 func main() {}

--- a/modules/btcd/module.cpp
+++ b/modules/btcd/module.cpp
@@ -150,5 +150,20 @@ Btcd::sign_schnorr(std::span<const uint8_t> buffer,
   return res;
 }
 
+std::optional<std::string>
+Btcd::decode_ellswift(std::span<const uint8_t> buffer) const {
+  ByteArray ell;
+  ell.data = (char *)buffer.data();
+  ell.length = buffer.size();
+
+  char *result = BTCDDecodeEllswift(ell);
+  if (!result)
+    return std::nullopt;
+
+  std::string res(result);
+  BTCDFreeString(result);
+  return res;
+}
+
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/btcd/module.h
+++ b/modules/btcd/module.h
@@ -29,6 +29,8 @@ public:
   std::optional<std::string>
   sign_schnorr(std::span<const uint8_t> buffer, std::span<const uint8_t> hash,
                std::span<const uint8_t> aux) const override;
+  std::optional<std::string>
+  decode_ellswift(std::span<const uint8_t> buffer) const override;
   ~Btcd() noexcept override = default;
 };
 

--- a/modules/secp256k1/module.cpp
+++ b/modules/secp256k1/module.cpp
@@ -3,6 +3,7 @@
 extern "C" {
 #include <secp256k1.h>
 #include <secp256k1_ecdh.h>
+#include <secp256k1_ellswift.h>
 #include <secp256k1_extrakeys.h>
 #include <secp256k1_schnorrsig.h>
 }
@@ -180,6 +181,19 @@ secp256k1_sign_schnorr(std::span<const uint8_t> buffer,
   return hex_encode(signature.data(), 64);
 }
 
+std::optional<std::string>
+secp256k1_decode_ellswift(std::span<const uint8_t> buffer) {
+  static size_t pubkey_len = SECP256K1_PUBKEY_COMPRESSED_LEN;
+  std::vector<uint8_t> pubkey_compressed(pubkey_len);
+  secp256k1_pubkey pubkey;
+  secp256k1_ellswift_decode(secp256k1_ctx, &pubkey, buffer.data());
+
+  secp256k1_ec_pubkey_serialize(secp256k1_ctx, pubkey_compressed.data(),
+                                &pubkey_len, &pubkey, SECP256K1_EC_COMPRESSED);
+
+  return hex_encode(pubkey_compressed.data(), pubkey_len);
+}
+
 namespace bitcoinfuzz {
 namespace module {
 Secp256k1::Secp256k1(void) : BaseModule("Secp256k1") { init(nullptr, nullptr); }
@@ -219,6 +233,11 @@ Secp256k1::sign_schnorr(std::span<const uint8_t> buffer,
                         std::span<const uint8_t> hash,
                         std::span<const uint8_t> aux) const {
   return secp256k1_sign_schnorr(buffer, hash, aux);
+}
+
+std::optional<std::string>
+Secp256k1::decode_ellswift(std::span<const uint8_t> buffer) const {
+  return secp256k1_decode_ellswift(buffer);
 }
 
 } // namespace module

--- a/modules/secp256k1/module.h
+++ b/modules/secp256k1/module.h
@@ -25,6 +25,8 @@ public:
   std::optional<std::string>
   sign_schnorr(std::span<const uint8_t> buffer, std::span<const uint8_t> hash,
                std::span<const uint8_t> aux) const override;
+  std::optional<std::string>
+  decode_ellswift(std::span<const uint8_t> buffer) const override;
   ~Secp256k1() noexcept override = default;
 };
 } // namespace module


### PR DESCRIPTION
Implements ellswift decoding differential fuzzing between secp256k1 and btcd.
Changes

- Add `decode_ellswift` target to base module interface
- Implement secp256k1 ellswift decoding using `secp256k1_ellswift_decode`
- Implement btcd ellswift decoding using `btcec/ellswift` package
- Add CI workflow and Docker Compose configuration