### PR TITLE
refactor(addrv2): change return format to JSON array with detailed address info

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -274,6 +274,22 @@ void Driver::AddrV2Target(std::span<const uint8_t> buffer) const {
       continue;
     if (last_response.has_value()) {
       if (*res != *last_response) {
+#ifdef BTCD
+        // Skip mismatches involving btcd when i2p or cjdns addresses are
+        // present (btcd always skips i2p and cjdns)
+        bool involves_btcd =
+            (module.first == "Btcd" || last_module_name == "Btcd");
+        bool has_i2p_or_cjdns =
+            (res->find("i2p") != std::string::npos ||
+             res->find("cjdns") != std::string::npos ||
+             last_response->find("i2p") != std::string::npos ||
+             last_response->find("cjdns") != std::string::npos);
+        if (involves_btcd && has_i2p_or_cjdns) {
+          last_response = *res;
+          last_module_name = module.first;
+          continue;
+        }
+#endif
         std::cout << "Addrv2 parse failed" << std::endl;
         std::cout << "Module: " << module.first << std::endl;
         std::cout << "Result: " << *res << std::endl;

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -393,31 +393,61 @@ std::optional<std::string>
 Bitcoin::addrv2_parse(std::span<const uint8_t> buffer) const {
   std::vector<CAddress> addrs;
   DataStream ds{buffer};
-  uint64_t clearnet{0}, tor{0}, i2p{0}, cjdns{0};
   try {
     ds >> CAddress::V2_NETWORK(addrs);
-    if (addrs.size() > 1000)
-      return "clearnet=0tor=0cjdns=0i2p=0";
-    for (auto &addr : addrs) {
-      if (addr.IsIPv4() || addr.IsIPv6())
-        clearnet++;
-      if (addr.IsTor())
-        tor++;
-      if (addr.IsI2P())
-        i2p++;
-      if (addr.IsCJDNS())
-        cjdns++;
-      if (!addr.IsRoutable())
-        return "clearnet=0tor=0cjdns=0i2p=0";
-    }
   } catch (const std::ios_base::failure &e) {
-    // TODO: remove workaround to make it compatible with Core
-    return std::nullopt;
-    // return "clearnet=0tor=0cjdns=0i2p=0";
+    return "[]";
   }
 
-  return "clearnet=" + std::to_string(clearnet) + "tor=" + std::to_string(tor) +
-         "cjdns=" + std::to_string(cjdns) + "i2p=" + std::to_string(i2p);
+  std::string result = "[";
+  bool first = true;
+  for (const auto &addr : addrs) {
+    if (!addr.IsRoutable()) {
+      continue;
+    }
+
+    if (!first) {
+      result += ",";
+    }
+    first = false;
+
+    auto addr_bytes = addr.GetAddrBytes();
+    std::string addr_hex;
+    if (addr.IsIPv4() && addr_bytes.size() == 16) {
+      // GetAddrBytes returns IPv4-mapped IPv6 format (16 bytes), extract last 4
+      // bytes
+      addr_hex = HexStr(std::span(addr_bytes).last(4));
+    } else {
+      addr_hex = HexStr(addr_bytes);
+    }
+    uint32_t time =
+        static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(
+                                  addr.nTime.time_since_epoch())
+                                  .count());
+    uint64_t services = static_cast<uint64_t>(addr.nServices);
+    uint16_t port = addr.GetPort();
+
+    std::string addr_type;
+    if (addr.IsIPv4()) {
+      addr_type = "ipv4";
+    } else if (addr.IsIPv6()) {
+      addr_type = "ipv6";
+    } else if (addr.IsTor()) {
+      addr_type = "tor";
+    } else if (addr.IsI2P()) {
+      addr_type = "i2p";
+    } else if (addr.IsCJDNS()) {
+      addr_type = "cjdns";
+    }
+
+    result += "{\"addr\":\"" + addr_hex + "\",\"type\":\"" + addr_type +
+              "\",\"time\":\"" + std::to_string(time) + "\",\"services\":\"" +
+              std::to_string(services) + "\",\"port\":\"" +
+              std::to_string(port) + "\"}";
+  }
+  result += "]";
+
+  return result;
 }
 
 std::optional<std::string>

--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -15,6 +15,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math/big"
+	"net"
+	"reflect"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -96,47 +98,109 @@ func BTCDParseP2PMessage(messageData C.ByteArray) *C.char {
 	return C.CString(msg.Command())
 }
 
+// getAddrBytes extracts raw address bytes from a net.Addr using reflection
+// since btcd's address types are unexported
+func getAddrBytes(addr net.Addr) []byte {
+	v := reflect.ValueOf(addr)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	addrField := v.FieldByName("addr")
+	if !addrField.IsValid() {
+		return nil
+	}
+	// Get the underlying bytes from the array
+	length := addrField.Len()
+	result := make([]byte, length)
+	for i := 0; i < length; i++ {
+		result[i] = byte(addrField.Index(i).Uint())
+	}
+	return result
+}
+
+// getAddrType determines the address type from a net.Addr using reflection
+// to inspect the underlying type name since btcd's address types are unexported
+func getAddrType(addr net.Addr) string {
+	typeName := reflect.TypeOf(addr).String()
+	switch {
+	case strings.Contains(typeName, "ipv4Addr"):
+		return "ipv4"
+	case strings.Contains(typeName, "ipv6Addr"):
+		return "ipv6"
+	case strings.Contains(typeName, "torv3Addr"):
+		return "tor"
+	case strings.Contains(typeName, "torv2Addr"):
+		return "torv2"
+	case strings.Contains(typeName, "i2pAddr"):
+		return "i2p"
+	case strings.Contains(typeName, "cjdnsAddr"):
+		return "cjdns"
+	default:
+		return ""
+	}
+}
+
 //export BTCDAddrv2
 func BTCDAddrv2(addrv2Data C.ByteArray) *C.char {
 	data := C.GoBytes(unsafe.Pointer(addrv2Data.data), addrv2Data.length)
 	r := bytes.NewReader(data)
 	m := &wire.MsgAddrV2{}
 	err := m.BtcDecode(r, 0, wire.WitnessEncoding)
+	if err != nil {
+		// BTCD parses TorV2, so it may return an error for an invalid address size
+		// of a TorV2, which other implementations would not throw.
+		if err == wire.ErrInvalidAddressSize {
+			return nil
+		}
+		return C.CString("[]")
+	}
 
-	clearnet_count := 0
-	tor_count := 0
-	cjdns_count := 0
-	i2p_count := 0
+	// IPv4-mapped IPv6 prefix (::ffff:0:0/96) - RFC 4291
+	ipv4MappedPrefix := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF}
 
+	var entries []string
 	for i := 0; i < len(m.AddrList); i++ {
 		if m.AddrList[i].Addr != nil {
+			addr := m.AddrList[i].Addr
+			addrBytes := getAddrBytes(addr)
+			if addrBytes == nil {
+				continue
+			}
+			addrHex := hex.EncodeToString(addrBytes)
+			addrType := getAddrType(addr)
 			if !addrmgr.IsRoutable(m.AddrList[i]) {
-				return C.CString("clearnet=0tor=0cjdns=0i2p=0")
+				continue
 			}
-			switch m.AddrList[i].Addr.Network() {
-			case string(1):
-				clearnet_count += 1
-			case string(2):
-				clearnet_count += 1
-			case string(3):
-				//Bitcoin Core does not support torv2 anymore
-				tor_count += 0
-			case string(4):
-				tor_count += 1
-			case string(5):
-				i2p_count += 1
-			case string(6):
-				cjdns_count += 1
+			if addrType == "torv2" {
+				continue
 			}
+
+			// These verification should be in BTCD library.
+			if addrType == "ipv6" {
+				// Skip IPv4-mapped IPv6 addresses (RFC 4291)
+				// These should use network ID 0x01 (IPv4), not 0x02 (IPv6)
+				if len(addrBytes) >= 12 && bytes.HasPrefix(addrBytes, ipv4MappedPrefix) {
+					continue
+				}
+
+				// RFC 7343 - ORCHIDv2 - 2001:20::/28
+				if addrBytes[0] == 0x20 && addrBytes[1] == 0x01 &&
+					addrBytes[2] == 0x00 && (addrBytes[3]&0xf0) == 0x20 {
+					continue
+				}
+			}
+
+			time := m.AddrList[i].Timestamp.Unix()
+			services := m.AddrList[i].Services
+			port := m.AddrList[i].Port
+
+			entry := fmt.Sprintf("{\"addr\":\"%s\",\"type\":\"%s\",\"time\":\"%d\",\"services\":\"%d\",\"port\":\"%d\"}",
+				addrHex, addrType, time, services, port)
+			entries = append(entries, entry)
 		}
 	}
 
-	if err != nil {
-		return C.CString("clearnet=0tor=0cjdns=0i2p=0")
-	}
-
-	return C.CString(fmt.Sprintf("clearnet=%dtor=%dcjdns=%di2p=%d",
-		clearnet_count, tor_count, cjdns_count, i2p_count))
+	return C.CString("[" + strings.Join(entries, ",") + "]")
 }
 
 //export BTCDScriptAsm

--- a/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
+++ b/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
@@ -18,6 +18,8 @@ use p2p::message::{AddrV2Payload, RawNetworkMessage};
 use p2p::Magic;
 use std::ffi::CStr;
 use std::ffi::CString;
+use std::net::Ipv4Addr;
+use std::net::Ipv6Addr;
 use std::os::raw::c_char;
 use std::slice;
 use std::str::{FromStr, Utf8Error};
@@ -199,41 +201,144 @@ pub unsafe extern "C" fn rust_bitcoin_psbt_parse(data: *const u8, len: usize) ->
     }
 }
 
+/// Converts AddrV2 to hex string representation of its raw bytes
+fn addrv2_to_hex(addr: &AddrV2) -> String {
+    match addr {
+        AddrV2::Ipv4(ip) => ip.octets().iter().map(|b| format!("{:02x}", b)).collect(),
+        AddrV2::Ipv6(ip) => ip.octets().iter().map(|b| format!("{:02x}", b)).collect(),
+        AddrV2::TorV3(bytes) => bytes.iter().map(|b| format!("{:02x}", b)).collect(),
+        AddrV2::I2p(bytes) => bytes.iter().map(|b| format!("{:02x}", b)).collect(),
+        AddrV2::Cjdns(ip) => ip.octets().iter().map(|b| format!("{:02x}", b)).collect(),
+        AddrV2::Unknown(network_id, bytes) => {
+            format!(
+                "{:02x}:{}",
+                network_id,
+                bytes
+                    .iter()
+                    .map(|b| format!("{:02x}", b))
+                    .collect::<String>()
+            )
+        }
+    }
+}
+
+/// Returns the type string for an AddrV2 address
+fn addrv2_type(addr: &AddrV2) -> &'static str {
+    match addr {
+        AddrV2::Ipv4(_) => "ipv4",
+        AddrV2::Ipv6(_) => "ipv6",
+        AddrV2::TorV3(_) => "tor",
+        AddrV2::I2p(_) => "i2p",
+        AddrV2::Cjdns(_) => "cjdns",
+        AddrV2::Unknown(_, _) => "unknown",
+    }
+}
+
+fn is_routable_ipv4(ip: &Ipv4Addr) -> bool {
+    let octets = ip.octets();
+
+    // 0.0.0.0/8 - "This" network
+    if octets[0] == 0 {
+        return false;
+    }
+
+    // Loopback, broadcast, private (RFC 1918)
+    if ip.is_loopback() || ip.is_broadcast() || ip.is_private() {
+        return false;
+    }
+
+    // RFC 2544 - Benchmarking - 198.18.0.0/15
+    if octets[0] == 198 && (octets[1] == 18 || octets[1] == 19) {
+        return false;
+    }
+
+    // RFC 3927 - Link-Local - 169.254.0.0/16
+    if ip.is_link_local() {
+        return false;
+    }
+
+    // RFC 6598 - Shared Address Space (CGNAT) - 100.64.0.0/10
+    if octets[0] == 100 && (octets[1] >= 64 && octets[1] <= 127) {
+        return false;
+    }
+
+    // RFC 5737 - Documentation (TEST-NET-1, TEST-NET-2, TEST-NET-3)
+    if ip.is_documentation() {
+        return false;
+    }
+
+    true
+}
+
+fn is_routable_ipv6(ip: &Ipv6Addr) -> bool {
+    let octets = ip.octets();
+
+    // Unspecified, loopback, unique local (RFC 4193 - fc00::/7)
+    if ip.is_unspecified() || ip.is_loopback() || ip.is_unique_local() {
+        return false;
+    }
+
+    // RFC 4843 - ORCHID - 2001:10::/28
+    if octets[0] == 0x20 && octets[1] == 0x01 && octets[2] == 0x00 && (octets[3] & 0xF0) == 0x10 {
+        return false;
+    }
+
+    // RFC 4862 - Link-local - fe80::/64
+    if octets[..8] == [0xFE, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00] {
+        return false;
+    }
+
+    // RFC 7343 - ORCHIDv2 - 2001:20::/28
+    if octets[0] == 0x20 && octets[1] == 0x01 && octets[2] == 0x00 && (octets[3] & 0xf0) == 0x20 {
+        return false;
+    }
+
+    true
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn rust_bitcoin_addrv2(data: *const u8, len: usize) -> *mut c_char {
     // Safety: Ensure that the data pointer is valid for the given length
     let data_slice = slice::from_raw_parts(data, len);
 
     let addr: Result<(AddrV2Payload, usize), _> = encode::deserialize_partial(data_slice);
-    let mut clearnet: u64 = 0;
-    let mut tor: u64 = 0;
-    let mut i2p: u64 = 0;
-    let mut cjdns: u64 = 0;
     match addr {
-        Err(_) => str_to_c_string("clearnet=0tor=0cjdns=0i2p=0"),
-        Ok(vec_addr) => {
-            for a in vec_addr.0 .0 {
-                if matches!(a.addr, AddrV2::Ipv4(_)) {
-                    clearnet += 1;
-                } else if matches!(a.addr, AddrV2::Ipv6(_)) {
-                    clearnet += 1;
-                } else if matches!(a.addr, AddrV2::TorV3(_)) {
-                    tor += 1;
-                } else if matches!(a.addr, AddrV2::Cjdns(_)) {
-                    cjdns += 1;
-                } else if matches!(a.addr, AddrV2::I2p(_)) {
-                    i2p += 1;
-                }
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("invalid CJDNS address") || msg.contains("IPV4 wrapped address") {
+                return std::ptr::null_mut();
             }
-            let res = "clearnet=".to_string()
-                + &clearnet.to_string()
-                + "tor="
-                + &tor.to_string()
-                + "cjdns="
-                + &cjdns.to_string()
-                + "i2p="
-                + &i2p.to_string();
-            return str_to_c_string(&res);
+            str_to_c_string("[]")
+        }
+        Ok(vec_addr) => {
+            let mut entries: Vec<String> = Vec::new();
+            for a in vec_addr.0 .0 {
+                if matches!(a.addr, AddrV2::Unknown(..)) {
+                    continue;
+                }
+                // Match the same behavior as isRoutable() function from core.
+                if let AddrV2::Ipv4(ip) = &a.addr {
+                    if !is_routable_ipv4(ip) {
+                        continue;
+                    }
+                }
+                if let AddrV2::Ipv6(ip) = &a.addr {
+                    if !is_routable_ipv6(ip) {
+                        continue;
+                    }
+                }
+                let addr_hex = addrv2_to_hex(&a.addr);
+                let addr_type = addrv2_type(&a.addr);
+                let time = a.time;
+                let services = a.services.to_u64();
+                let port = a.port;
+                entries.push(format!(
+                    "{{\"addr\":\"{}\",\"type\":\"{}\",\"time\":\"{}\",\"services\":\"{}\",\"port\":\"{}\"}}",
+                    addr_hex, addr_type, time, services, port
+                ));
+            }
+            let result = format!("[{}]", entries.join(","));
+            str_to_c_string(&result)
         }
     }
 }


### PR DESCRIPTION
Change the `addrv2` target return format from aggregate counts (clearnet=X tor=Y cjdns=Z i2p=W) to a JSON array containing detailed information for each address entry.

Each entry now includes:
- addr: raw address bytes in hexadecimal format
- type: address type (ipv4, ipv6, tor, i2p, cjdns)
- time: timestamp as string
- services: service bits as string
- port: network port as string

Using hex format for addresses ensures consistent comparison across different implementations (Bitcoin Core, rust-bitcoin, btcd) without relying on potentially different address formatting logic.

Changes by module:
- `bitcoin/module.cpp`: Return JSON array with full address details, handle IPv4-mapped IPv6 format from GetAddrBytes()
- `btcd/wrapper.go`: Use reflection to extract raw address bytes from unexported btcd types, skip torv2 and IPv4-mapped IPv6 addresses
- `rustbitcoin/lib.rs`: Add addrv2_to_hex() and addrv2_type() helpers, implement is_routable_ipv4/ipv6() checks matching Core behavior
- `driver.cpp`: Add BTCD ifdef to skip i2p/cjdns mismatches (btcd skips these address types)

This enables byte-level verification that all implementations parse and route the same addresses from addrv2 messages.

closes #385