### PR TITLE
build: improve Makefile dependency tracking and simplify build commands

### DIFF
--- a/.github/workflows/commit-by-commit-build.yml
+++ b/.github/workflows/commit-by-commit-build.yml
@@ -135,14 +135,14 @@ jobs:
         timeout-minutes: 5
         run: |
           rustup default nightly
-          cd modules/rustbitcoin && make cargo && make
+          cd modules/rustbitcoin && make
 
       - name: Build - rust-bitcoinkernel
         timeout-minutes: 5
         run: |
           if [ -d "modules/rustbitcoinkernel" ]; then
             rustup default nightly
-            cd modules/rustbitcoinkernel && make cargo && make
+            cd modules/rustbitcoinkernel && make
           else
             echo "Skipping rust-bitcoinkernel (not present in this commit)"
           fi
@@ -160,7 +160,7 @@ jobs:
         timeout-minutes: 5
         run: |
           rustup default nightly
-          cd modules/rustminiscript && make cargo && make
+          cd modules/rustminiscript && make
 
       - name: Build - btcd
         timeout-minutes: 5
@@ -186,7 +186,7 @@ jobs:
         timeout-minutes: 5
         run: |
           rustup default nightly
-          cd modules/ldk && make cargo && make
+          cd modules/ldk && make
 
       - name: Build - nlightning
         timeout-minutes: 5

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you prefer, you can still build the modules manually. Below are the steps for
 
     ```bash
     cd modules/rustbitcoin
-    make cargo && make
+    make
     export CXXFLAGS="$CXXFLAGS -DRUST_BITCOIN"
     ```
 
@@ -107,7 +107,7 @@ If you prefer, you can still build the modules manually. Below are the steps for
 
     ```bash
     cd modules/tinyminiscript
-    make cargo && make
+    make
     export CXXFLAGS="$CXXFLAGS -DTINY_MINISCRIPT"
     ```
 
@@ -115,7 +115,7 @@ If you prefer, you can still build the modules manually. Below are the steps for
 
     ```bash
     cd modules/rustminiscript
-    make cargo && make
+    make
     export CXXFLAGS="$CXXFLAGS -DRUST_MINISCRIPT"
     ```
 
@@ -155,7 +155,7 @@ If you prefer, you can still build the modules manually. Below are the steps for
 
     ```bash
     cd modules/rustbitcoinkernel
-    make cargo && make
+    make
     export CXXFLAGS="$CXXFLAGS -DRUSTBITCOINKERNEL"
 
 - ### py-bitcoinkernel
@@ -196,7 +196,7 @@ If you prefer, you can still build the modules manually. Below are the steps for
 
     ```bash
     cd modules/ldk
-    make cargo && make
+    make
     export CXXFLAGS="$CXXFLAGS -DLDK"
     ```
 

--- a/auto_build.py
+++ b/auto_build.py
@@ -101,7 +101,7 @@ def build_module(flag: str, quiet: bool):
     if needs_rust_nightly(flag):
         execute_in_dir(
             dirpath,
-            "rustup default nightly && make cargo && make",
+            "rustup default nightly && make",
             quiet,
         )
     else:

--- a/modules/bitcoinj/Makefile
+++ b/modules/bitcoinj/Makefile
@@ -41,3 +41,5 @@ check-format:
 clean:
 	rm -f *.o *.a $(BUILD_DIR)/app.zip
 	rm -rf lib bitcoinj_extracted
+
+.PHONY: all lib clean format check-format $(BUILD_DIR)/app.zip

--- a/modules/btcd/Makefile
+++ b/modules/btcd/Makefile
@@ -23,4 +23,4 @@ check-format:
 clean:
 	rm -f *.o *.a btcd_wrapper/*.a
 
-.PHONY: all clean
+.PHONY: all clean format check-format btcd_wrapper/libbtcd_wrapper.a

--- a/modules/decredsecp256k1/Makefile
+++ b/modules/decredsecp256k1/Makefile
@@ -23,4 +23,4 @@ check-format:
 clean:
 	rm -f *.o *.a decredsecp256k1_wrapper/*.a
 
-.PHONY: all clean
+.PHONY: all clean format check-format decredsecp256k1_wrapper/libdecredsecp256k1_wrapper.a

--- a/modules/eclair/Makefile
+++ b/modules/eclair/Makefile
@@ -56,3 +56,5 @@ check-format:
 clean:
 	rm -f *.o *.a eclair.zip *.class
 	rm -rf lib eclair_extracted
+
+.PHONY: all lib clean format check-format lib/EclairWrapper.jar eclair.zip

--- a/modules/embit/Makefile
+++ b/modules/embit/Makefile
@@ -21,3 +21,5 @@ check-format:
 
 clean:
 	rm -rf *.o *.a ./embit_lib/embit_lib.o ../../main.py
+
+.PHONY: all clean format check-format

--- a/modules/ldk/Makefile
+++ b/modules/ldk/Makefile
@@ -6,7 +6,7 @@ TARGET := $(shell rustc --print host-tuple)
 
 LDK_LIB_PATH := ./ldk_lib/target/$(TARGET)/release/libldk_lib.a
 
-cargo:
+$(LDK_LIB_PATH):
 	cd ldk_lib && \
 	RUSTFLAGS="\
 		--cfg fuzzing \
@@ -18,6 +18,8 @@ cargo:
 		-C llvm-args=-sanitizer-coverage-level=4 \
 		-C llvm-args=-simplifycfg-branch-fold-threshold=0" \
 	cargo +nightly build --release --target $(TARGET)
+
+cargo: $(LDK_LIB_PATH)
 
 module.a: module.o $(LDK_LIB_PATH)
 	bash ../../merge.sh module.a $(LDK_LIB_PATH) module.o
@@ -37,3 +39,5 @@ check-format:
 clean:
 	rm -rf *.o module.a
 	cd ldk_lib && cargo clean
+
+.PHONY: all cargo clean format check-format $(LDK_LIB_PATH)

--- a/modules/lightningkmp/Makefile
+++ b/modules/lightningkmp/Makefile
@@ -41,3 +41,5 @@ check-format:
 clean:
 	rm -f *.o *.a $(BUILD_DIR)/app.zip
 	rm -rf lib lightning_kmp_extracted
+
+.PHONY: all lib clean format check-format $(BUILD_DIR)/app.zip

--- a/modules/lnd/Makefile
+++ b/modules/lnd/Makefile
@@ -2,12 +2,14 @@ CXXFLAGS += -Wall -Wextra -std=c++20 -I. -I ../../include -I./lnd_wrapper
 
 all: module.a
 
-module.a: golang module.o lnd_wrapper/liblnd_wrapper.a
+module.a: module.o lnd_wrapper/liblnd_wrapper.a
 	bash ../../merge.sh module.a lnd_wrapper/liblnd_wrapper.a module.o
 	ranlib module.a
 
-golang:
+lnd_wrapper/liblnd_wrapper.a:
 	cd lnd_wrapper && go build -o liblnd_wrapper.a -buildmode=c-archive -tags=libfuzzer -gcflags=all=-d=libfuzzer wrapper.go
+
+golang: lnd_wrapper/liblnd_wrapper.a
 
 module.o: module.cpp
 	$(CXX) $(CXXFLAGS) -lscript -L. -fPIC -c module.cpp -o module.o
@@ -22,3 +24,5 @@ check-format:
 
 clean:
 	rm -f *.o *.a
+
+.PHONY: all golang clean format check-format lnd_wrapper/liblnd_wrapper.a

--- a/modules/nbitcoin/Makefile
+++ b/modules/nbitcoin/Makefile
@@ -40,4 +40,4 @@ check-format:
 clean:
 	rm -rf *.o module.a ./bin ./obj
 
-.PHONY: $(NBITCOIN_LIB_PATH)
+.PHONY: all clean format check-format $(NBITCOIN_LIB_PATH)

--- a/modules/nbitcoinsecp256k1/Makefile
+++ b/modules/nbitcoinsecp256k1/Makefile
@@ -40,4 +40,4 @@ check-format:
 clean:
 	rm -rf *.o module.a ./bin ./obj
 
-.PHONY: $(NBITCOIN_SECP256K1_LIB_PATH)
+.PHONY: all clean format check-format $(NBITCOIN_SECP256K1_LIB_PATH)

--- a/modules/nlightning/Makefile
+++ b/modules/nlightning/Makefile
@@ -40,4 +40,4 @@ check-format:
 clean:
 	rm -rf *.o module.a ./bin ./obj
 
-.PHONY: $(NLIGHTNING_LIB_PATH)
+.PHONY: all clean format check-format $(NLIGHTNING_LIB_PATH)

--- a/modules/pybitcoinkernel/Makefile
+++ b/modules/pybitcoinkernel/Makefile
@@ -21,3 +21,5 @@ check-format:
 
 clean:
 	rm -rf *.o *.a ./pybitcoinkernel_lib/pybitcoinkernel_lib.o ../../main.py
+
+.PHONY: all clean format check-format

--- a/modules/rustbitcoin/Makefile
+++ b/modules/rustbitcoin/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer -std=c++20 -I ../../include
 # MacOS: ./rust_bitcoin_lib/target/aarch64-apple-darwin/release/librust_bitcoin_lib.a
 RUST_LIB_PATH := ./rust_bitcoin_lib/target/release/librust_bitcoin_lib.a
 
-cargo:
+$(RUST_LIB_PATH):
 	cd rust_bitcoin_lib && \
 	RUSTFLAGS="\
 		-Z sanitizer=address \
@@ -15,6 +15,8 @@ cargo:
 		-C llvm-args=-sanitizer-coverage-level=4 \
 		-C llvm-args=-simplifycfg-branch-fold-threshold=0" \
 	cargo +nightly build --release
+
+cargo: $(RUST_LIB_PATH)
 
 module.a: module.o $(RUST_LIB_PATH)
 	bash ../../merge.sh module.a $(RUST_LIB_PATH) module.o
@@ -34,3 +36,5 @@ check-format:
 clean:
 	rm -rf *.o module.a
 	cd rust_bitcoin_lib && cargo clean
+
+.PHONY: all cargo clean format check-format $(RUST_LIB_PATH)

--- a/modules/rustbitcoinkernel/Makefile
+++ b/modules/rustbitcoinkernel/Makefile
@@ -3,7 +3,7 @@ all: module.a
 CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer-no-link -std=c++20 -I ../../include
 RUST_LIB_PATH := ./rustbitcoinkernel_lib/target/release/librustbitcoinkernel_lib.a
 
-cargo:
+$(RUST_LIB_PATH):
 	cd rustbitcoinkernel_lib && \
 	CFLAGS="-fsanitize=address,fuzzer-no-link -ftrivial-auto-var-init=pattern" \
     CXXFLAGS="-fsanitize=address,fuzzer-no-link -ftrivial-auto-var-init=pattern" \
@@ -17,6 +17,8 @@ cargo:
 		-C llvm-args=-sanitizer-coverage-level=4 \
 		-C llvm-args=-simplifycfg-branch-fold-threshold=0" \
 	cargo +nightly build --release
+
+cargo: $(RUST_LIB_PATH)
 
 module.a: module.o $(RUST_LIB_PATH)
 	bash ../../merge.sh module.a $(RUST_LIB_PATH) module.o
@@ -36,3 +38,5 @@ check-format:
 clean:
 	rm -rf *.o module.a
 	cd rustbitcoinkernel_lib && cargo clean
+
+.PHONY: all cargo clean format check-format $(RUST_LIB_PATH)

--- a/modules/rustminiscript/Makefile
+++ b/modules/rustminiscript/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer -std=c++20 -I ../../include
 # MacOS: ./rust_miniscript_lib/target/aarch64-apple-darwin/release/librust_bitcoin_lib.a
 RUST_MINISCRIPT_LIB_PATH := ./rust_miniscript_lib/target/release/librust_miniscript_lib.a
 
-cargo:
+$(RUST_MINISCRIPT_LIB_PATH):
 	cd rust_miniscript_lib && \
 	RUSTFLAGS="\
 		-Z sanitizer=address \
@@ -15,6 +15,8 @@ cargo:
 		-C llvm-args=-sanitizer-coverage-level=4 \
 		-C llvm-args=-simplifycfg-branch-fold-threshold=0" \
 	cargo +nightly build --release
+
+cargo: $(RUST_MINISCRIPT_LIB_PATH)
 
 module.a: module.o $(RUST_MINISCRIPT_LIB_PATH)
 	bash ../../merge.sh module.a $(RUST_MINISCRIPT_LIB_PATH) module.o
@@ -34,3 +36,5 @@ check-format:
 clean:
 	rm -rf *.o module.a
 	cd rust_miniscript_lib && cargo clean
+
+.PHONY: all cargo clean format check-format $(RUST_MINISCRIPT_LIB_PATH)

--- a/modules/secp256k1/Makefile
+++ b/modules/secp256k1/Makefile
@@ -39,4 +39,4 @@ clean:
 	rm -f *.o *.a
 	cd ../../external/secp256k1 && $(MAKE) clean || true
 
-.PHONY: clean
+.PHONY: all clean format check-format

--- a/modules/tinyminiscript/Makefile
+++ b/modules/tinyminiscript/Makefile
@@ -9,9 +9,9 @@ else
   TINY_LIB_EXT := so
 endif
 
-TINY_MINISCRIPT_LIB_PATH := ./tiny_miniscript_lib/target/release/libtiny_miniscript_lib.so
+TINY_MINISCRIPT_LIB_PATH := ./tiny_miniscript_lib/target/release/libtiny_miniscript_lib.$(TINY_LIB_EXT)
 
-cargo:
+$(TINY_MINISCRIPT_LIB_PATH):
 	cd tiny_miniscript_lib && \
 	RUSTFLAGS="\
 		-Z sanitizer=address \
@@ -22,7 +22,9 @@ cargo:
 		-C llvm-args=-sanitizer-coverage-level=4 \
 		-C llvm-args=-simplifycfg-branch-fold-threshold=0" \
 	cargo +nightly build --release
-	cp $(TINY_MINISCRIPT_LIB_PATH) ../../libtiny_miniscript_lib.so
+	cp $(TINY_MINISCRIPT_LIB_PATH) ../../libtiny_miniscript_lib.$(TINY_LIB_EXT)
+
+cargo: $(TINY_MINISCRIPT_LIB_PATH)
 
 module.a: module.o $(TINY_MINISCRIPT_LIB_PATH)
 	ar rcs module.a module.o
@@ -41,3 +43,5 @@ check-format:
 clean:
 	rm -rf *.o module.a
 	cd tiny_miniscript_lib && cargo clean
+
+.PHONY: all cargo clean format check-format $(TINY_MINISCRIPT_LIB_PATH)


### PR DESCRIPTION
- Use proper file targets instead of phony cargo targets for incremental builds
- Simplify build commands: `make` now handles cargo builds automatically
- Add missing .PHONY declarations across all module Makefiles
- Fix tinyminiscript to use TINY_LIB_EXT variable consistently