### PR TITLE
feat: print python errors

### DIFF
--- a/modules/embit/module.cpp
+++ b/modules/embit/module.cpp
@@ -72,6 +72,7 @@ cleanup:
   Py_XDECREF(input_obj);
 
   if (PyErr_Occurred()) {
+    PyErr_Print();
     PyObject *ptype, *pvalue, *ptraceback;
     PyErr_Fetch(&ptype, &pvalue, &ptraceback);
 

--- a/modules/pybitcoinkernel/module.cpp
+++ b/modules/pybitcoinkernel/module.cpp
@@ -72,6 +72,7 @@ cleanup:
   Py_XDECREF(input_obj);
 
   if (PyErr_Occurred()) {
+    PyErr_Print();
     PyObject *ptype, *pvalue, *ptraceback;
     PyErr_Fetch(&ptype, &pvalue, &ptraceback);
 


### PR DESCRIPTION
Sometimes, when I forget to use a virtual environment (venv) when trying to run a Python module, it looks like the fuzzing is working, but it's not.. Adding `PyErr_Print();` makes it clear that it's not working if the environment is not configured correctly.