### PR TITLE
Add verify_schnorr differential fuzzing target 

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -208,6 +208,10 @@ jobs:
           - corpus: "decode_ellswift"
             target: "decode_ellswift"
             cxxflags: "-DBTCD -DSECP256K1"
+          - corpus: "schnorr_verify"
+            target: "schnorr_verify"
+            cxxflags: "-DBTCD -DSECP256K1 -DNBITCOIN_SECP256K1 -DCUSTOM_MUTATOR_SCHNORR_SIGNATURE"
+            asan_options: "detect_leaks=0:detect_container_overflow=0"
 
     steps:
       - name: Checkout repo

--- a/custommutator/mutators/schnorr_signature.h
+++ b/custommutator/mutators/schnorr_signature.h
@@ -1,0 +1,75 @@
+#ifndef BITCOINFUZZ_CUSTOMMUTATOR_SECP256K1_SIGNATURE_H
+#define BITCOINFUZZ_CUSTOMMUTATOR_SECP256K1_SIGNATURE_H
+
+#define template c_template
+
+extern "C" {
+#include <external/secp256k1/include/secp256k1.h>
+#include <external/secp256k1/include/secp256k1_schnorrsig.h>
+}
+
+#undef template
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <cstdlib>
+#include <span>
+
+static constexpr size_t MIN_BUFFER_SIZE = 64;
+static constexpr size_t MAX_SIGNATURE_DER_SIZE = 74;
+static constexpr size_t SCHNORR_SIGNATURE_SIZE = 64;
+static secp256k1_context *secp256k1_ctx = nullptr;
+
+static secp256k1_context *get_secp256k1_context() {
+  if (!secp256k1_ctx) {
+    secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
+  }
+  return secp256k1_ctx;
+}
+
+extern "C" size_t LLVMFuzzerMutate(uint8_t *Data, size_t Size, size_t MaxSize);
+
+extern "C" size_t LLVMFuzzerCustomMutator(uint8_t *fuzz_data, size_t size,
+                                          size_t max_size, unsigned int seed) {
+  size_t new_size = LLVMFuzzerMutate(fuzz_data, size, max_size);
+
+  if (new_size < MIN_BUFFER_SIZE) {
+    return new_size;
+  }
+
+  std::srand(seed);
+  // 50% chance to skip signature generation and test invalid/malformed inputs
+  if (std::rand() % 2 == 0) {
+    return new_size;
+  }
+
+  secp256k1_context *ctx = get_secp256k1_context();
+  if (!ctx) {
+    return new_size;
+  }
+
+  unsigned char signature[64];
+  secp256k1_keypair keypair;
+
+  std::span<const uint8_t> buffer(fuzz_data, MIN_BUFFER_SIZE);
+  std::span<const uint8_t> privkey = buffer.subspan(0, 32);
+  std::span<const uint8_t> hash = buffer.subspan(32, 32);
+
+  if (secp256k1_keypair_create(ctx, &keypair, privkey.data()) == 0) {
+    return new_size;
+  }
+
+  if (secp256k1_schnorrsig_sign32(ctx, signature, hash.data(), &keypair, nullptr) == 0) {
+    return new_size;
+  }
+
+  if (MIN_BUFFER_SIZE + SCHNORR_SIGNATURE_SIZE <= max_size) {
+    memcpy(fuzz_data + MIN_BUFFER_SIZE, signature, SCHNORR_SIGNATURE_SIZE);
+    return MIN_BUFFER_SIZE + SCHNORR_SIGNATURE_SIZE;
+  }
+
+  return new_size;
+}
+
+#endif // BITCOINFUZZ_CUSTOMMUTATOR_SECP256K1_SIGNATURE_H

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -316,3 +316,19 @@ services:
     env_file: .env
     volumes:
       - ./docker:/app/data
+  
+  schnorr_verify:
+    build:
+      context: .
+      tags:
+        - bitcoinfuzz:schnorr_verify
+      args:
+        CXXFLAGS: "-DBTCD -DSECP256K1 -DNBITCOIN_SECP256K1 -DCUSTOM_MUTATOR_SCHNORR_SIGNATURE"
+        FUZZ: schnorr_verify
+    environment:
+      LIBFUZZ_DETECT_LEAKS: 0
+      ASAN_OPTIONS: detect_leaks=0
+    env_file: .env
+    volumes:
+      - ./docker:/app/data
+

--- a/driver.cpp
+++ b/driver.cpp
@@ -740,6 +740,38 @@ void Driver::DecodeEllswiftTarget(std::span<const uint8_t> buffer) const {
   }
 }
 
+void Driver::SchnorrVerifyTarget(std::span<const uint8_t> buffer) const {
+  FuzzedDataProvider provider(buffer.data(), buffer.size());
+  if (buffer.size() != 128)
+    return;
+
+  std::vector<uint8_t> privkey = provider.ConsumeBytes<uint8_t>(32);
+  std::vector<uint8_t> hash = provider.ConsumeBytes<uint8_t>(32);
+  std::vector<uint8_t> sign = provider.ConsumeBytes<uint8_t>(64);
+  std::optional<std::string> last_response{std::nullopt};
+  std::string last_module_name;
+
+  for (auto &module : modules) {
+    std::optional<std::string> res{
+        module.second->schnorr_verify(privkey, hash, sign)};
+    if (!res.has_value())
+      continue;
+    if (last_response.has_value()) {
+      if (*res != *last_response) {
+        std::cout << "SchnorrVerifyTarget failed" << std::endl;
+        std::cout << "Module: " << module.first << std::endl;
+        std::cout << "Result: " << *res << std::endl;
+        std::cout << "Module: " << last_module_name << std::endl;
+        std::cout << "Result: " << *last_response << std::endl;
+      }
+      assert(*res == *last_response);
+    }
+
+    last_response = res.value();
+    last_module_name = module.first;
+  }
+}
+
 void Driver::Run(const uint8_t *data, const size_t size,
                  const std::string &target) const {
   std::span<const uint8_t> buffer{data, size};
@@ -793,6 +825,8 @@ void Driver::Run(const uint8_t *data, const size_t size,
     this->Bip32DeserializeExtendedKeyTarget(buffer);
   } else if (target == "decode_ellswift") {
     this->DecodeEllswiftTarget(buffer);
+  } else if (target == "schnorr_verify") {
+    this->SchnorrVerifyTarget(buffer);
   } else {
     std::cout << "Target not defined!" << std::endl;
     assert(false);

--- a/driver.cpp
+++ b/driver.cpp
@@ -686,7 +686,7 @@ void Driver::SignSchnorrTarget(std::span<const uint8_t> buffer) const {
   }
 }
 
-void Driver::Bip32DeserializeExtendedKey(
+void Driver::Bip32DeserializeExtendedKeyTarget(
     std::span<const uint8_t> buffer) const {
   std::optional<std::string> last_response{std::nullopt};
   std::string last_module_name;
@@ -790,7 +790,7 @@ void Driver::Run(const uint8_t *data, const size_t size,
   } else if (target == "sign_schnorr") {
     this->SignSchnorrTarget(buffer);
   } else if (target == "bip32_deserialize_extended_key") {
-    this->Bip32DeserializeExtendedKey(buffer);
+    this->Bip32DeserializeExtendedKeyTarget(buffer);
   } else if (target == "decode_ellswift") {
     this->DecodeEllswiftTarget(buffer);
   } else {

--- a/driver.h
+++ b/driver.h
@@ -47,5 +47,6 @@ public:
   void SignSchnorrTarget(std::span<const uint8_t> buffer) const;
   void Bip32DeserializeExtendedKeyTarget(std::span<const uint8_t> buffer) const;
   void DecodeEllswiftTarget(std::span<const uint8_t> buffer) const;
+  void SchnorrVerifyTarget(std::span<const uint8_t> buffer) const;
 };
 } // namespace bitcoinfuzz

--- a/driver.h
+++ b/driver.h
@@ -45,7 +45,7 @@ public:
   void SignVerifyTarget(std::span<const uint8_t> buffer) const;
   void ECDHTarget(std::span<const uint8_t> buffer) const;
   void SignSchnorrTarget(std::span<const uint8_t> buffer) const;
-  void Bip32DeserializeExtendedKey(std::span<const uint8_t> buffer) const;
+  void Bip32DeserializeExtendedKeyTarget(std::span<const uint8_t> buffer) const;
   void DecodeEllswiftTarget(std::span<const uint8_t> buffer) const;
 };
 } // namespace bitcoinfuzz

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -137,4 +137,10 @@ BaseModule::decode_ellswift(std::span<const uint8_t> buffer) const {
   return std::nullopt;
 }
 
+std::optional<std::string>
+BaseModule::schnorr_verify(std::span<const uint8_t> privkey,
+                           std::span<const uint8_t> hash,
+                           std::span<const uint8_t> sign) const {
+  return std::nullopt;
+}
 } // namespace bitcoinfuzz

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -67,6 +67,11 @@ public:
   virtual std::optional<std::string>
   bip32_deserialize_extended_key(std::span<const uint8_t> buffer) const;
 
+  virtual std::optional<std::string>
+  schnorr_verify(std::span<const uint8_t> privkey,
+                 std::span<const uint8_t> hash,
+                 std::span<const uint8_t> sign) const;
+
   virtual ~BaseModule() noexcept;
 };
 } // namespace bitcoinfuzz

--- a/main.cpp
+++ b/main.cpp
@@ -112,6 +112,10 @@
 #include <custommutator/mutators/extended_key.h>
 #endif
 
+#ifdef CUSTOM_MUTATOR_SCHNORR_SIGNATURE
+#include <custommutator/mutators/schnorr_signature.h>
+#endif
+
 std::shared_ptr<bitcoinfuzz::Driver> driver = nullptr;
 
 static bitcoinfuzz::ModuleLogger module_logger;
@@ -207,6 +211,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
 #ifdef CUSTOM_MUTATOR_EXTENDED_KEY
   module_logger.addCustomMutator("Extended Key Base58 Custom Mutator");
+#endif
+
+#ifdef CUSTOM_MUTATOR_SCHNORR_SIGNATURE
+  module_logger.addCustomMutator("Schnorr Signature Custom Mutator");
 #endif
 
   module_logger.logModules();

--- a/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
+++ b/modules/btcd/btcd_wrapper/libbtcd_wrapper.h
@@ -105,6 +105,7 @@ extern char* BTCDAddress(ByteArray data);
 extern char* BTCDBip32MasterKeygen(ByteArray data);
 extern char* BTCDSignSchnorr(ByteArray privKey, ByteArray hash, ByteArray aux);
 extern char* BTCDDecodeEllswift(ByteArray buffer);
+extern char* BTCDSchnorrVerify(ByteArray buffer, ByteArray hash, ByteArray sig);
 
 #ifdef __cplusplus
 }

--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -417,4 +417,23 @@ func BTCDDecodeEllswift(buffer C.ByteArray) *C.char {
 	return C.CString(hex.EncodeToString(pubkey.SerializeCompressed()))
 }
 
+//export BTCDSchnorrVerify
+func BTCDSchnorrVerify(buffer C.ByteArray, hash C.ByteArray, sig C.ByteArray) *C.char {
+	privkeyBytes := C.GoBytes(unsafe.Pointer(buffer.data), buffer.length)
+	hashBytes := C.GoBytes(unsafe.Pointer(hash.data), hash.length)
+	sigBytes := C.GoBytes(unsafe.Pointer(sig.data), sig.length)
+
+	_, pubkey := btcec.PrivKeyFromBytes(privkeyBytes)
+
+	signature, err := schnorr.ParseSignature(sigBytes)
+	if err != nil {
+		return C.CString("INVALID")
+	}
+
+	if !signature.Verify(hashBytes, pubkey) {
+		return C.CString("INVALID")
+	}
+	return C.CString("VALID")
+}
+
 func main() {}

--- a/modules/btcd/module.cpp
+++ b/modules/btcd/module.cpp
@@ -165,5 +165,30 @@ Btcd::decode_ellswift(std::span<const uint8_t> buffer) const {
   return res;
 }
 
+std::optional<std::string>
+Btcd::schnorr_verify(std::span<const uint8_t> privkey_bytes,
+                     std::span<const uint8_t> hash,
+                     std::span<const uint8_t> sig) const {
+  ByteArray privkey;
+  privkey.data = (char *)privkey_bytes.data();
+  privkey.length = privkey_bytes.size();
+
+  ByteArray msgHash;
+  msgHash.data = (char *)hash.data();
+  msgHash.length = hash.size();
+
+  ByteArray signature;
+  signature.data = (char *)sig.data();
+  signature.length = sig.size();
+
+  char *result = BTCDSchnorrVerify(privkey, msgHash, signature);
+  if (!result)
+    return std::nullopt;
+
+  std::string res(result);
+  BTCDFreeString(result);
+  return res;
+}
+
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/btcd/module.h
+++ b/modules/btcd/module.h
@@ -31,6 +31,10 @@ public:
                std::span<const uint8_t> aux) const override;
   std::optional<std::string>
   decode_ellswift(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  schnorr_verify(std::span<const uint8_t> privkey,
+                 std::span<const uint8_t> hash,
+                 std::span<const uint8_t> sign) const override;
   ~Btcd() noexcept override = default;
 };
 

--- a/modules/nbitcoinsecp256k1/NBitcoinSecp256k1/NBitcoinSecp256k1Bridge.cs
+++ b/modules/nbitcoinsecp256k1/NBitcoinSecp256k1/NBitcoinSecp256k1Bridge.cs
@@ -154,6 +154,43 @@ public static unsafe class Bridge
         }
     }
 
+    [UnmanagedCallersOnly(EntryPoint = "nbitcoinsecp256k1_schnorr_verify")]
+    public static unsafe IntPtr SchnorrVerify(
+        byte* privateKey32,
+        byte* hash32,
+        byte* sig64)
+    {
+        var privateKeyBytes = new ReadOnlySpan<byte>(privateKey32, 32);
+        var hashBytes = new ReadOnlySpan<byte>(hash32, 32);
+        var sigBytes = new ReadOnlySpan<byte>(sig64, 64);
+        try
+        {
+            Context ctx = Context.Instance;
+            if (!ctx.TryCreateECPrivKey(privateKeyBytes, out var privKey))
+            {
+                return Marshal.StringToCoTaskMemUTF8("INVALID");
+            }
+
+            if (!SecpSchnorrSignature.TryCreate(sigBytes.ToArray(), out var sig))
+            {
+                return Marshal.StringToCoTaskMemUTF8("INVALID");
+            }
+
+            ECXOnlyPubKey pubkey = privKey.CreateXOnlyPubKey();
+
+            if (pubkey.SigVerifyBIP340(sig, hashBytes) == false)
+            {
+                return Marshal.StringToCoTaskMemUTF8("INVALID");
+            }
+
+            return Marshal.StringToCoTaskMemUTF8("VALID");
+        }
+        catch
+        {
+            return Marshal.StringToCoTaskMemUTF8("INVALID");
+        }
+    }
+
     [UnmanagedCallersOnly(EntryPoint = "nbitcoinsecp256k1_free_c_string")]
     public static void FreeString(IntPtr ptr)
     {

--- a/modules/nbitcoinsecp256k1/NBitcoinSecp256k1/nbitcoinsecp256k1_lib.h
+++ b/modules/nbitcoinsecp256k1/NBitcoinSecp256k1/nbitcoinsecp256k1_lib.h
@@ -16,4 +16,8 @@ extern "C" bool nbitcoinsecp256k1_sign_verify(const uint8_t *buffer,
 extern "C" char *nbitcoinsecp256k1_ecdh(const uint8_t *buffer,
                                         const uint8_t *pubkey);
 
+extern "C" char *nbitcoinsecp256k1_schnorr_verify(const uint8_t *private_key_32,
+                                                  const uint8_t *hash_32,
+                                                  const uint8_t *sig_64);
+
 extern "C" void nbitcoinsecp256k1_free_c_string(void *ptr);

--- a/modules/nbitcoinsecp256k1/module.cpp
+++ b/modules/nbitcoinsecp256k1/module.cpp
@@ -52,5 +52,17 @@ NBitcoin_secp256k1::ecdh(std::span<const uint8_t> buffer,
   nbitcoinsecp256k1_free_c_string(p);
   return s;
 }
+std::optional<std::string>
+NBitcoin_secp256k1::schnorr_verify(std::span<const uint8_t> privkey,
+                                   std::span<const uint8_t> hash,
+                                   std::span<const uint8_t> sign) const {
+  char *p = nbitcoinsecp256k1_schnorr_verify(privkey.data(), hash.data(),
+                                             sign.data());
+  if (!p)
+    return std::nullopt;
+  std::string s(p);
+  nbitcoinsecp256k1_free_c_string(p);
+  return s;
+}
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/nbitcoinsecp256k1/module.h
+++ b/modules/nbitcoinsecp256k1/module.h
@@ -21,6 +21,10 @@ public:
   std::optional<std::string>
   ecdh(std::span<const uint8_t> buffer,
        std::span<const uint8_t> pubkey) const override;
+  std::optional<std::string>
+  schnorr_verify(std::span<const uint8_t> privkey,
+                 std::span<const uint8_t> hash,
+                 std::span<const uint8_t> sign) const override;
   ~NBitcoin_secp256k1() noexcept override = default;
 };
 } // namespace module

--- a/modules/secp256k1/module.cpp
+++ b/modules/secp256k1/module.cpp
@@ -194,6 +194,26 @@ secp256k1_decode_ellswift(std::span<const uint8_t> buffer) {
   return hex_encode(pubkey_compressed.data(), pubkey_len);
 }
 
+std::optional<std::string>
+secp256k1_schnorr_verify(std::span<const uint8_t> privkey,
+                         std::span<const uint8_t> hash,
+                         std::span<const uint8_t> sig) {
+  secp256k1_pubkey pubkey;
+  secp256k1_xonly_pubkey xonly_pubkey;
+  int pk_parity;
+
+  if (!secp256k1_ec_pubkey_create(secp256k1_ctx, &pubkey, privkey.data())) {
+    return "INVALID";
+  }
+  secp256k1_xonly_pubkey_from_pubkey(secp256k1_ctx, &xonly_pubkey, &pk_parity,
+                                     &pubkey);
+  if (secp256k1_schnorrsig_verify(secp256k1_ctx, sig.data(), hash.data(),
+                                  hash.size(), &xonly_pubkey) == 0) {
+    return "INVALID";
+  }
+  return "VALID";
+}
+
 namespace bitcoinfuzz {
 namespace module {
 Secp256k1::Secp256k1(void) : BaseModule("Secp256k1") { init(nullptr, nullptr); }
@@ -238,6 +258,12 @@ Secp256k1::sign_schnorr(std::span<const uint8_t> buffer,
 std::optional<std::string>
 Secp256k1::decode_ellswift(std::span<const uint8_t> buffer) const {
   return secp256k1_decode_ellswift(buffer);
+}
+std::optional<std::string>
+Secp256k1::schnorr_verify(std::span<const uint8_t> privkey,
+                          std::span<const uint8_t> hash,
+                          std::span<const uint8_t> sign) const {
+  return secp256k1_schnorr_verify(privkey, hash, sign);
 }
 
 } // namespace module

--- a/modules/secp256k1/module.h
+++ b/modules/secp256k1/module.h
@@ -27,6 +27,10 @@ public:
                std::span<const uint8_t> aux) const override;
   std::optional<std::string>
   decode_ellswift(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  schnorr_verify(std::span<const uint8_t> privkey,
+                 std::span<const uint8_t> hash,
+                 std::span<const uint8_t> sign) const override;
   ~Secp256k1() noexcept override = default;
 };
 } // namespace module


### PR DESCRIPTION
Implements Schnorr signature verification differential fuzzing between `secp256k1`, `btcd`, and `NBitcoinSecp256k1`. Changes:

- Add `schnorr_verify` target to base module interface
- Implement `secp256k1` verification using `secp256k1_schnorrsig_verify`
- Implement `btcd` verification using `schnorr.ParseSignature` and Verify
- Implement `NBitcoinSecp256k1` verification using `ECXOnlyPubKey.SigVerifyBIP340`
- Add custom mutator for generating valid Schnorr signatures (50% probability)
- Add CI workflow and Docker Compose configuration