### PR TITLE
Prototype for dynamic loading bitcoinkernel module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,11 @@ ifneq ($(findstring -DRUST_K256,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
 	MODULES += modules/rustk256/module.a
 endif
 
+ifneq ($(filter -DDYNAMICBITCOINKERNEL,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+	MODULES += modules/dynamicbitcoinkernel/module.a
+	LDFLAGS := -ldl
+endif
+
 ifeq ($(UNAME_S), Darwin)
 	LDFLAGS = -framework CoreFoundation -Wl,-ld_classic
 endif

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you prefer, you can still build the modules manually. Below are the steps for
 
     ```bash
     cd modules/rustbitcoin
-    make
+    rustup default nightly && make cargo && make
     export CXXFLAGS="$CXXFLAGS -DRUST_BITCOIN"
     ```
 
@@ -107,7 +107,7 @@ If you prefer, you can still build the modules manually. Below are the steps for
 
     ```bash
     cd modules/tinyminiscript
-    make
+    rustup default nightly && make cargo && make
     export CXXFLAGS="$CXXFLAGS -DTINY_MINISCRIPT"
     ```
 
@@ -115,7 +115,7 @@ If you prefer, you can still build the modules manually. Below are the steps for
 
     ```bash
     cd modules/rustminiscript
-    make
+    rustup default nightly && make cargo && make
     export CXXFLAGS="$CXXFLAGS -DRUST_MINISCRIPT"
     ```
 
@@ -155,7 +155,7 @@ If you prefer, you can still build the modules manually. Below are the steps for
 
     ```bash
     cd modules/rustbitcoinkernel
-    make
+    rustup default nightly && make cargo && make
     export CXXFLAGS="$CXXFLAGS -DRUSTBITCOINKERNEL"
 
 - ### py-bitcoinkernel
@@ -196,7 +196,7 @@ If you prefer, you can still build the modules manually. Below are the steps for
 
     ```bash
     cd modules/ldk
-    make
+    rustup default nightly && make cargo && make
     export CXXFLAGS="$CXXFLAGS -DLDK"
     ```
 

--- a/driver.cpp
+++ b/driver.cpp
@@ -449,7 +449,30 @@ void Driver::KernelTransactionTarget(std::span<const uint8_t> buffer) const {
     last_module_name = module.first;
   }
 }
+// showcase target, will be removed later
+void Driver::LibraryTagTarget() const {
+  std::optional<std::string> last_response{std::nullopt};
+  std::string last_module_name;
 
+  for (auto &module : modules) {
+    std::optional<std::string> res{module.second->library_tag()};
+    if (!res.has_value())
+      continue;
+    if (last_response.has_value()) {
+      if (*res != *last_response) {
+        std::cout << "Library tag retrieval failed" << std::endl;
+        std::cout << "Module: " << module.first << std::endl;
+        std::cout << "Result: " << *res << std::endl;
+        std::cout << "Module: " << last_module_name << std::endl;
+        std::cout << "Result: " << *last_response << std::endl;
+      }
+      assert(*res == *last_response);
+    }
+    std::cout << "Result from " << module.first << ": " << *res << std::endl;
+    last_response = res.value();
+    last_module_name = module.first;
+  }
+}
 void Driver::ParseLightningP2pMessageTarget(
     std::span<const uint8_t> buffer) const {
   std::optional<std::string> last_response{std::nullopt};

--- a/driver.h
+++ b/driver.h
@@ -39,6 +39,8 @@ public:
   void Bip32MasterKeygenTarget(std::span<const uint8_t> buffer) const;
   void KernelBlockTarget(std::span<const uint8_t> buffer) const;
   void KernelTransactionTarget(std::span<const uint8_t> buffer) const;
+  // showcase function, will be removed later
+  void LibraryTagTarget() const;
   void PrivateToPublicKeyTarget(std::span<const uint8_t> buffer) const;
   void SignCompactTarget(std::span<const uint8_t> buffer) const;
   void SignDerTarget(std::span<const uint8_t> buffer) const;

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -35,6 +35,10 @@ std::optional<std::string>
 BaseModule::kernel_block(std::span<const uint8_t> buffer) const {
   return std::nullopt;
 }
+// showcase function, will be removed later
+std::optional<std::string> BaseModule::library_tag() const {
+  return std::nullopt;
+}
 
 std::optional<std::string>
 BaseModule::kernel_transaction(std::span<const uint8_t> buffer) const {

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -43,6 +43,8 @@ public:
   bip32_master_keygen(std::span<const uint8_t> buffer) const;
   virtual std::optional<std::string>
   kernel_block(std::span<const uint8_t> buffer) const;
+  // showcase function, will be removed later
+  virtual std::optional<std::string> library_tag() const;
   virtual std::optional<std::string>
   kernel_transaction(std::span<const uint8_t> buffer) const;
   virtual std::optional<std::string>

--- a/main.cpp
+++ b/main.cpp
@@ -84,6 +84,10 @@
 #include <modules/rustk256/module.h>
 #endif
 
+#ifdef DYNAMICBITCOINKERNEL
+#include <modules/dynamicbitcoinkernel/module.h>
+#endif
+
 #ifdef CUSTOM_MUTATOR_BOLT12_OFFER
 #include <custommutator/mutators/bolt12_offer.h>
 #endif
@@ -176,6 +180,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 #endif
 #ifdef RUST_K256
   driver->LoadModule(std::make_shared<bitcoinfuzz::module::K256>());
+#endif
+
+#ifdef DYNAMICBITCOINKERNEL
+  driver->LoadModule(std::make_shared<bitcoinfuzz::module::DynamicKernel>(
+      "bitcoinkernelA",
+      "modules/dynamicbitcoinkernel/libs/libbitcoinkernelA.so"));
+  driver->LoadModule(std::make_shared<bitcoinfuzz::module::DynamicKernel>(
+      "bitcoinkernelB",
+      "modules/dynamicbitcoinkernel/libs/libbitcoinkernelB.so"));
 #endif
 
 #ifdef CUSTOM_MUTATOR_BOLT11

--- a/modules/dynamicbitcoinkernel/Makefile
+++ b/modules/dynamicbitcoinkernel/Makefile
@@ -1,0 +1,18 @@
+all: module.a
+
+CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer -std=c++20 -I ../../include
+
+module.a: module.o
+	$(AR) rcs $@ $^
+
+module.o: module.cpp module.h
+	$(CXX) $(CXXFLAGS) -I . -fPIC -c $< -o $@
+
+format:
+	clang-format -i module.h module.cpp
+
+check-format:
+	clang-format -Werror --fail-on-incomplete-format -n module.h module.cpp
+
+clean:
+	rm -rf *.o module.a

--- a/modules/dynamicbitcoinkernel/bitcoinkernel_wrapper/bitcoinkernel.h
+++ b/modules/dynamicbitcoinkernel/bitcoinkernel_wrapper/bitcoinkernel.h
@@ -1,0 +1,1629 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_KERNEL_BITCOINKERNEL_H
+#define BITCOIN_KERNEL_BITCOINKERNEL_H
+
+#ifndef __cplusplus
+#include <stddef.h>
+#include <stdint.h>
+#else
+#include <cstddef>
+#include <cstdint>
+#endif // __cplusplus
+
+#ifndef BITCOINKERNEL_API
+    #ifdef BITCOINKERNEL_BUILD
+        #if defined(_WIN32)
+            #define BITCOINKERNEL_API __declspec(dllexport)
+        #else
+            #define BITCOINKERNEL_API __attribute__((visibility("default")))
+        #endif
+    #else
+        #if defined(_WIN32) && !defined(BITCOINKERNEL_STATIC)
+            #define BITCOINKERNEL_API __declspec(dllimport)
+        #else
+            #define BITCOINKERNEL_API
+        #endif
+    #endif
+#endif
+
+/* Warning attributes */
+#if defined(__GNUC__)
+    #define BITCOINKERNEL_WARN_UNUSED_RESULT __attribute__((__warn_unused_result__))
+#else
+    #define BITCOINKERNEL_WARN_UNUSED_RESULT
+#endif
+
+/**
+ * BITCOINKERNEL_ARG_NONNULL is a compiler attribute used to indicate that
+ * certain pointer arguments to a function are not expected to be null.
+ *
+ * Callers must not pass a null pointer for arguments marked with this attribute,
+ * as doing so may result in undefined behavior. This attribute should only be
+ * used for arguments where a null pointer is unambiguously a programmer error,
+ * such as for opaque handles, and not for pointers to raw input data that might
+ * validly be null (e.g., from an empty std::span or std::string).
+ */
+#if !defined(BITCOINKERNEL_BUILD) && defined(__GNUC__)
+    #define BITCOINKERNEL_ARG_NONNULL(...) __attribute__((__nonnull__(__VA_ARGS__)))
+#else
+    #define BITCOINKERNEL_ARG_NONNULL(...)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+BITCOINKERNEL_API const char* btck_library_tag(void);
+// For this function to work, add
+// const char* btck_library_tag(void)
+// {
+//     return "KERNEL A";
+// }
+// to bitcoinkernel.cpp when compiling it 
+
+/**
+ * @page remarks Remarks
+ *
+ * @section purpose Purpose
+ *
+ * This header currently exposes an API for interacting with parts of Bitcoin
+ * Core's consensus code. Users can validate blocks, iterate the block index,
+ * read block and undo data from disk, and validate scripts. The header is
+ * unversioned and not stable yet. Users should expect breaking changes. It is
+ * also not yet included in releases of Bitcoin Core.
+ *
+ * @section context Context
+ *
+ * The library provides a built-in static constant kernel context. This static
+ * context offers only limited functionality. It detects and self-checks the
+ * correct sha256 implementation, initializes the random number generator and
+ * self-checks the secp256k1 static context. It is used internally for
+ * otherwise "context-free" operations. This means that the user is not
+ * required to initialize their own context before using the library.
+ *
+ * The user should create their own context for passing it to state-rich validation
+ * functions and holding callbacks for kernel events.
+ *
+ * @section error Error handling
+ *
+ * Functions communicate an error through their return types, usually returning
+ * a nullptr, 0, or false if an error is encountered. Additionally, verification
+ * functions, e.g. for scripts, may communicate more detailed error information
+ * through status code out parameters.
+ *
+ * Fine-grained validation information is communicated through the validation
+ * interface.
+ *
+ * The kernel notifications issue callbacks for errors. These are usually
+ * indicative of a system error. If such an error is issued, it is recommended
+ * to halt and tear down the existing kernel objects. Remediating the error may
+ * require system intervention by the user.
+ *
+ * @section pointer Pointer and argument conventions
+ *
+ * The user is responsible for de-allocating the memory owned by pointers
+ * returned by functions. Typically pointers returned by *_create(...) functions
+ * can be de-allocated by corresponding *_destroy(...) functions.
+ *
+ * A function that takes pointer arguments makes no assumptions on their
+ * lifetime. Once the function returns the user can safely de-allocate the
+ * passed in arguments.
+ *
+ * Const pointers represent views, and do not transfer ownership. Lifetime
+ * guarantees of these objects are described in the respective documentation.
+ * Ownership of these resources may be taken by copying. They are typically
+ * used for iteration with minimal overhead and require some care by the
+ * programmer that their lifetime is not extended beyond that of the original
+ * object.
+ *
+ * Array lengths follow the pointer argument they describe.
+ */
+
+/**
+ * Opaque data structure for holding a transaction.
+ */
+typedef struct btck_Transaction btck_Transaction;
+
+/**
+ * Opaque data structure for holding a script pubkey.
+ */
+typedef struct btck_ScriptPubkey btck_ScriptPubkey;
+
+/**
+ * Opaque data structure for holding a transaction output.
+ */
+typedef struct btck_TransactionOutput btck_TransactionOutput;
+
+/**
+ * Opaque data structure for holding a logging connection.
+ *
+ * The logging connection can be used to manually stop logging.
+ *
+ * Messages that were logged before a connection is created are buffered in a
+ * 1MB buffer. Logging can alternatively be permanently disabled by calling
+ * @ref btck_logging_disable. Functions changing the logging settings are
+ * global and change the settings for all existing btck_LoggingConnection
+ * instances.
+ */
+typedef struct btck_LoggingConnection btck_LoggingConnection;
+
+/**
+ * Opaque data structure for holding the chain parameters.
+ *
+ * These are eventually placed into a kernel context through the kernel context
+ * options. The parameters describe the properties of a chain, and may be
+ * instantiated for either mainnet, testnet, signet, or regtest.
+ */
+typedef struct btck_ChainParameters btck_ChainParameters;
+
+/**
+ * Opaque data structure for holding options for creating a new kernel context.
+ *
+ * Once a kernel context has been created from these options, they may be
+ * destroyed. The options hold the notification and validation interface
+ * callbacks as well as the selected chain type until they are passed to the
+ * context. If no options are configured, the context will be instantiated with
+ * no callbacks and for mainnet. Their content and scope can be expanded over
+ * time.
+ */
+typedef struct btck_ContextOptions btck_ContextOptions;
+
+/**
+ * Opaque data structure for holding a kernel context.
+ *
+ * The kernel context is used to initialize internal state and hold the chain
+ * parameters and callbacks for handling error and validation events. Once
+ * other validation objects are instantiated from it, the context is kept in
+ * memory for the duration of their lifetimes.
+ *
+ * The processing of validation events is done through an internal task runner
+ * owned by the context. It passes events through the registered validation
+ * interface callbacks.
+ *
+ * A constructed context can be safely used from multiple threads.
+ */
+typedef struct btck_Context btck_Context;
+
+/**
+ * Opaque data structure for holding a block tree entry.
+ *
+ * This is a pointer to an element in the block index currently in memory of
+ * the chainstate manager. It is valid for the lifetime of the chainstate
+ * manager it was retrieved from. The entry is part of a tree-like structure
+ * that is maintained internally. Every entry, besides the genesis, points to a
+ * single parent. Multiple entries may share a parent, thus forming a tree.
+ * Each entry corresponds to a single block and may be used to retrieve its
+ * data and validation status.
+ */
+typedef struct btck_BlockTreeEntry btck_BlockTreeEntry;
+
+/**
+ * Opaque data structure for holding options for creating a new chainstate
+ * manager.
+ *
+ * The chainstate manager options are used to set some parameters for the
+ * chainstate manager.
+ */
+typedef struct btck_ChainstateManagerOptions btck_ChainstateManagerOptions;
+
+/**
+ * Opaque data structure for holding a chainstate manager.
+ *
+ * The chainstate manager is the central object for doing validation tasks as
+ * well as retrieving data from the chain. Internally it is a complex data
+ * structure with diverse functionality.
+ *
+ * Its functionality will be more and more exposed in the future.
+ */
+typedef struct btck_ChainstateManager btck_ChainstateManager;
+
+/**
+ * Opaque data structure for holding a block.
+ */
+typedef struct btck_Block btck_Block;
+
+/**
+ * Opaque data structure for holding the state of a block during validation.
+ *
+ * Contains information indicating whether validation was successful, and if not
+ * which step during block validation failed.
+ */
+typedef struct btck_BlockValidationState btck_BlockValidationState;
+
+/**
+ * Opaque data structure for holding the currently known best-chain associated
+ * with a chainstate.
+ */
+typedef struct btck_Chain btck_Chain;
+
+/**
+ * Opaque data structure for holding a block's spent outputs.
+ *
+ * Contains all the previous outputs consumed by all transactions in a specific
+ * block. Internally it holds a nested vector. The top level vector has an
+ * entry for each transaction in a block (in order of the actual transactions
+ * of the block and without the coinbase transaction). This is exposed through
+ * @ref btck_TransactionSpentOutputs. Each btck_TransactionSpentOutputs is in
+ * turn a vector of all the previous outputs of a transaction (in order of
+ * their corresponding inputs).
+ */
+typedef struct btck_BlockSpentOutputs btck_BlockSpentOutputs;
+
+/**
+ * Opaque data structure for holding a transaction's spent outputs.
+ *
+ * Holds the coins consumed by a certain transaction. Retrieved through the
+ * @ref btck_BlockSpentOutputs. The coins are in the same order as the
+ * transaction's inputs consuming them.
+ */
+typedef struct btck_TransactionSpentOutputs btck_TransactionSpentOutputs;
+
+/**
+ * Opaque data structure for holding a coin.
+ *
+ * Holds information on the @ref btck_TransactionOutput held within,
+ * including the height it was spent at and whether it is a coinbase output.
+ */
+typedef struct btck_Coin btck_Coin;
+
+/**
+ * Opaque data structure for holding a block hash.
+ *
+ * This is a type-safe identifier for a block.
+ */
+typedef struct btck_BlockHash btck_BlockHash;
+
+/**
+ * Opaque data structure for holding a transaction input.
+ *
+ * Holds information on the @ref btck_TransactionOutPoint held within.
+ */
+typedef struct btck_TransactionInput btck_TransactionInput;
+
+/**
+ * Opaque data structure for holding a transaction out point.
+ *
+ * Holds the txid and output index it is pointing to.
+ */
+typedef struct btck_TransactionOutPoint btck_TransactionOutPoint;
+
+/**
+ * Opaque data structure for holding precomputed transaction data.
+ *
+ * Reusable when verifying multiple inputs of the same transaction.
+ * This avoids recomputing transaction hashes for each input.
+ *
+ * Required when verifying a taproot input.
+ */
+typedef struct btck_PrecomputedTransactionData btck_PrecomputedTransactionData;
+
+typedef struct btck_Txid btck_Txid;
+
+/** Current sync state passed to tip changed callbacks. */
+typedef uint8_t btck_SynchronizationState;
+#define btck_SynchronizationState_INIT_REINDEX ((btck_SynchronizationState)(0))
+#define btck_SynchronizationState_INIT_DOWNLOAD ((btck_SynchronizationState)(1))
+#define btck_SynchronizationState_POST_INIT ((btck_SynchronizationState)(2))
+
+/** Possible warning types issued by validation. */
+typedef uint8_t btck_Warning;
+#define btck_Warning_UNKNOWN_NEW_RULES_ACTIVATED ((btck_Warning)(0))
+#define btck_Warning_LARGE_WORK_INVALID_CHAIN ((btck_Warning)(1))
+
+/** Callback function types */
+
+/**
+ * Function signature for the global logging callback. All bitcoin kernel
+ * internal logs will pass through this callback.
+ */
+typedef void (*btck_LogCallback)(void* user_data, const char* message, size_t message_len);
+
+/**
+ * Function signature for freeing user data.
+ */
+typedef void (*btck_DestroyCallback)(void* user_data);
+
+/**
+ * Function signatures for the kernel notifications.
+ */
+typedef void (*btck_NotifyBlockTip)(void* user_data, btck_SynchronizationState state, const btck_BlockTreeEntry* entry, double verification_progress);
+typedef void (*btck_NotifyHeaderTip)(void* user_data, btck_SynchronizationState state, int64_t height, int64_t timestamp, int presync);
+typedef void (*btck_NotifyProgress)(void* user_data, const char* title, size_t title_len, int progress_percent, int resume_possible);
+typedef void (*btck_NotifyWarningSet)(void* user_data, btck_Warning warning, const char* message, size_t message_len);
+typedef void (*btck_NotifyWarningUnset)(void* user_data, btck_Warning warning);
+typedef void (*btck_NotifyFlushError)(void* user_data, const char* message, size_t message_len);
+typedef void (*btck_NotifyFatalError)(void* user_data, const char* message, size_t message_len);
+
+/**
+ * Function signatures for the validation interface.
+ */
+typedef void (*btck_ValidationInterfaceBlockChecked)(void* user_data, btck_Block* block, const btck_BlockValidationState* state);
+typedef void (*btck_ValidationInterfacePoWValidBlock)(void* user_data, btck_Block* block, const btck_BlockTreeEntry* entry);
+typedef void (*btck_ValidationInterfaceBlockConnected)(void* user_data, btck_Block* block, const btck_BlockTreeEntry* entry);
+typedef void (*btck_ValidationInterfaceBlockDisconnected)(void* user_data, btck_Block* block, const btck_BlockTreeEntry* entry);
+
+/**
+ * Function signature for serializing data.
+ */
+typedef int (*btck_WriteBytes)(const void* bytes, size_t size, void* userdata);
+
+/**
+ * Whether a validated data structure is valid, invalid, or an error was
+ * encountered during processing.
+ */
+typedef uint8_t btck_ValidationMode;
+#define btck_ValidationMode_VALID ((btck_ValidationMode)(0))
+#define btck_ValidationMode_INVALID ((btck_ValidationMode)(1))
+#define btck_ValidationMode_INTERNAL_ERROR ((btck_ValidationMode)(2))
+
+/**
+ * A granular "reason" why a block was invalid.
+ */
+typedef uint32_t btck_BlockValidationResult;
+#define btck_BlockValidationResult_UNSET ((btck_BlockValidationResult)(0))           //!< initial value. Block has not yet been rejected
+#define btck_BlockValidationResult_CONSENSUS ((btck_BlockValidationResult)(1))       //!< invalid by consensus rules (excluding any below reasons)
+#define btck_BlockValidationResult_CACHED_INVALID ((btck_BlockValidationResult)(2))  //!< this block was cached as being invalid and we didn't store the reason why
+#define btck_BlockValidationResult_INVALID_HEADER ((btck_BlockValidationResult)(3))  //!< invalid proof of work or time too old
+#define btck_BlockValidationResult_MUTATED ((btck_BlockValidationResult)(4))         //!< the block's data didn't match the data committed to by the PoW
+#define btck_BlockValidationResult_MISSING_PREV ((btck_BlockValidationResult)(5))    //!< We don't have the previous block the checked one is built on
+#define btck_BlockValidationResult_INVALID_PREV ((btck_BlockValidationResult)(6))    //!< A block this one builds on is invalid
+#define btck_BlockValidationResult_TIME_FUTURE ((btck_BlockValidationResult)(7))     //!< block timestamp was > 2 hours in the future (or our clock is bad)
+#define btck_BlockValidationResult_HEADER_LOW_WORK ((btck_BlockValidationResult)(8)) //!< the block header may be on a too-little-work chain
+
+/**
+ * Holds the validation interface callbacks. The user data pointer may be used
+ * to point to user-defined structures to make processing the validation
+ * callbacks easier. Note that these callbacks block any further validation
+ * execution when they are called.
+ */
+typedef struct {
+    void* user_data;                                              //!< Holds a user-defined opaque structure that is passed to the validation
+                                                                  //!< interface callbacks. If user_data_destroy is also defined ownership of the
+                                                                  //!< user_data is passed to the created context options and subsequently context.
+    btck_DestroyCallback user_data_destroy;                       //!< Frees the provided user data structure.
+    btck_ValidationInterfaceBlockChecked block_checked;           //!< Called when a new block has been fully validated. Contains the
+                                                                  //!< result of its validation.
+    btck_ValidationInterfacePoWValidBlock pow_valid_block;        //!< Called when a new block extends the header chain and has a valid transaction
+                                                                  //!< and segwit merkle root.
+    btck_ValidationInterfaceBlockConnected block_connected;       //!< Called when a block is valid and has now been connected to the best chain.
+    btck_ValidationInterfaceBlockDisconnected block_disconnected; //!< Called during a re-org when a block has been removed from the best chain.
+} btck_ValidationInterfaceCallbacks;
+
+/**
+ * A struct for holding the kernel notification callbacks. The user data
+ * pointer may be used to point to user-defined structures to make processing
+ * the notifications easier.
+ *
+ * If user_data_destroy is provided, the kernel will automatically call this
+ * callback to clean up user_data when the notification interface object is destroyed.
+ * If user_data_destroy is NULL, it is the user's responsibility to ensure that
+ * the user_data outlives the kernel objects. Notifications can
+ * occur even as kernel objects are deleted, so care has to be taken to ensure
+ * safe unwinding.
+ */
+typedef struct {
+    void* user_data;                        //!< Holds a user-defined opaque structure that is passed to the notification callbacks.
+                                            //!< If user_data_destroy is also defined ownership of the user_data is passed to the
+                                            //!< created context options and subsequently context.
+    btck_DestroyCallback user_data_destroy; //!< Frees the provided user data structure.
+    btck_NotifyBlockTip block_tip;          //!< The chain's tip was updated to the provided block entry.
+    btck_NotifyHeaderTip header_tip;        //!< A new best block header was added.
+    btck_NotifyProgress progress;           //!< Reports on current block synchronization progress.
+    btck_NotifyWarningSet warning_set;      //!< A warning issued by the kernel library during validation.
+    btck_NotifyWarningUnset warning_unset;  //!< A previous condition leading to the issuance of a warning is no longer given.
+    btck_NotifyFlushError flush_error;      //!< An error encountered when flushing data to disk.
+    btck_NotifyFatalError fatal_error;      //!< An unrecoverable system error encountered by the library.
+} btck_NotificationInterfaceCallbacks;
+
+/**
+ * A collection of logging categories that may be encountered by kernel code.
+ */
+typedef uint8_t btck_LogCategory;
+#define btck_LogCategory_ALL ((btck_LogCategory)(0))
+#define btck_LogCategory_BENCH ((btck_LogCategory)(1))
+#define btck_LogCategory_BLOCKSTORAGE ((btck_LogCategory)(2))
+#define btck_LogCategory_COINDB ((btck_LogCategory)(3))
+#define btck_LogCategory_LEVELDB ((btck_LogCategory)(4))
+#define btck_LogCategory_MEMPOOL ((btck_LogCategory)(5))
+#define btck_LogCategory_PRUNE ((btck_LogCategory)(6))
+#define btck_LogCategory_RAND ((btck_LogCategory)(7))
+#define btck_LogCategory_REINDEX ((btck_LogCategory)(8))
+#define btck_LogCategory_VALIDATION ((btck_LogCategory)(9))
+#define btck_LogCategory_KERNEL ((btck_LogCategory)(10))
+
+/**
+ * The level at which logs should be produced.
+ */
+typedef uint8_t btck_LogLevel;
+#define btck_LogLevel_TRACE ((btck_LogLevel)(0))
+#define btck_LogLevel_DEBUG ((btck_LogLevel)(1))
+#define btck_LogLevel_INFO ((btck_LogLevel)(2))
+
+/**
+ * Options controlling the format of log messages.
+ *
+ * Set fields as non-zero to indicate true.
+ */
+typedef struct {
+    int log_timestamps;               //!< Prepend a timestamp to log messages.
+    int log_time_micros;              //!< Log timestamps in microsecond precision.
+    int log_threadnames;              //!< Prepend the name of the thread to log messages.
+    int log_sourcelocations;          //!< Prepend the source location to log messages.
+    int always_print_category_levels; //!< Prepend the log category and level to log messages.
+} btck_LoggingOptions;
+
+/**
+ * A collection of status codes that may be issued by the script verify function.
+ */
+typedef uint8_t btck_ScriptVerifyStatus;
+#define btck_ScriptVerifyStatus_OK ((btck_ScriptVerifyStatus)(0))
+#define btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS_COMBINATION ((btck_ScriptVerifyStatus)(1)) //!< The flags were combined in an invalid way.
+#define btck_ScriptVerifyStatus_ERROR_SPENT_OUTPUTS_REQUIRED ((btck_ScriptVerifyStatus)(2))    //!< The taproot flag was set, so valid spent_outputs have to be provided.
+
+/**
+ * Script verification flags that may be composed with each other.
+ */
+typedef uint32_t btck_ScriptVerificationFlags;
+#define btck_ScriptVerificationFlags_NONE ((btck_ScriptVerificationFlags)(0))
+#define btck_ScriptVerificationFlags_P2SH ((btck_ScriptVerificationFlags)(1U << 0))                 //!< evaluate P2SH (BIP16) subscripts
+#define btck_ScriptVerificationFlags_DERSIG ((btck_ScriptVerificationFlags)(1U << 2))               //!< enforce strict DER (BIP66) compliance
+#define btck_ScriptVerificationFlags_NULLDUMMY ((btck_ScriptVerificationFlags)(1U << 4))            //!< enforce NULLDUMMY (BIP147)
+#define btck_ScriptVerificationFlags_CHECKLOCKTIMEVERIFY ((btck_ScriptVerificationFlags)(1U << 9))  //!< enable CHECKLOCKTIMEVERIFY (BIP65)
+#define btck_ScriptVerificationFlags_CHECKSEQUENCEVERIFY ((btck_ScriptVerificationFlags)(1U << 10)) //!< enable CHECKSEQUENCEVERIFY (BIP112)
+#define btck_ScriptVerificationFlags_WITNESS ((btck_ScriptVerificationFlags)(1U << 11))             //!< enable WITNESS (BIP141)
+#define btck_ScriptVerificationFlags_TAPROOT ((btck_ScriptVerificationFlags)(1U << 17))             //!< enable TAPROOT (BIPs 341 & 342)
+#define btck_ScriptVerificationFlags_ALL ((btck_ScriptVerificationFlags)(btck_ScriptVerificationFlags_P2SH |                \
+                                                                         btck_ScriptVerificationFlags_DERSIG |              \
+                                                                         btck_ScriptVerificationFlags_NULLDUMMY |           \
+                                                                         btck_ScriptVerificationFlags_CHECKLOCKTIMEVERIFY | \
+                                                                         btck_ScriptVerificationFlags_CHECKSEQUENCEVERIFY | \
+                                                                         btck_ScriptVerificationFlags_WITNESS |             \
+                                                                         btck_ScriptVerificationFlags_TAPROOT))
+
+typedef uint8_t btck_ChainType;
+#define btck_ChainType_MAINNET ((btck_ChainType)(0))
+#define btck_ChainType_TESTNET ((btck_ChainType)(1))
+#define btck_ChainType_TESTNET_4 ((btck_ChainType)(2))
+#define btck_ChainType_SIGNET ((btck_ChainType)(3))
+#define btck_ChainType_REGTEST ((btck_ChainType)(4))
+
+/** @name Transaction
+ * Functions for working with transactions.
+ */
+///@{
+
+/**
+ * @brief Create a new transaction from the serialized data.
+ *
+ * @param[in] raw_transaction     Serialized transaction.
+ * @param[in] raw_transaction_len Length of the serialized transaction.
+ * @return                        The transaction, or null on error.
+ */
+BITCOINKERNEL_API btck_Transaction* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_create(
+    const void* raw_transaction, size_t raw_transaction_len);
+
+/**
+ * @brief Copy a transaction. Transactions are reference counted, so this just
+ * increments the reference count.
+ *
+ * @param[in] transaction Non-null.
+ * @return                The copied transaction.
+ */
+BITCOINKERNEL_API btck_Transaction* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_copy(
+    const btck_Transaction* transaction) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Serializes the transaction through the passed in callback to bytes.
+ * This is consensus serialization that is also used for the P2P network.
+ *
+ * @param[in] transaction Non-null.
+ * @param[in] writer      Non-null, callback to a write bytes function.
+ * @param[in] user_data   Holds a user-defined opaque structure that will be
+ *                        passed back through the writer callback.
+ * @return                0 on success.
+ */
+BITCOINKERNEL_API int btck_transaction_to_bytes(
+    const btck_Transaction* transaction,
+    btck_WriteBytes writer,
+    void* user_data) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * @brief Get the number of outputs of a transaction.
+ *
+ * @param[in] transaction Non-null.
+ * @return                The number of outputs.
+ */
+BITCOINKERNEL_API size_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_count_outputs(
+    const btck_Transaction* transaction) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Get the transaction outputs at the provided index. The returned
+ * transaction output is not owned and depends on the lifetime of the
+ * transaction.
+ *
+ * @param[in] transaction  Non-null.
+ * @param[in] output_index The index of the transaction output to be retrieved.
+ * @return                 The transaction output
+ */
+BITCOINKERNEL_API const btck_TransactionOutput* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_get_output_at(
+    const btck_Transaction* transaction, size_t output_index) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Get the transaction input at the provided index. The returned
+ * transaction input is not owned and depends on the lifetime of the
+ * transaction.
+ *
+ * @param[in] transaction Non-null.
+ * @param[in] input_index The index of the transaction input to be retrieved.
+ * @return                 The transaction input
+ */
+BITCOINKERNEL_API const btck_TransactionInput* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_get_input_at(
+    const btck_Transaction* transaction, size_t input_index) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Get the number of inputs of a transaction.
+ *
+ * @param[in] transaction Non-null.
+ * @return                The number of inputs.
+ */
+BITCOINKERNEL_API size_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_count_inputs(
+    const btck_Transaction* transaction) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Get the txid of a transaction. The returned txid is not owned and
+ * depends on the lifetime of the transaction.
+ *
+ * @param[in] transaction Non-null.
+ * @return                The txid.
+ */
+BITCOINKERNEL_API const btck_Txid* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_get_txid(
+    const btck_Transaction* transaction) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Destroy the transaction.
+ */
+BITCOINKERNEL_API void btck_transaction_destroy(btck_Transaction* transaction);
+
+///@}
+
+/** @name PrecomputedTransactionData
+ * Functions for working with precomputed transaction data.
+ */
+///@{
+
+/**
+ * @brief Create precomputed transaction data for script verification.
+ *
+ * @param[in] tx_to             Non-null.
+ * @param[in] spent_outputs     Nullable for non-taproot verification. Points to an array of
+ *                              outputs spent by the transaction.
+ * @param[in] spent_outputs_len Length of the spent_outputs array.
+ * @return                      The precomputed data, or null on error.
+ */
+BITCOINKERNEL_API btck_PrecomputedTransactionData* BITCOINKERNEL_WARN_UNUSED_RESULT btck_precomputed_transaction_data_create(
+    const btck_Transaction* tx_to,
+    const btck_TransactionOutput** spent_outputs, size_t spent_outputs_len) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Copy precomputed transaction data.
+ *
+ * @param[in] precomputed_txdata Non-null.
+ * @return                       The copied precomputed transaction data.
+ */
+BITCOINKERNEL_API btck_PrecomputedTransactionData* BITCOINKERNEL_WARN_UNUSED_RESULT btck_precomputed_transaction_data_copy(
+    const btck_PrecomputedTransactionData* precomputed_txdata) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Destroy the precomputed transaction data.
+ */
+BITCOINKERNEL_API void btck_precomputed_transaction_data_destroy(btck_PrecomputedTransactionData* precomputed_txdata);
+
+///@}
+
+/** @name ScriptPubkey
+ * Functions for working with script pubkeys.
+ */
+///@{
+
+/**
+ * @brief Create a script pubkey from serialized data.
+ * @param[in] script_pubkey     Serialized script pubkey.
+ * @param[in] script_pubkey_len Length of the script pubkey data.
+ * @return                      The script pubkey.
+ */
+BITCOINKERNEL_API btck_ScriptPubkey* BITCOINKERNEL_WARN_UNUSED_RESULT btck_script_pubkey_create(
+    const void* script_pubkey, size_t script_pubkey_len);
+
+/**
+ * @brief Copy a script pubkey.
+ *
+ * @param[in] script_pubkey Non-null.
+ * @return                  The copied script pubkey.
+ */
+BITCOINKERNEL_API btck_ScriptPubkey* BITCOINKERNEL_WARN_UNUSED_RESULT btck_script_pubkey_copy(
+    const btck_ScriptPubkey* script_pubkey) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Verify if the input at input_index of tx_to spends the script pubkey
+ * under the constraints specified by flags. If the
+ * `btck_ScriptVerificationFlags_WITNESS` flag is set in the flags bitfield, the
+ * amount parameter is used. If the taproot flag is set, the precomputed data
+ * must contain the spent outputs.
+ *
+ * @param[in] script_pubkey      Non-null, script pubkey to be spent.
+ * @param[in] amount             Amount of the script pubkey's associated output. May be zero if
+ *                               the witness flag is not set.
+ * @param[in] tx_to              Non-null, transaction spending the script_pubkey.
+ * @param[in] precomputed_txdata Nullable if the taproot flag is not set. Otherwise, precomputed data
+ *                               for tx_to with the spent outputs must be provided.
+ * @param[in] input_index        Index of the input in tx_to spending the script_pubkey.
+ * @param[in] flags              Bitfield of btck_ScriptVerificationFlags controlling validation constraints.
+ * @param[out] status            Nullable, will be set to an error code if the operation fails, or OK otherwise.
+ * @return                       1 if the script is valid, 0 otherwise.
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_script_pubkey_verify(
+    const btck_ScriptPubkey* script_pubkey,
+    int64_t amount,
+    const btck_Transaction* tx_to,
+    const btck_PrecomputedTransactionData* precomputed_txdata,
+    unsigned int input_index,
+    btck_ScriptVerificationFlags flags,
+    btck_ScriptVerifyStatus* status) BITCOINKERNEL_ARG_NONNULL(1, 3);
+
+/**
+ * @brief Serializes the script pubkey through the passed in callback to bytes.
+ *
+ * @param[in] script_pubkey Non-null.
+ * @param[in] writer        Non-null, callback to a write bytes function.
+ * @param[in] user_data     Holds a user-defined opaque structure that will be
+ *                          passed back through the writer callback.
+ * @return                  0 on success.
+ */
+BITCOINKERNEL_API int btck_script_pubkey_to_bytes(
+    const btck_ScriptPubkey* script_pubkey,
+    btck_WriteBytes writer,
+    void* user_data) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * Destroy the script pubkey.
+ */
+BITCOINKERNEL_API void btck_script_pubkey_destroy(btck_ScriptPubkey* script_pubkey);
+
+///@}
+
+/** @name TransactionOutput
+ * Functions for working with transaction outputs.
+ */
+///@{
+
+/**
+ * @brief Create a transaction output from a script pubkey and an amount.
+ *
+ * @param[in] script_pubkey Non-null.
+ * @param[in] amount        The amount associated with the script pubkey for this output.
+ * @return                  The transaction output.
+ */
+BITCOINKERNEL_API btck_TransactionOutput* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_output_create(
+    const btck_ScriptPubkey* script_pubkey,
+    int64_t amount) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Get the script pubkey of the output. The returned
+ * script pubkey is not owned and depends on the lifetime of the
+ * transaction output.
+ *
+ * @param[in] transaction_output Non-null.
+ * @return                       The script pubkey.
+ */
+BITCOINKERNEL_API const btck_ScriptPubkey* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_output_get_script_pubkey(
+    const btck_TransactionOutput* transaction_output) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Get the amount in the output.
+ *
+ * @param[in] transaction_output Non-null.
+ * @return                       The amount.
+ */
+BITCOINKERNEL_API int64_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_output_get_amount(
+    const btck_TransactionOutput* transaction_output) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ *  @brief Copy a transaction output.
+ *
+ *  @param[in] transaction_output Non-null.
+ *  @return                       The copied transaction output.
+ */
+BITCOINKERNEL_API btck_TransactionOutput* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_output_copy(
+    const btck_TransactionOutput* transaction_output) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Destroy the transaction output.
+ */
+BITCOINKERNEL_API void btck_transaction_output_destroy(btck_TransactionOutput* transaction_output);
+
+///@}
+
+/** @name Logging
+ * Logging-related functions.
+ */
+///@{
+
+/**
+ * @brief This disables the global internal logger. No log messages will be
+ * buffered internally anymore once this is called and the buffer is cleared.
+ * This function should only be called once and is not thread or re-entry safe.
+ * Log messages will be buffered until this function is called, or a logging
+ * connection is created. This must not be called while a logging connection
+ * already exists.
+ */
+BITCOINKERNEL_API void btck_logging_disable();
+
+/**
+ * @brief Set some options for the global internal logger. This changes global
+ * settings and will override settings for all existing @ref
+ * btck_LoggingConnection instances.
+ *
+ * @param[in] options Sets formatting options of the log messages.
+ */
+BITCOINKERNEL_API void btck_logging_set_options(const btck_LoggingOptions options);
+
+/**
+ * @brief Set the log level of the global internal logger. This does not
+ * enable the selected categories. Use @ref btck_logging_enable_category to
+ * start logging from a specific, or all categories. This changes a global
+ * setting and will override settings for all existing
+ * @ref btck_LoggingConnection instances.
+ *
+ * @param[in] category If btck_LogCategory_ALL is chosen, sets both the global fallback log level
+ *                     used by all categories that don't have a specific level set, and also
+ *                     sets the log level for messages logged with the btck_LogCategory_ALL category itself.
+ *                     For any other category, sets a category-specific log level that overrides
+ *                     the global fallback for that category only.
+
+ * @param[in] level    Log level at which the log category is set.
+ */
+BITCOINKERNEL_API void btck_logging_set_level_category(btck_LogCategory category, btck_LogLevel level);
+
+/**
+ * @brief Enable a specific log category for the global internal logger. This
+ * changes a global setting and will override settings for all existing @ref
+ * btck_LoggingConnection instances.
+ *
+ * @param[in] category If btck_LogCategory_ALL is chosen, all categories will be enabled.
+ */
+BITCOINKERNEL_API void btck_logging_enable_category(btck_LogCategory category);
+
+/**
+ * @brief Disable a specific log category for the global internal logger. This
+ * changes a global setting and will override settings for all existing @ref
+ * btck_LoggingConnection instances.
+ *
+ * @param[in] category If btck_LogCategory_ALL is chosen, all categories will be disabled.
+ */
+BITCOINKERNEL_API void btck_logging_disable_category(btck_LogCategory category);
+
+/**
+ * @brief Start logging messages through the provided callback. Log messages
+ * produced before this function is first called are buffered and on calling this
+ * function are logged immediately.
+ *
+ * @param[in] log_callback               Non-null, function through which messages will be logged.
+ * @param[in] user_data                  Nullable, holds a user-defined opaque structure. Is passed back
+ *                                       to the user through the callback. If the user_data_destroy_callback
+ *                                       is also defined it is assumed that ownership of the user_data is passed
+ *                                       to the created logging connection.
+ * @param[in] user_data_destroy_callback Nullable, function for freeing the user data.
+ * @return                               A new kernel logging connection, or null on error.
+ */
+BITCOINKERNEL_API btck_LoggingConnection* BITCOINKERNEL_WARN_UNUSED_RESULT btck_logging_connection_create(
+    btck_LogCallback log_callback,
+    void* user_data,
+    btck_DestroyCallback user_data_destroy_callback) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Stop logging and destroy the logging connection.
+ */
+BITCOINKERNEL_API void btck_logging_connection_destroy(btck_LoggingConnection* logging_connection);
+
+///@}
+
+/** @name ChainParameters
+ * Functions for working with chain parameters.
+ */
+///@{
+
+/**
+ * @brief Creates a chain parameters struct with default parameters based on the
+ * passed in chain type.
+ *
+ * @param[in] chain_type Controls the chain parameters type created.
+ * @return               An allocated chain parameters opaque struct.
+ */
+BITCOINKERNEL_API btck_ChainParameters* BITCOINKERNEL_WARN_UNUSED_RESULT btck_chain_parameters_create(
+    const btck_ChainType chain_type);
+
+/**
+ * Copy the chain parameters.
+ */
+BITCOINKERNEL_API btck_ChainParameters* BITCOINKERNEL_WARN_UNUSED_RESULT btck_chain_parameters_copy(
+    const btck_ChainParameters* chain_parameters) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Destroy the chain parameters.
+ */
+BITCOINKERNEL_API void btck_chain_parameters_destroy(btck_ChainParameters* chain_parameters);
+
+///@}
+
+/** @name ContextOptions
+ * Functions for working with context options.
+ */
+///@{
+
+/**
+ * Creates an empty context options.
+ */
+BITCOINKERNEL_API btck_ContextOptions* BITCOINKERNEL_WARN_UNUSED_RESULT btck_context_options_create();
+
+/**
+ * @brief Sets the chain params for the context options. The context created
+ * with the options will be configured for these chain parameters.
+ *
+ * @param[in] context_options  Non-null, previously created by @ref btck_context_options_create.
+ * @param[in] chain_parameters Is set to the context options.
+ */
+BITCOINKERNEL_API void btck_context_options_set_chainparams(
+    btck_ContextOptions* context_options,
+    const btck_ChainParameters* chain_parameters) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * @brief Set the kernel notifications for the context options. The context
+ * created with the options will be configured with these notifications.
+ *
+ * @param[in] context_options Non-null, previously created by @ref btck_context_options_create.
+ * @param[in] notifications   Is set to the context options.
+ */
+BITCOINKERNEL_API void btck_context_options_set_notifications(
+    btck_ContextOptions* context_options,
+    btck_NotificationInterfaceCallbacks notifications) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Set the validation interface callbacks for the context options. The
+ * context created with the options will be configured for these validation
+ * interface callbacks. The callbacks will then be triggered from validation
+ * events issued by the chainstate manager created from the same context.
+ *
+ * @param[in] context_options                Non-null, previously created with btck_context_options_create.
+ * @param[in] validation_interface_callbacks The callbacks used for passing validation information to the
+ *                                           user.
+ */
+BITCOINKERNEL_API void btck_context_options_set_validation_interface(
+    btck_ContextOptions* context_options,
+    btck_ValidationInterfaceCallbacks validation_interface_callbacks) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Destroy the context options.
+ */
+BITCOINKERNEL_API void btck_context_options_destroy(btck_ContextOptions* context_options);
+
+///@}
+
+/** @name Context
+ * Functions for working with contexts.
+ */
+///@{
+
+/**
+ * @brief Create a new kernel context. If the options have not been previously
+ * set, their corresponding fields will be initialized to default values; the
+ * context will assume mainnet chain parameters and won't attempt to call the
+ * kernel notification callbacks.
+ *
+ * @param[in] context_options Nullable, created by @ref btck_context_options_create.
+ * @return                    The allocated context, or null on error.
+ */
+BITCOINKERNEL_API btck_Context* BITCOINKERNEL_WARN_UNUSED_RESULT btck_context_create(
+    const btck_ContextOptions* context_options);
+
+/**
+ * Copy the context.
+ */
+BITCOINKERNEL_API btck_Context* BITCOINKERNEL_WARN_UNUSED_RESULT btck_context_copy(
+    const btck_Context* context) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Interrupt can be used to halt long-running validation functions like
+ * when reindexing, importing or processing blocks.
+ *
+ * @param[in] context  Non-null.
+ * @return             0 if the interrupt was successful, non-zero otherwise.
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_context_interrupt(
+    btck_Context* context) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Destroy the context.
+ */
+BITCOINKERNEL_API void btck_context_destroy(btck_Context* context);
+
+///@}
+
+/** @name BlockTreeEntry
+ * Functions for working with block tree entries.
+ */
+///@{
+
+/**
+ * @brief Returns the previous block tree entry in the tree, or null if the current
+ * block tree entry is the genesis block.
+ *
+ * @param[in] block_tree_entry Non-null.
+ * @return                     The previous block tree entry, or null on error or if the current block tree entry is the genesis block.
+ */
+BITCOINKERNEL_API const btck_BlockTreeEntry* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_tree_entry_get_previous(
+    const btck_BlockTreeEntry* block_tree_entry) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Return the height of a certain block tree entry.
+ *
+ * @param[in] block_tree_entry Non-null.
+ * @return                     The block height.
+ */
+BITCOINKERNEL_API int32_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_tree_entry_get_height(
+    const btck_BlockTreeEntry* block_tree_entry) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Return the block hash associated with a block tree entry.
+ *
+ * @param[in] block_tree_entry Non-null.
+ * @return                     The block hash.
+ */
+BITCOINKERNEL_API const btck_BlockHash* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_tree_entry_get_block_hash(
+    const btck_BlockTreeEntry* block_tree_entry) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Check if two block tree entries are equal. Two block tree entries are equal when they
+ * point to the same block.
+ *
+ * @param[in] entry1 Non-null.
+ * @param[in] entry2 Non-null.
+ * @return           1 if the block tree entries are equal, 0 otherwise.
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_tree_entry_equals(
+    const btck_BlockTreeEntry* entry1, const btck_BlockTreeEntry* entry2) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+///@}
+
+/** @name ChainstateManagerOptions
+ * Functions for working with chainstate manager options.
+ */
+///@{
+
+/**
+ * @brief Create options for the chainstate manager.
+ *
+ * @param[in] context          Non-null, the created options and through it the chainstate manager will
+ *                             associate with this kernel context for the duration of their lifetimes.
+ * @param[in] data_directory   Non-null, non-empty path string of the directory containing the
+ *                             chainstate data. If the directory does not exist yet, it will be
+ *                             created.
+ * @param[in] blocks_directory Non-null, non-empty path string of the directory containing the block
+ *                             data. If the directory does not exist yet, it will be created.
+ * @return                     The allocated chainstate manager options, or null on error.
+ */
+BITCOINKERNEL_API btck_ChainstateManagerOptions* BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_options_create(
+    const btck_Context* context,
+    const char* data_directory,
+    size_t data_directory_len,
+    const char* blocks_directory,
+    size_t blocks_directory_len) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Set the number of available worker threads used during validation.
+ *
+ * @param[in] chainstate_manager_options Non-null, options to be set.
+ * @param[in] worker_threads             The number of worker threads that should be spawned in the thread pool
+ *                                       used for validation. When set to 0 no parallel verification is done.
+ *                                       The value range is clamped internally between 0 and 15.
+ */
+BITCOINKERNEL_API void btck_chainstate_manager_options_set_worker_threads_num(
+    btck_ChainstateManagerOptions* chainstate_manager_options,
+    int worker_threads) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Sets wipe db in the options. In combination with calling
+ * @ref btck_chainstate_manager_import_blocks this triggers either a full reindex,
+ * or a reindex of just the chainstate database.
+ *
+ * @param[in] chainstate_manager_options Non-null, created by @ref btck_chainstate_manager_options_create.
+ * @param[in] wipe_block_tree_db         Set wipe block tree db. Should only be 1 if wipe_chainstate_db is 1 too.
+ * @param[in] wipe_chainstate_db         Set wipe chainstate db.
+ * @return                               0 if the set was successful, non-zero if the set failed.
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_options_set_wipe_dbs(
+    btck_ChainstateManagerOptions* chainstate_manager_options,
+    int wipe_block_tree_db,
+    int wipe_chainstate_db) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Sets block tree db in memory in the options.
+ *
+ * @param[in] chainstate_manager_options   Non-null, created by @ref btck_chainstate_manager_options_create.
+ * @param[in] block_tree_db_in_memory      Set block tree db in memory.
+ */
+BITCOINKERNEL_API void btck_chainstate_manager_options_update_block_tree_db_in_memory(
+    btck_ChainstateManagerOptions* chainstate_manager_options,
+    int block_tree_db_in_memory) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Sets chainstate db in memory in the options.
+ *
+ * @param[in] chainstate_manager_options Non-null, created by @ref btck_chainstate_manager_options_create.
+ * @param[in] chainstate_db_in_memory    Set chainstate db in memory.
+ */
+BITCOINKERNEL_API void btck_chainstate_manager_options_update_chainstate_db_in_memory(
+    btck_ChainstateManagerOptions* chainstate_manager_options,
+    int chainstate_db_in_memory) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Destroy the chainstate manager options.
+ */
+BITCOINKERNEL_API void btck_chainstate_manager_options_destroy(btck_ChainstateManagerOptions* chainstate_manager_options);
+
+///@}
+
+/** @name ChainstateManager
+ * Functions for chainstate management.
+ */
+///@{
+
+/**
+ * @brief Create a chainstate manager. This is the main object for many
+ * validation tasks as well as for retrieving data from the chain and
+ * interacting with its chainstate and indexes.
+ *
+ * @param[in] chainstate_manager_options Non-null, created by @ref btck_chainstate_manager_options_create.
+ * @return                               The allocated chainstate manager, or null on error.
+ */
+BITCOINKERNEL_API btck_ChainstateManager* BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_create(
+    const btck_ChainstateManagerOptions* chainstate_manager_options) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Triggers the start of a reindex if the wipe options were previously
+ * set for the chainstate manager. Can also import an array of existing block
+ * files selected by the user.
+ *
+ * @param[in] chainstate_manager        Non-null.
+ * @param[in] block_file_paths_data     Nullable, array of block files described by their full filesystem paths.
+ * @param[in] block_file_paths_lens     Nullable, array containing the lengths of each of the paths.
+ * @param[in] block_file_paths_data_len Length of the block_file_paths_data and block_file_paths_len arrays.
+ * @return                              0 if the import blocks call was completed successfully, non-zero otherwise.
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_import_blocks(
+    btck_ChainstateManager* chainstate_manager,
+    const char** block_file_paths_data, size_t* block_file_paths_lens,
+    size_t block_file_paths_data_len) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Process and validate the passed in block with the chainstate
+ * manager. Processing first does checks on the block, and if these passed,
+ * saves it to disk. It then validates the block against the utxo set. If it is
+ * valid, the chain is extended with it. The return value is not indicative of
+ * the block's validity. Detailed information on the validity of the block can
+ * be retrieved by registering the `block_checked` callback in the validation
+ * interface.
+ *
+ * @param[in] chainstate_manager Non-null.
+ * @param[in] block              Non-null, block to be validated.
+ *
+ * @param[out] new_block         Nullable, will be set to 1 if this block was not processed before. Note that this means it
+ *                               might also not be 1 if processing was attempted before, but the block was found invalid
+ *                               before its data was persisted.
+ * @return                       0 if processing the block was successful. Will also return 0 for valid, but duplicate blocks.
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_process_block(
+    btck_ChainstateManager* chainstate_manager,
+    const btck_Block* block,
+    int* new_block) BITCOINKERNEL_ARG_NONNULL(1, 2, 3);
+
+/**
+ * @brief Returns the best known currently active chain. Its lifetime is
+ * dependent on the chainstate manager. It can be thought of as a view on a
+ * vector of block tree entries that form the best chain. The returned chain
+ * reference always points to the currently active best chain. However, state
+ * transitions within the chainstate manager (e.g., processing blocks) will
+ * update the chain's contents. Data retrieved from this chain is only
+ * consistent up to the point when new data is processed in the chainstate
+ * manager. It is the user's responsibility to guard against these
+ * inconsistencies.
+ *
+ * @param[in] chainstate_manager Non-null.
+ * @return                       The chain.
+ */
+BITCOINKERNEL_API const btck_Chain* BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_get_active_chain(
+    const btck_ChainstateManager* chainstate_manager) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Retrieve a block tree entry by its block hash.
+ *
+ * @param[in] chainstate_manager Non-null.
+ * @param[in] block_hash         Non-null.
+ * @return                       The block tree entry of the block with the passed in hash, or null if
+ *                               the block hash is not found.
+ */
+BITCOINKERNEL_API const btck_BlockTreeEntry* BITCOINKERNEL_WARN_UNUSED_RESULT btck_chainstate_manager_get_block_tree_entry_by_hash(
+    const btck_ChainstateManager* chainstate_manager,
+    const btck_BlockHash* block_hash) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * Destroy the chainstate manager.
+ */
+BITCOINKERNEL_API void btck_chainstate_manager_destroy(btck_ChainstateManager* chainstate_manager);
+
+///@}
+
+/** @name Block
+ * Functions for working with blocks.
+ */
+///@{
+
+/**
+ * @brief Reads the block the passed in block tree entry points to from disk and
+ * returns it.
+ *
+ * @param[in] chainstate_manager Non-null.
+ * @param[in] block_tree_entry   Non-null.
+ * @return                       The read out block, or null on error.
+ */
+BITCOINKERNEL_API btck_Block* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_read(
+    const btck_ChainstateManager* chainstate_manager,
+    const btck_BlockTreeEntry* block_tree_entry) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * @brief Parse a serialized raw block into a new block object.
+ *
+ * @param[in] raw_block     Serialized block.
+ * @param[in] raw_block_len Length of the serialized block.
+ * @return                  The allocated block, or null on error.
+ */
+BITCOINKERNEL_API btck_Block* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_create(
+    const void* raw_block, size_t raw_block_len);
+
+/**
+ * @brief Copy a block. Blocks are reference counted, so this just increments
+ * the reference count.
+ *
+ * @param[in] block Non-null.
+ * @return          The copied block.
+ */
+BITCOINKERNEL_API btck_Block* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_copy(
+    const btck_Block* block) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Count the number of transactions contained in a block.
+ *
+ * @param[in] block Non-null.
+ * @return          The number of transactions in the block.
+ */
+BITCOINKERNEL_API size_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_count_transactions(
+    const btck_Block* block) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Get the transaction at the provided index. The returned transaction
+ * is not owned and depends on the lifetime of the block.
+ *
+ * @param[in] block             Non-null.
+ * @param[in] transaction_index The index of the transaction to be retrieved.
+ * @return                      The transaction.
+ */
+BITCOINKERNEL_API const btck_Transaction* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_get_transaction_at(
+    const btck_Block* block, size_t transaction_index) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Calculate and return the hash of a block.
+ *
+ * @param[in] block Non-null.
+ * @return    The block hash.
+ */
+BITCOINKERNEL_API btck_BlockHash* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_get_hash(
+    const btck_Block* block) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Serializes the block through the passed in callback to bytes.
+ * This is consensus serialization that is also used for the P2P network.
+ *
+ * @param[in] block     Non-null.
+ * @param[in] writer    Non-null, callback to a write bytes function.
+ * @param[in] user_data Holds a user-defined opaque structure that will be
+ *                      passed back through the writer callback.
+ * @return              0 on success.
+ */
+BITCOINKERNEL_API int btck_block_to_bytes(
+    const btck_Block* block,
+    btck_WriteBytes writer,
+    void* user_data) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * Destroy the block.
+ */
+BITCOINKERNEL_API void btck_block_destroy(btck_Block* block);
+
+///@}
+
+/** @name BlockValidationState
+ * Functions for working with block validation states.
+ */
+///@{
+
+/**
+ * Returns the validation mode from an opaque block validation state pointer.
+ */
+BITCOINKERNEL_API btck_ValidationMode btck_block_validation_state_get_validation_mode(
+    const btck_BlockValidationState* block_validation_state) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Returns the validation result from an opaque block validation state pointer.
+ */
+BITCOINKERNEL_API btck_BlockValidationResult btck_block_validation_state_get_block_validation_result(
+    const btck_BlockValidationState* block_validation_state) BITCOINKERNEL_ARG_NONNULL(1);
+
+///@}
+
+/** @name Chain
+ * Functions for working with the chain
+ */
+///@{
+
+/**
+ * @brief Return the height of the tip of the chain.
+ *
+ * @param[in] chain Non-null.
+ * @return          The current height.
+ */
+BITCOINKERNEL_API int32_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_chain_get_height(
+    const btck_Chain* chain) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Retrieve a block tree entry by its height in the currently active chain.
+ * Once retrieved there is no guarantee that it remains in the active chain.
+ *
+ * @param[in] chain        Non-null.
+ * @param[in] block_height Height in the chain of the to be retrieved block tree entry.
+ * @return                 The block tree entry at a certain height in the currently active chain, or null
+ *                         if the height is out of bounds.
+ */
+BITCOINKERNEL_API const btck_BlockTreeEntry* BITCOINKERNEL_WARN_UNUSED_RESULT btck_chain_get_by_height(
+    const btck_Chain* chain,
+    int block_height) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Return true if the passed in chain contains the block tree entry.
+ *
+ * @param[in] chain            Non-null.
+ * @param[in] block_tree_entry Non-null.
+ * @return                     1 if the block_tree_entry is in the chain, 0 otherwise.
+ *
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_chain_contains(
+    const btck_Chain* chain,
+    const btck_BlockTreeEntry* block_tree_entry) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+///@}
+
+/** @name BlockSpentOutputs
+ * Functions for working with block spent outputs.
+ */
+///@{
+
+/**
+ * @brief Reads the block spent coins data the passed in block tree entry points to from
+ * disk and returns it.
+ *
+ * @param[in] chainstate_manager Non-null.
+ * @param[in] block_tree_entry   Non-null.
+ * @return                       The read out block spent outputs, or null on error.
+ */
+BITCOINKERNEL_API btck_BlockSpentOutputs* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_spent_outputs_read(
+    const btck_ChainstateManager* chainstate_manager,
+    const btck_BlockTreeEntry* block_tree_entry) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * @brief Copy a block's spent outputs.
+ *
+ * @param[in] block_spent_outputs Non-null.
+ * @return                        The copied block spent outputs.
+ */
+BITCOINKERNEL_API btck_BlockSpentOutputs* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_spent_outputs_copy(
+    const btck_BlockSpentOutputs* block_spent_outputs) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Returns the number of transaction spent outputs whose data is contained in
+ * block spent outputs.
+ *
+ * @param[in] block_spent_outputs Non-null.
+ * @return                        The number of transaction spent outputs data in the block spent outputs.
+ */
+BITCOINKERNEL_API size_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_spent_outputs_count(
+    const btck_BlockSpentOutputs* block_spent_outputs) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Returns a transaction spent outputs contained in the block spent
+ * outputs at a certain index. The returned pointer is unowned and only valid
+ * for the lifetime of block_spent_outputs.
+ *
+ * @param[in] block_spent_outputs             Non-null.
+ * @param[in] transaction_spent_outputs_index The index of the transaction spent outputs within the block spent outputs.
+ * @return                                    A transaction spent outputs pointer.
+ */
+BITCOINKERNEL_API const btck_TransactionSpentOutputs* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_spent_outputs_get_transaction_spent_outputs_at(
+    const btck_BlockSpentOutputs* block_spent_outputs,
+    size_t transaction_spent_outputs_index) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Destroy the block spent outputs.
+ */
+BITCOINKERNEL_API void btck_block_spent_outputs_destroy(btck_BlockSpentOutputs* block_spent_outputs);
+
+///@}
+
+/** @name TransactionSpentOutputs
+ * Functions for working with the spent coins of a transaction
+ */
+///@{
+
+/**
+ * @brief Copy a transaction's spent outputs.
+ *
+ * @param[in] transaction_spent_outputs Non-null.
+ * @return                              The copied transaction spent outputs.
+ */
+BITCOINKERNEL_API btck_TransactionSpentOutputs* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_spent_outputs_copy(
+    const btck_TransactionSpentOutputs* transaction_spent_outputs) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Returns the number of previous transaction outputs contained in the
+ * transaction spent outputs data.
+ *
+ * @param[in] transaction_spent_outputs Non-null
+ * @return                              The number of spent transaction outputs for the transaction.
+ */
+BITCOINKERNEL_API size_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_spent_outputs_count(
+    const btck_TransactionSpentOutputs* transaction_spent_outputs) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Returns a coin contained in the transaction spent outputs at a
+ * certain index. The returned pointer is unowned and only valid for the
+ * lifetime of transaction_spent_outputs.
+ *
+ * @param[in] transaction_spent_outputs Non-null.
+ * @param[in] coin_index                The index of the to be retrieved coin within the
+ *                                      transaction spent outputs.
+ * @return                              A coin pointer.
+ */
+BITCOINKERNEL_API const btck_Coin* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_spent_outputs_get_coin_at(
+    const btck_TransactionSpentOutputs* transaction_spent_outputs,
+    size_t coin_index) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Destroy the transaction spent outputs.
+ */
+BITCOINKERNEL_API void btck_transaction_spent_outputs_destroy(btck_TransactionSpentOutputs* transaction_spent_outputs);
+
+///@}
+
+/** @name Transaction Input
+ * Functions for working with transaction inputs.
+ */
+///@{
+
+/**
+ * @brief Copy a transaction input.
+ *
+ * @param[in] transaction_input Non-null.
+ * @return                      The copied transaction input.
+ */
+BITCOINKERNEL_API btck_TransactionInput* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_input_copy(
+    const btck_TransactionInput* transaction_input) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Get the transaction out point. The returned transaction out point is
+ * not owned and depends on the lifetime of the transaction.
+ *
+ * @param[in] transaction_input Non-null.
+ * @return                      The transaction out point.
+ */
+BITCOINKERNEL_API const btck_TransactionOutPoint* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_input_get_out_point(
+    const btck_TransactionInput* transaction_input) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Destroy the transaction input.
+ */
+BITCOINKERNEL_API void btck_transaction_input_destroy(btck_TransactionInput* transaction_input);
+
+///@}
+
+/** @name Transaction Out Point
+ * Functions for working with transaction out points.
+ */
+///@{
+
+/**
+ * @brief Copy a transaction out point.
+ *
+ * @param[in] transaction_out_point Non-null.
+ * @return                          The copied transaction out point.
+ */
+BITCOINKERNEL_API btck_TransactionOutPoint* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_out_point_copy(
+    const btck_TransactionOutPoint* transaction_out_point) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Get the output position from the transaction out point.
+ *
+ * @param[in] transaction_out_point Non-null.
+ * @return                          The output index.
+ */
+BITCOINKERNEL_API uint32_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_out_point_get_index(
+    const btck_TransactionOutPoint* transaction_out_point) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Get the txid from the transaction out point. The returned txid is
+ * not owned and depends on the lifetime of the transaction out point.
+ *
+ * @param[in] transaction_out_point Non-null.
+ * @return                          The txid.
+ */
+BITCOINKERNEL_API const btck_Txid* BITCOINKERNEL_WARN_UNUSED_RESULT btck_transaction_out_point_get_txid(
+    const btck_TransactionOutPoint* transaction_out_point) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Destroy the transaction out point.
+ */
+BITCOINKERNEL_API void btck_transaction_out_point_destroy(btck_TransactionOutPoint* transaction_out_point);
+
+///@}
+
+/** @name Txid
+ * Functions for working with txids.
+ */
+///@{
+
+/**
+ * @brief Copy a txid.
+ *
+ * @param[in] txid Non-null.
+ * @return         The copied txid.
+ */
+BITCOINKERNEL_API btck_Txid* BITCOINKERNEL_WARN_UNUSED_RESULT btck_txid_copy(
+    const btck_Txid* txid) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Check if two txids are equal.
+ *
+ * @param[in] txid1 Non-null.
+ * @param[in] txid2 Non-null.
+ * @return          0 if the txid is not equal.
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_txid_equals(
+    const btck_Txid* txid1, const btck_Txid* txid2) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * @brief Serializes the txid to bytes.
+ *
+ * @param[in] txid    Non-null.
+ * @param[out] output The serialized txid.
+ */
+BITCOINKERNEL_API void btck_txid_to_bytes(
+    const btck_Txid* txid, unsigned char output[32]) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * Destroy the txid.
+ */
+BITCOINKERNEL_API void btck_txid_destroy(btck_Txid* txid);
+
+///@}
+
+///@}
+
+/** @name Coin
+ * Functions for working with coins.
+ */
+///@{
+
+/**
+ * @brief Copy a coin.
+ *
+ * @param[in] coin Non-null.
+ * @return         The copied coin.
+ */
+BITCOINKERNEL_API btck_Coin* BITCOINKERNEL_WARN_UNUSED_RESULT btck_coin_copy(
+    const btck_Coin* coin) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Returns the block height where the transaction that
+ * created this coin was included in.
+ *
+ * @param[in] coin Non-null.
+ * @return         The block height of the coin.
+ */
+BITCOINKERNEL_API uint32_t BITCOINKERNEL_WARN_UNUSED_RESULT btck_coin_confirmation_height(
+    const btck_Coin* coin) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Returns whether the containing transaction was a coinbase.
+ *
+ * @param[in] coin Non-null.
+ * @return         1 if the coin is a coinbase coin, 0 otherwise.
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_coin_is_coinbase(
+    const btck_Coin* coin) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Return the transaction output of a coin. The returned pointer is
+ * unowned and only valid for the lifetime of the coin.
+ *
+ * @param[in] coin Non-null.
+ * @return         A transaction output pointer.
+ */
+BITCOINKERNEL_API const btck_TransactionOutput* BITCOINKERNEL_WARN_UNUSED_RESULT btck_coin_get_output(
+    const btck_Coin* coin) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * Destroy the coin.
+ */
+BITCOINKERNEL_API void btck_coin_destroy(btck_Coin* coin);
+
+///@}
+
+/** @name BlockHash
+ * Functions for working with block hashes.
+ */
+///@{
+
+/**
+ * @brief Create a block hash from its raw data.
+ */
+BITCOINKERNEL_API btck_BlockHash* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_hash_create(
+    const unsigned char block_hash[32]) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Check if two block hashes are equal.
+ *
+ * @param[in] hash1 Non-null.
+ * @param[in] hash2 Non-null.
+ * @return          0 if the block hashes are not equal.
+ */
+BITCOINKERNEL_API int BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_hash_equals(
+    const btck_BlockHash* hash1, const btck_BlockHash* hash2) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * @brief Copy a block hash.
+ *
+ * @param[in] block_hash Non-null.
+ * @return               The copied block hash.
+ */
+BITCOINKERNEL_API btck_BlockHash* BITCOINKERNEL_WARN_UNUSED_RESULT btck_block_hash_copy(
+    const btck_BlockHash* block_hash) BITCOINKERNEL_ARG_NONNULL(1);
+
+/**
+ * @brief Serializes the block hash to bytes.
+ *
+ * @param[in] block_hash     Non-null.
+ * @param[in] output         The serialized block hash.
+ */
+BITCOINKERNEL_API void btck_block_hash_to_bytes(
+    const btck_BlockHash* block_hash, unsigned char output[32]) BITCOINKERNEL_ARG_NONNULL(1, 2);
+
+/**
+ * Destroy the block hash.
+ */
+BITCOINKERNEL_API void btck_block_hash_destroy(btck_BlockHash* block_hash);
+
+///@}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#endif // BITCOIN_KERNEL_BITCOINKERNEL_H

--- a/modules/dynamicbitcoinkernel/bitcoinkernel_wrapper/bitcoinkernel_wrapper.h
+++ b/modules/dynamicbitcoinkernel/bitcoinkernel_wrapper/bitcoinkernel_wrapper.h
@@ -1,0 +1,1160 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_KERNEL_BITCOINKERNEL_WRAPPER_H
+#define BITCOIN_KERNEL_BITCOINKERNEL_WRAPPER_H
+
+#include "bitcoinkernel.h"
+
+#include <array>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace btck {
+
+enum class LogCategory : btck_LogCategory {
+    ALL = btck_LogCategory_ALL,
+    BENCH = btck_LogCategory_BENCH,
+    BLOCKSTORAGE = btck_LogCategory_BLOCKSTORAGE,
+    COINDB = btck_LogCategory_COINDB,
+    LEVELDB = btck_LogCategory_LEVELDB,
+    MEMPOOL = btck_LogCategory_MEMPOOL,
+    PRUNE = btck_LogCategory_PRUNE,
+    RAND = btck_LogCategory_RAND,
+    REINDEX = btck_LogCategory_REINDEX,
+    VALIDATION = btck_LogCategory_VALIDATION,
+    KERNEL = btck_LogCategory_KERNEL
+};
+
+enum class LogLevel : btck_LogLevel {
+    TRACE_LEVEL = btck_LogLevel_TRACE,
+    DEBUG_LEVEL = btck_LogLevel_DEBUG,
+    INFO_LEVEL = btck_LogLevel_INFO
+};
+
+enum class ChainType : btck_ChainType {
+    MAINNET = btck_ChainType_MAINNET,
+    TESTNET = btck_ChainType_TESTNET,
+    TESTNET_4 = btck_ChainType_TESTNET_4,
+    SIGNET = btck_ChainType_SIGNET,
+    REGTEST = btck_ChainType_REGTEST
+};
+
+enum class SynchronizationState : btck_SynchronizationState {
+    INIT_REINDEX = btck_SynchronizationState_INIT_REINDEX,
+    INIT_DOWNLOAD = btck_SynchronizationState_INIT_DOWNLOAD,
+    POST_INIT = btck_SynchronizationState_POST_INIT
+};
+
+enum class Warning : btck_Warning {
+    UNKNOWN_NEW_RULES_ACTIVATED = btck_Warning_UNKNOWN_NEW_RULES_ACTIVATED,
+    LARGE_WORK_INVALID_CHAIN = btck_Warning_LARGE_WORK_INVALID_CHAIN
+};
+
+enum class ValidationMode : btck_ValidationMode {
+    VALID = btck_ValidationMode_VALID,
+    INVALID = btck_ValidationMode_INVALID,
+    INTERNAL_ERROR = btck_ValidationMode_INTERNAL_ERROR
+};
+
+enum class BlockValidationResult : btck_BlockValidationResult {
+    UNSET = btck_BlockValidationResult_UNSET,
+    CONSENSUS = btck_BlockValidationResult_CONSENSUS,
+    CACHED_INVALID = btck_BlockValidationResult_CACHED_INVALID,
+    INVALID_HEADER = btck_BlockValidationResult_INVALID_HEADER,
+    MUTATED = btck_BlockValidationResult_MUTATED,
+    MISSING_PREV = btck_BlockValidationResult_MISSING_PREV,
+    INVALID_PREV = btck_BlockValidationResult_INVALID_PREV,
+    TIME_FUTURE = btck_BlockValidationResult_TIME_FUTURE,
+    HEADER_LOW_WORK = btck_BlockValidationResult_HEADER_LOW_WORK
+};
+
+enum class ScriptVerifyStatus : btck_ScriptVerifyStatus {
+    OK = btck_ScriptVerifyStatus_OK,
+    ERROR_INVALID_FLAGS_COMBINATION = btck_ScriptVerifyStatus_ERROR_INVALID_FLAGS_COMBINATION,
+    ERROR_SPENT_OUTPUTS_REQUIRED = btck_ScriptVerifyStatus_ERROR_SPENT_OUTPUTS_REQUIRED,
+};
+
+enum class ScriptVerificationFlags : btck_ScriptVerificationFlags {
+    NONE = btck_ScriptVerificationFlags_NONE,
+    P2SH = btck_ScriptVerificationFlags_P2SH,
+    DERSIG = btck_ScriptVerificationFlags_DERSIG,
+    NULLDUMMY = btck_ScriptVerificationFlags_NULLDUMMY,
+    CHECKLOCKTIMEVERIFY = btck_ScriptVerificationFlags_CHECKLOCKTIMEVERIFY,
+    CHECKSEQUENCEVERIFY = btck_ScriptVerificationFlags_CHECKSEQUENCEVERIFY,
+    WITNESS = btck_ScriptVerificationFlags_WITNESS,
+    TAPROOT = btck_ScriptVerificationFlags_TAPROOT,
+    ALL = btck_ScriptVerificationFlags_ALL
+};
+
+template <typename T>
+struct is_bitmask_enum : std::false_type {
+};
+
+template <>
+struct is_bitmask_enum<ScriptVerificationFlags> : std::true_type {
+};
+
+template <typename T>
+concept BitmaskEnum = is_bitmask_enum<T>::value;
+
+template <BitmaskEnum T>
+constexpr T operator|(T lhs, T rhs)
+{
+    return static_cast<T>(
+        static_cast<std::underlying_type_t<T>>(lhs) | static_cast<std::underlying_type_t<T>>(rhs));
+}
+
+template <BitmaskEnum T>
+constexpr T operator&(T lhs, T rhs)
+{
+    return static_cast<T>(
+        static_cast<std::underlying_type_t<T>>(lhs) & static_cast<std::underlying_type_t<T>>(rhs));
+}
+
+template <BitmaskEnum T>
+constexpr T operator^(T lhs, T rhs)
+{
+    return static_cast<T>(
+        static_cast<std::underlying_type_t<T>>(lhs) ^ static_cast<std::underlying_type_t<T>>(rhs));
+}
+
+template <BitmaskEnum T>
+constexpr T operator~(T value)
+{
+    return static_cast<T>(~static_cast<std::underlying_type_t<T>>(value));
+}
+
+template <BitmaskEnum T>
+constexpr T& operator|=(T& lhs, T rhs)
+{
+    return lhs = lhs | rhs;
+}
+
+template <BitmaskEnum T>
+constexpr T& operator&=(T& lhs, T rhs)
+{
+    return lhs = lhs & rhs;
+}
+
+template <BitmaskEnum T>
+constexpr T& operator^=(T& lhs, T rhs)
+{
+    return lhs = lhs ^ rhs;
+}
+
+template <typename T>
+T check(T ptr)
+{
+    if (ptr == nullptr) {
+        throw std::runtime_error("failed to instantiate btck object");
+    }
+    return ptr;
+}
+
+template <typename Collection, typename ValueType>
+class Iterator
+{
+public:
+    using iterator_category = std::random_access_iterator_tag;
+    using iterator_concept = std::random_access_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = ValueType;
+
+private:
+    const Collection* m_collection;
+    size_t m_idx;
+
+public:
+    Iterator() = default;
+    Iterator(const Collection* ptr) : m_collection{ptr}, m_idx{0} {}
+    Iterator(const Collection* ptr, size_t idx) : m_collection{ptr}, m_idx{idx} {}
+
+    // This is just a view, so return a copy.
+    auto operator*() const { return (*m_collection)[m_idx]; }
+    auto operator->() const { return (*m_collection)[m_idx]; }
+
+    auto& operator++() { m_idx++; return *this; }
+    auto operator++(int) { Iterator tmp = *this; ++(*this); return tmp; }
+
+    auto& operator--() { m_idx--; return *this; }
+    auto operator--(int) { auto temp = *this; --m_idx; return temp; }
+
+    auto& operator+=(difference_type n) { m_idx += n; return *this; }
+    auto& operator-=(difference_type n) { m_idx -= n; return *this; }
+
+    auto operator+(difference_type n) const { return Iterator(m_collection, m_idx + n); }
+    auto operator-(difference_type n) const { return Iterator(m_collection, m_idx - n); }
+
+    auto operator-(const Iterator& other) const { return static_cast<difference_type>(m_idx) - static_cast<difference_type>(other.m_idx); }
+
+    ValueType operator[](difference_type n) const { return (*m_collection)[m_idx + n]; }
+
+    auto operator<=>(const Iterator& other) const { return m_idx <=> other.m_idx; }
+
+    bool operator==(const Iterator& other) const { return m_collection == other.m_collection && m_idx == other.m_idx; }
+
+private:
+    friend Iterator operator+(difference_type n, const Iterator& it) { return it + n; }
+};
+
+template <typename Container, typename SizeFunc, typename GetFunc>
+concept IndexedContainer = requires(const Container& c, SizeFunc size_func, GetFunc get_func, std::size_t i) {
+    { std::invoke(size_func, c) } -> std::convertible_to<std::size_t>;
+    { std::invoke(get_func, c, i) }; // Return type is deduced
+};
+
+template <typename Container, auto SizeFunc, auto GetFunc>
+    requires IndexedContainer<Container, decltype(SizeFunc), decltype(GetFunc)>
+class Range
+{
+public:
+    using value_type = std::invoke_result_t<decltype(GetFunc), const Container&, size_t>;
+    using difference_type = std::ptrdiff_t;
+    using iterator = Iterator<Range, value_type>;
+    using const_iterator = iterator;
+
+private:
+    const Container* m_container;
+
+public:
+    explicit Range(const Container& container) : m_container(&container)
+    {
+        static_assert(std::ranges::random_access_range<Range>);
+    }
+
+    iterator begin() const { return iterator(this, 0); }
+    iterator end() const { return iterator(this, size()); }
+
+    const_iterator cbegin() const { return begin(); }
+    const_iterator cend() const { return end(); }
+
+    size_t size() const { return std::invoke(SizeFunc, *m_container); }
+
+    bool empty() const { return size() == 0; }
+
+    value_type operator[](size_t index) const { return std::invoke(GetFunc, *m_container, index); }
+
+    value_type at(size_t index) const
+    {
+        if (index >= size()) {
+            throw std::out_of_range("Index out of range");
+        }
+        return (*this)[index];
+    }
+
+    value_type front() const { return (*this)[0]; }
+    value_type back() const { return (*this)[size() - 1]; }
+};
+
+#define MAKE_RANGE_METHOD(method_name, ContainerType, SizeFunc, GetFunc, container_expr) \
+    auto method_name() const & { \
+        return Range<ContainerType, SizeFunc, GetFunc>{container_expr}; \
+    } \
+    auto method_name() const && = delete;
+
+template <typename T>
+std::vector<std::byte> write_bytes(const T* object, int (*to_bytes)(const T*, btck_WriteBytes, void*))
+{
+    std::vector<std::byte> bytes;
+    struct UserData {
+        std::vector<std::byte>* bytes;
+        std::exception_ptr exception;
+    };
+    UserData user_data = UserData{.bytes = &bytes, .exception = nullptr};
+
+    constexpr auto const write = +[](const void* buffer, size_t len, void* user_data) -> int {
+        auto& data = *reinterpret_cast<UserData*>(user_data);
+        auto& bytes = *data.bytes;
+        try {
+            auto const* first = static_cast<const std::byte*>(buffer);
+            auto const* last = first + len;
+            bytes.insert(bytes.end(), first, last);
+            return 0;
+        } catch (...) {
+            data.exception = std::current_exception();
+            return -1;
+        }
+    };
+
+    if (to_bytes(object, write, &user_data) != 0) {
+        std::rethrow_exception(user_data.exception);
+    }
+    return bytes;
+}
+
+template <typename CType>
+class View
+{
+protected:
+    const CType* m_ptr;
+
+public:
+    explicit View(const CType* ptr) : m_ptr{check(ptr)} {}
+
+    const CType* get() const { return m_ptr; }
+};
+
+template <typename CType, CType* (*CopyFunc)(const CType*), void (*DestroyFunc)(CType*)>
+class Handle
+{
+protected:
+    CType* m_ptr;
+
+public:
+    explicit Handle(CType* ptr) : m_ptr{check(ptr)} {}
+
+    // Copy constructors
+    Handle(const Handle& other)
+        : m_ptr{check(CopyFunc(other.m_ptr))} {}
+    Handle& operator=(const Handle& other)
+    {
+        if (this != &other) {
+            Handle temp(other);
+            std::swap(m_ptr, temp.m_ptr);
+        }
+        return *this;
+    }
+
+    // Move constructors
+    Handle(Handle&& other) noexcept : m_ptr(other.m_ptr) { other.m_ptr = nullptr; }
+    Handle& operator=(Handle&& other) noexcept
+    {
+        DestroyFunc(m_ptr);
+        m_ptr = std::exchange(other.m_ptr, nullptr);
+        return *this;
+    }
+
+    template <typename ViewType>
+        requires std::derived_from<ViewType, View<CType>>
+    Handle(const ViewType& view)
+        : Handle{CopyFunc(view.get())}
+    {
+    }
+
+    ~Handle() { DestroyFunc(m_ptr); }
+
+    CType* get() { return m_ptr; }
+    const CType* get() const { return m_ptr; }
+};
+
+template <typename CType, void (*DestroyFunc)(CType*)>
+class UniqueHandle
+{
+protected:
+    struct Deleter {
+        void operator()(CType* ptr) const noexcept
+        {
+            if (ptr) DestroyFunc(ptr);
+        }
+    };
+    std::unique_ptr<CType, Deleter> m_ptr;
+
+public:
+    explicit UniqueHandle(CType* ptr) : m_ptr{check(ptr)} {}
+
+    CType* get() { return m_ptr.get(); }
+    const CType* get() const { return m_ptr.get(); }
+};
+
+class PrecomputedTransactionData;
+class Transaction;
+class TransactionOutput;
+
+template <typename Derived>
+class ScriptPubkeyApi
+{
+private:
+    auto impl() const
+    {
+        return static_cast<const Derived*>(this)->get();
+    }
+
+    friend Derived;
+    ScriptPubkeyApi() = default;
+
+public:
+    bool Verify(int64_t amount,
+                const Transaction& tx_to,
+                const PrecomputedTransactionData* precomputed_txdata,
+                unsigned int input_index,
+                ScriptVerificationFlags flags,
+                ScriptVerifyStatus& status) const;
+
+    std::vector<std::byte> ToBytes() const
+    {
+        return write_bytes(impl(), btck_script_pubkey_to_bytes);
+    }
+};
+
+class ScriptPubkeyView : public View<btck_ScriptPubkey>, public ScriptPubkeyApi<ScriptPubkeyView>
+{
+public:
+    explicit ScriptPubkeyView(const btck_ScriptPubkey* ptr) : View{ptr} {}
+};
+
+class ScriptPubkey : public Handle<btck_ScriptPubkey, btck_script_pubkey_copy, btck_script_pubkey_destroy>, public ScriptPubkeyApi<ScriptPubkey>
+{
+public:
+    explicit ScriptPubkey(std::span<const std::byte> raw)
+        : Handle{btck_script_pubkey_create(raw.data(), raw.size())} {}
+
+    ScriptPubkey(const ScriptPubkeyView& view)
+        : Handle(view) {}
+};
+
+template <typename Derived>
+class TransactionOutputApi
+{
+private:
+    auto impl() const
+    {
+        return static_cast<const Derived*>(this)->get();
+    }
+
+    friend Derived;
+    TransactionOutputApi() = default;
+
+public:
+    int64_t Amount() const
+    {
+        return btck_transaction_output_get_amount(impl());
+    }
+
+    ScriptPubkeyView GetScriptPubkey() const
+    {
+        return ScriptPubkeyView{btck_transaction_output_get_script_pubkey(impl())};
+    }
+};
+
+class TransactionOutputView : public View<btck_TransactionOutput>, public TransactionOutputApi<TransactionOutputView>
+{
+public:
+    explicit TransactionOutputView(const btck_TransactionOutput* ptr) : View{ptr} {}
+};
+
+class TransactionOutput : public Handle<btck_TransactionOutput, btck_transaction_output_copy, btck_transaction_output_destroy>, public TransactionOutputApi<TransactionOutput>
+{
+public:
+    explicit TransactionOutput(const ScriptPubkey& script_pubkey, int64_t amount)
+        : Handle{btck_transaction_output_create(script_pubkey.get(), amount)} {}
+
+    TransactionOutput(const TransactionOutputView& view)
+        : Handle(view) {}
+};
+
+template <typename Derived>
+class TxidApi
+{
+private:
+    auto impl() const
+    {
+        return static_cast<const Derived*>(this)->get();
+    }
+
+    friend Derived;
+    TxidApi() = default;
+
+public:
+    bool operator==(const TxidApi& other) const
+    {
+        return btck_txid_equals(impl(), other.impl()) != 0;
+    }
+
+    bool operator!=(const TxidApi& other) const
+    {
+        return btck_txid_equals(impl(), other.impl()) == 0;
+    }
+
+    std::array<std::byte, 32> ToBytes() const
+    {
+        std::array<std::byte, 32> hash;
+        btck_txid_to_bytes(impl(), reinterpret_cast<unsigned char*>(hash.data()));
+        return hash;
+    }
+};
+
+class TxidView : public View<btck_Txid>, public TxidApi<TxidView>
+{
+public:
+    explicit TxidView(const btck_Txid* ptr) : View{ptr} {}
+};
+
+class Txid : public Handle<btck_Txid, btck_txid_copy, btck_txid_destroy>, public TxidApi<Txid>
+{
+public:
+    Txid(const TxidView& view)
+        : Handle(view) {}
+};
+
+template <typename Derived>
+class OutPointApi
+{
+private:
+    auto impl() const
+    {
+        return static_cast<const Derived*>(this)->get();
+    }
+
+    friend Derived;
+    OutPointApi() = default;
+
+public:
+    uint32_t index() const
+    {
+        return btck_transaction_out_point_get_index(impl());
+    }
+
+    TxidView Txid() const
+    {
+        return TxidView{btck_transaction_out_point_get_txid(impl())};
+    }
+};
+
+class OutPointView : public View<btck_TransactionOutPoint>, public OutPointApi<OutPointView>
+{
+public:
+    explicit OutPointView(const btck_TransactionOutPoint* ptr) : View{ptr} {}
+};
+
+class OutPoint : public Handle<btck_TransactionOutPoint, btck_transaction_out_point_copy, btck_transaction_out_point_destroy>, public OutPointApi<OutPoint>
+{
+public:
+    OutPoint(const OutPointView& view)
+        : Handle(view) {}
+};
+
+template <typename Derived>
+class TransactionInputApi
+{
+private:
+    auto impl() const
+    {
+        return static_cast<const Derived*>(this)->get();
+    }
+
+    friend Derived;
+    TransactionInputApi() = default;
+
+public:
+    OutPointView OutPoint() const
+    {
+        return OutPointView{btck_transaction_input_get_out_point(impl())};
+    }
+};
+
+class TransactionInputView : public View<btck_TransactionInput>, public TransactionInputApi<TransactionInputView>
+{
+public:
+    explicit TransactionInputView(const btck_TransactionInput* ptr) : View{ptr} {}
+};
+
+class TransactionInput : public Handle<btck_TransactionInput, btck_transaction_input_copy, btck_transaction_input_destroy>, public TransactionInputApi<TransactionInput>
+{
+public:
+    TransactionInput(const TransactionInputView& view)
+        : Handle(view) {}
+};
+
+template <typename Derived>
+class TransactionApi
+{
+private:
+    auto impl() const
+    {
+        return static_cast<const Derived*>(this)->get();
+    }
+
+public:
+    size_t CountOutputs() const
+    {
+        return btck_transaction_count_outputs(impl());
+    }
+
+    size_t CountInputs() const
+    {
+        return btck_transaction_count_inputs(impl());
+    }
+
+    TransactionOutputView GetOutput(size_t index) const
+    {
+        return TransactionOutputView{btck_transaction_get_output_at(impl(), index)};
+    }
+
+    TransactionInputView GetInput(size_t index) const
+    {
+        return TransactionInputView{btck_transaction_get_input_at(impl(), index)};
+    }
+
+    TxidView Txid() const
+    {
+        return TxidView{btck_transaction_get_txid(impl())};
+    }
+
+    MAKE_RANGE_METHOD(Outputs, Derived, &TransactionApi<Derived>::CountOutputs, &TransactionApi<Derived>::GetOutput, *static_cast<const Derived*>(this))
+
+    MAKE_RANGE_METHOD(Inputs, Derived, &TransactionApi<Derived>::CountInputs, &TransactionApi<Derived>::GetInput, *static_cast<const Derived*>(this))
+
+    std::vector<std::byte> ToBytes() const
+    {
+        return write_bytes(impl(), btck_transaction_to_bytes);
+    }
+};
+
+class TransactionView : public View<btck_Transaction>, public TransactionApi<TransactionView>
+{
+public:
+    explicit TransactionView(const btck_Transaction* ptr) : View{ptr} {}
+};
+
+class Transaction : public Handle<btck_Transaction, btck_transaction_copy, btck_transaction_destroy>, public TransactionApi<Transaction>
+{
+public:
+    explicit Transaction(std::span<const std::byte> raw_transaction)
+        : Handle{btck_transaction_create(raw_transaction.data(), raw_transaction.size())} {}
+
+    Transaction(const TransactionView& view)
+        : Handle{view} {}
+};
+
+class PrecomputedTransactionData : public Handle<btck_PrecomputedTransactionData, btck_precomputed_transaction_data_copy, btck_precomputed_transaction_data_destroy>
+{
+public:
+    explicit PrecomputedTransactionData(const Transaction& tx_to, std::span<const TransactionOutput> spent_outputs)
+        : Handle{btck_precomputed_transaction_data_create(
+            tx_to.get(),
+            reinterpret_cast<const btck_TransactionOutput**>(
+                const_cast<TransactionOutput*>(spent_outputs.data())),
+            spent_outputs.size())} {}
+};
+
+template <typename Derived>
+bool ScriptPubkeyApi<Derived>::Verify(int64_t amount,
+                                      const Transaction& tx_to,
+                                      const PrecomputedTransactionData* precomputed_txdata,
+                                      unsigned int input_index,
+                                      ScriptVerificationFlags flags,
+                                      ScriptVerifyStatus& status) const
+{
+    auto result = btck_script_pubkey_verify(
+        impl(),
+        amount,
+        tx_to.get(),
+        precomputed_txdata ? precomputed_txdata->get() : nullptr,
+        input_index,
+        static_cast<btck_ScriptVerificationFlags>(flags),
+        reinterpret_cast<btck_ScriptVerifyStatus*>(&status));
+    return result == 1;
+}
+
+template <typename Derived>
+class BlockHashApi
+{
+private:
+    auto impl() const
+    {
+        return static_cast<const Derived*>(this)->get();
+    }
+
+public:
+    bool operator==(const Derived& other) const
+    {
+        return btck_block_hash_equals(impl(), other.get()) != 0;
+    }
+
+    bool operator!=(const Derived& other) const
+    {
+        return btck_block_hash_equals(impl(), other.get()) == 0;
+    }
+
+    std::array<std::byte, 32> ToBytes() const
+    {
+        std::array<std::byte, 32> hash;
+        btck_block_hash_to_bytes(impl(), reinterpret_cast<unsigned char*>(hash.data()));
+        return hash;
+    }
+};
+
+class BlockHashView: public View<btck_BlockHash>, public BlockHashApi<BlockHashView>
+{
+public:
+    explicit BlockHashView(const btck_BlockHash* ptr) : View{ptr} {}
+};
+
+class BlockHash : public Handle<btck_BlockHash, btck_block_hash_copy, btck_block_hash_destroy>, public BlockHashApi<BlockHash>
+{
+public:
+    explicit BlockHash(const std::array<std::byte, 32>& hash)
+        : Handle{btck_block_hash_create(reinterpret_cast<const unsigned char*>(hash.data()))} {}
+
+    explicit BlockHash(btck_BlockHash* hash)
+        : Handle{hash} {}
+
+    BlockHash(const BlockHashView& view)
+        : Handle{view} {}
+};
+
+class Block : public Handle<btck_Block, btck_block_copy, btck_block_destroy>
+{
+public:
+    Block(const std::span<const std::byte> raw_block)
+        : Handle{btck_block_create(raw_block.data(), raw_block.size())}
+    {
+    }
+
+    Block(btck_Block* block) : Handle{block} {}
+
+    size_t CountTransactions() const
+    {
+        return btck_block_count_transactions(get());
+    }
+
+    TransactionView GetTransaction(size_t index) const
+    {
+        return TransactionView{btck_block_get_transaction_at(get(), index)};
+    }
+
+    MAKE_RANGE_METHOD(Transactions, Block, &Block::CountTransactions, &Block::GetTransaction, *this)
+
+    BlockHash GetHash() const
+    {
+        return BlockHash{btck_block_get_hash(get())};
+    }
+
+    std::vector<std::byte> ToBytes() const
+    {
+        return write_bytes(get(), btck_block_to_bytes);
+    }
+};
+
+inline void logging_disable()
+{
+    btck_logging_disable();
+}
+
+inline void logging_set_options(const btck_LoggingOptions& logging_options)
+{
+    btck_logging_set_options(logging_options);
+}
+
+inline void logging_set_level_category(LogCategory category, LogLevel level)
+{
+    btck_logging_set_level_category(static_cast<btck_LogCategory>(category), static_cast<btck_LogLevel>(level));
+}
+
+inline void logging_enable_category(LogCategory category)
+{
+    btck_logging_enable_category(static_cast<btck_LogCategory>(category));
+}
+
+inline void logging_disable_category(LogCategory category)
+{
+    btck_logging_disable_category(static_cast<btck_LogCategory>(category));
+}
+
+template <typename T>
+concept Log = requires(T a, std::string_view message) {
+    { a.LogMessage(message) } -> std::same_as<void>;
+};
+
+template <Log T>
+class Logger : UniqueHandle<btck_LoggingConnection, btck_logging_connection_destroy>
+{
+public:
+    Logger(std::unique_ptr<T> log)
+        : UniqueHandle{btck_logging_connection_create(
+              +[](void* user_data, const char* message, size_t message_len) { static_cast<T*>(user_data)->LogMessage({message, message_len}); },
+              log.release(),
+              +[](void* user_data) { delete static_cast<T*>(user_data); })}
+    {
+    }
+};
+
+class BlockTreeEntry : public View<btck_BlockTreeEntry>
+{
+public:
+    BlockTreeEntry(const btck_BlockTreeEntry* entry)
+        : View{entry}
+    {
+    }
+
+    bool operator==(const BlockTreeEntry& other) const
+    {
+        return btck_block_tree_entry_equals(get(), other.get()) != 0;
+    }
+
+    std::optional<BlockTreeEntry> GetPrevious() const
+    {
+        auto entry{btck_block_tree_entry_get_previous(get())};
+        if (!entry) return std::nullopt;
+        return entry;
+    }
+
+    int32_t GetHeight() const
+    {
+        return btck_block_tree_entry_get_height(get());
+    }
+
+    BlockHashView GetHash() const
+    {
+        return BlockHashView{btck_block_tree_entry_get_block_hash(get())};
+    }
+};
+
+class KernelNotifications
+{
+public:
+    virtual ~KernelNotifications() = default;
+
+    virtual void BlockTipHandler(SynchronizationState state, BlockTreeEntry entry, double verification_progress) {}
+
+    virtual void HeaderTipHandler(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) {}
+
+    virtual void ProgressHandler(std::string_view title, int progress_percent, bool resume_possible) {}
+
+    virtual void WarningSetHandler(Warning warning, std::string_view message) {}
+
+    virtual void WarningUnsetHandler(Warning warning) {}
+
+    virtual void FlushErrorHandler(std::string_view error) {}
+
+    virtual void FatalErrorHandler(std::string_view error) {}
+};
+
+class BlockValidationState
+{
+private:
+    const btck_BlockValidationState* m_state;
+
+public:
+    BlockValidationState(const btck_BlockValidationState* state) : m_state{state} {}
+
+    BlockValidationState(const BlockValidationState&) = delete;
+    BlockValidationState& operator=(const BlockValidationState&) = delete;
+    BlockValidationState(BlockValidationState&&) = delete;
+    BlockValidationState& operator=(BlockValidationState&&) = delete;
+
+    ValidationMode GetValidationMode() const
+    {
+        return static_cast<ValidationMode>(btck_block_validation_state_get_validation_mode(m_state));
+    }
+
+    BlockValidationResult GetBlockValidationResult() const
+    {
+        return static_cast<BlockValidationResult>(btck_block_validation_state_get_block_validation_result(m_state));
+    }
+};
+
+class ValidationInterface
+{
+public:
+    virtual ~ValidationInterface() = default;
+
+    virtual void BlockChecked(Block block, const BlockValidationState state) {}
+
+    virtual void PowValidBlock(BlockTreeEntry entry, Block block) {}
+
+    virtual void BlockConnected(Block block, BlockTreeEntry entry) {}
+
+    virtual void BlockDisconnected(Block block, BlockTreeEntry entry) {}
+};
+
+class ChainParams : public Handle<btck_ChainParameters, btck_chain_parameters_copy, btck_chain_parameters_destroy>
+{
+public:
+    ChainParams(ChainType chain_type)
+        : Handle{btck_chain_parameters_create(static_cast<btck_ChainType>(chain_type))} {}
+};
+
+class ContextOptions : public UniqueHandle<btck_ContextOptions, btck_context_options_destroy>
+{
+public:
+    ContextOptions() : UniqueHandle{btck_context_options_create()} {}
+
+    void SetChainParams(ChainParams& chain_params)
+    {
+        btck_context_options_set_chainparams(get(), chain_params.get());
+    }
+
+    template <typename T>
+    void SetNotifications(std::shared_ptr<T> notifications)
+    {
+        static_assert(std::is_base_of_v<KernelNotifications, T>);
+        auto heap_notifications = std::make_unique<std::shared_ptr<T>>(std::move(notifications));
+        using user_type = std::shared_ptr<T>*;
+        btck_context_options_set_notifications(
+            get(),
+            btck_NotificationInterfaceCallbacks{
+                .user_data = heap_notifications.release(),
+                .user_data_destroy = +[](void* user_data) { delete static_cast<user_type>(user_data); },
+                .block_tip = +[](void* user_data, btck_SynchronizationState state, const btck_BlockTreeEntry* entry, double verification_progress) { (*static_cast<user_type>(user_data))->BlockTipHandler(static_cast<SynchronizationState>(state), BlockTreeEntry{entry}, verification_progress); },
+                .header_tip = +[](void* user_data, btck_SynchronizationState state, int64_t height, int64_t timestamp, int presync) { (*static_cast<user_type>(user_data))->HeaderTipHandler(static_cast<SynchronizationState>(state), height, timestamp, presync == 1); },
+                .progress = +[](void* user_data, const char* title, size_t title_len, int progress_percent, int resume_possible) { (*static_cast<user_type>(user_data))->ProgressHandler({title, title_len}, progress_percent, resume_possible == 1); },
+                .warning_set = +[](void* user_data, btck_Warning warning, const char* message, size_t message_len) { (*static_cast<user_type>(user_data))->WarningSetHandler(static_cast<Warning>(warning), {message, message_len}); },
+                .warning_unset = +[](void* user_data, btck_Warning warning) { (*static_cast<user_type>(user_data))->WarningUnsetHandler(static_cast<Warning>(warning)); },
+                .flush_error = +[](void* user_data, const char* error, size_t error_len) { (*static_cast<user_type>(user_data))->FlushErrorHandler({error, error_len}); },
+                .fatal_error = +[](void* user_data, const char* error, size_t error_len) { (*static_cast<user_type>(user_data))->FatalErrorHandler({error, error_len}); },
+            });
+    }
+
+    template <typename T>
+    void SetValidationInterface(std::shared_ptr<T> validation_interface)
+    {
+        static_assert(std::is_base_of_v<ValidationInterface, T>);
+        auto heap_vi = std::make_unique<std::shared_ptr<T>>(std::move(validation_interface));
+        using user_type = std::shared_ptr<T>*;
+        btck_context_options_set_validation_interface(
+            get(),
+            btck_ValidationInterfaceCallbacks{
+                .user_data = heap_vi.release(),
+                .user_data_destroy = +[](void* user_data) { delete static_cast<user_type>(user_data); },
+                .block_checked = +[](void* user_data, btck_Block* block, const btck_BlockValidationState* state) { (*static_cast<user_type>(user_data))->BlockChecked(Block{block}, BlockValidationState{state}); },
+                .pow_valid_block = +[](void* user_data, btck_Block* block, const btck_BlockTreeEntry* entry) { (*static_cast<user_type>(user_data))->PowValidBlock(BlockTreeEntry{entry}, Block{block}); },
+                .block_connected = +[](void* user_data, btck_Block* block, const btck_BlockTreeEntry* entry) { (*static_cast<user_type>(user_data))->BlockConnected(Block{block}, BlockTreeEntry{entry}); },
+                .block_disconnected = +[](void* user_data, btck_Block* block, const btck_BlockTreeEntry* entry) { (*static_cast<user_type>(user_data))->BlockDisconnected(Block{block}, BlockTreeEntry{entry}); },
+            });
+    }
+};
+
+class Context : public Handle<btck_Context, btck_context_copy, btck_context_destroy>
+{
+public:
+    Context(ContextOptions& opts)
+        : Handle{btck_context_create(opts.get())} {}
+
+    Context()
+        : Handle{btck_context_create(ContextOptions{}.get())} {}
+
+    bool interrupt()
+    {
+        return btck_context_interrupt(get()) == 0;
+    }
+};
+
+class ChainstateManagerOptions : public UniqueHandle<btck_ChainstateManagerOptions, btck_chainstate_manager_options_destroy>
+{
+public:
+    ChainstateManagerOptions(const Context& context, std::string_view data_dir, std::string_view blocks_dir)
+        : UniqueHandle{btck_chainstate_manager_options_create(
+              context.get(), data_dir.data(), data_dir.length(), blocks_dir.data(), blocks_dir.length())}
+    {
+    }
+
+    void SetWorkerThreads(int worker_threads)
+    {
+        btck_chainstate_manager_options_set_worker_threads_num(get(), worker_threads);
+    }
+
+    bool SetWipeDbs(bool wipe_block_tree, bool wipe_chainstate)
+    {
+        return btck_chainstate_manager_options_set_wipe_dbs(get(), wipe_block_tree, wipe_chainstate) == 0;
+    }
+
+    void UpdateBlockTreeDbInMemory(bool block_tree_db_in_memory)
+    {
+        btck_chainstate_manager_options_update_block_tree_db_in_memory(get(), block_tree_db_in_memory);
+    }
+
+    void UpdateChainstateDbInMemory(bool chainstate_db_in_memory)
+    {
+        btck_chainstate_manager_options_update_chainstate_db_in_memory(get(), chainstate_db_in_memory);
+    }
+};
+
+class ChainView : public View<btck_Chain>
+{
+public:
+    explicit ChainView(const btck_Chain* ptr) : View{ptr} {}
+
+    int32_t Height() const
+    {
+        return btck_chain_get_height(get());
+    }
+
+    int CountEntries() const
+    {
+        return btck_chain_get_height(get()) + 1;
+    }
+
+    BlockTreeEntry GetByHeight(int height) const
+    {
+        auto index{btck_chain_get_by_height(get(), height)};
+        if (!index) throw std::runtime_error("No entry in the chain at the provided height");
+        return index;
+    }
+
+    bool Contains(BlockTreeEntry& entry) const
+    {
+        return btck_chain_contains(get(), entry.get());
+    }
+
+    MAKE_RANGE_METHOD(Entries, ChainView, &ChainView::CountEntries, &ChainView::GetByHeight, *this)
+};
+
+template <typename Derived>
+class CoinApi
+{
+private:
+    auto impl() const
+    {
+        return static_cast<const Derived*>(this)->get();
+    }
+
+    friend Derived;
+    CoinApi() = default;
+
+public:
+    uint32_t GetConfirmationHeight() const { return btck_coin_confirmation_height(impl()); }
+
+    bool IsCoinbase() const { return btck_coin_is_coinbase(impl()) == 1; }
+
+    TransactionOutputView GetOutput() const
+    {
+        return TransactionOutputView{btck_coin_get_output(impl())};
+    }
+};
+
+class CoinView : public View<btck_Coin>, public CoinApi<CoinView>
+{
+public:
+    explicit CoinView(const btck_Coin* ptr) : View{ptr} {}
+};
+
+class Coin : public Handle<btck_Coin, btck_coin_copy, btck_coin_destroy>, public CoinApi<Coin>
+{
+public:
+    Coin(btck_Coin* coin) : Handle{coin} {}
+
+    Coin(const CoinView& view) : Handle{view} {}
+};
+
+template <typename Derived>
+class TransactionSpentOutputsApi
+{
+private:
+    auto impl() const
+    {
+        return static_cast<const Derived*>(this)->get();
+    }
+
+    friend Derived;
+    TransactionSpentOutputsApi() = default;
+
+public:
+    size_t Count() const
+    {
+        return btck_transaction_spent_outputs_count(impl());
+    }
+
+    CoinView GetCoin(size_t index) const
+    {
+        return CoinView{btck_transaction_spent_outputs_get_coin_at(impl(), index)};
+    }
+
+    MAKE_RANGE_METHOD(Coins, Derived, &TransactionSpentOutputsApi<Derived>::Count, &TransactionSpentOutputsApi<Derived>::GetCoin, *static_cast<const Derived*>(this))
+};
+
+class TransactionSpentOutputsView : public View<btck_TransactionSpentOutputs>, public TransactionSpentOutputsApi<TransactionSpentOutputsView>
+{
+public:
+    explicit TransactionSpentOutputsView(const btck_TransactionSpentOutputs* ptr) : View{ptr} {}
+};
+
+class TransactionSpentOutputs : public Handle<btck_TransactionSpentOutputs, btck_transaction_spent_outputs_copy, btck_transaction_spent_outputs_destroy>,
+                                public TransactionSpentOutputsApi<TransactionSpentOutputs>
+{
+public:
+    TransactionSpentOutputs(btck_TransactionSpentOutputs* transaction_spent_outputs) : Handle{transaction_spent_outputs} {}
+
+    TransactionSpentOutputs(const TransactionSpentOutputsView& view) : Handle{view} {}
+};
+
+class BlockSpentOutputs : public Handle<btck_BlockSpentOutputs, btck_block_spent_outputs_copy, btck_block_spent_outputs_destroy>
+{
+public:
+    BlockSpentOutputs(btck_BlockSpentOutputs* block_spent_outputs)
+        : Handle{block_spent_outputs}
+    {
+    }
+
+    size_t Count() const
+    {
+        return btck_block_spent_outputs_count(get());
+    }
+
+    TransactionSpentOutputsView GetTxSpentOutputs(size_t tx_undo_index) const
+    {
+        return TransactionSpentOutputsView{btck_block_spent_outputs_get_transaction_spent_outputs_at(get(), tx_undo_index)};
+    }
+
+    MAKE_RANGE_METHOD(TxsSpentOutputs, BlockSpentOutputs, &BlockSpentOutputs::Count, &BlockSpentOutputs::GetTxSpentOutputs, *this)
+};
+
+class ChainMan : UniqueHandle<btck_ChainstateManager, btck_chainstate_manager_destroy>
+{
+public:
+    ChainMan(const Context& context, const ChainstateManagerOptions& chainman_opts)
+        : UniqueHandle{btck_chainstate_manager_create(chainman_opts.get())}
+    {
+    }
+
+    bool ImportBlocks(const std::span<const std::string> paths)
+    {
+        std::vector<const char*> c_paths;
+        std::vector<size_t> c_paths_lens;
+        c_paths.reserve(paths.size());
+        c_paths_lens.reserve(paths.size());
+        for (const auto& path : paths) {
+            c_paths.push_back(path.c_str());
+            c_paths_lens.push_back(path.length());
+        }
+
+        return btck_chainstate_manager_import_blocks(get(), c_paths.data(), c_paths_lens.data(), c_paths.size()) == 0;
+    }
+
+    bool ProcessBlock(const Block& block, bool* new_block)
+    {
+        int _new_block;
+        int res = btck_chainstate_manager_process_block(get(), block.get(), &_new_block);
+        if (new_block) *new_block = _new_block == 1;
+        return res == 0;
+    }
+
+    ChainView GetChain() const
+    {
+        return ChainView{btck_chainstate_manager_get_active_chain(get())};
+    }
+
+    std::optional<BlockTreeEntry> GetBlockTreeEntry(const BlockHash& block_hash) const
+    {
+        auto entry{btck_chainstate_manager_get_block_tree_entry_by_hash(get(), block_hash.get())};
+        if (!entry) return std::nullopt;
+        return entry;
+    }
+
+    std::optional<Block> ReadBlock(const BlockTreeEntry& entry) const
+    {
+        auto block{btck_block_read(get(), entry.get())};
+        if (!block) return std::nullopt;
+        return block;
+    }
+
+    BlockSpentOutputs ReadBlockSpentOutputs(const BlockTreeEntry& entry) const
+    {
+        return btck_block_spent_outputs_read(get(), entry.get());
+    }
+};
+
+} // namespace btck
+
+#endif // BITCOIN_KERNEL_BITCOINKERNEL_WRAPPER_H

--- a/modules/dynamicbitcoinkernel/module.cpp
+++ b/modules/dynamicbitcoinkernel/module.cpp
@@ -1,0 +1,295 @@
+#include "module.h"
+#include "bitcoinkernel_wrapper/bitcoinkernel_wrapper.h"
+#include <dlfcn.h>
+#include <iomanip>
+#include <memory>
+#include <span>
+#include <sstream>
+#include <string.h>
+#include <unordered_map>
+
+struct btck_Block;
+struct btck_BlockHash;
+struct btck_Transaction;
+struct btck_Txid;
+
+using btck_WriteBytes = int (*)(const void *, size_t, void *);
+
+using btck_block_create_signature = btck_Block *(*)(const void *, size_t);
+using btck_block_copy_signature = btck_Block *(*)(const btck_Block *);
+using btck_block_count_transactions_signature = size_t (*)(const btck_Block *);
+using btck_block_get_transaction_at_signature =
+    const btck_Transaction *(*)(const btck_Block *, size_t);
+using btck_block_get_hash_signature = btck_BlockHash *(*)(const btck_Block *);
+using btck_block_to_bytes_signature = int (*)(const btck_Block *,
+                                              btck_WriteBytes, void *);
+using btck_block_hash_to_bytes_signature = void (*)(const btck_BlockHash *,
+                                                    unsigned char[32]);
+using btck_block_hash_destroy_signature = void (*)(btck_BlockHash *);
+using btck_block_hash_copy_signature =
+    btck_BlockHash *(*)(const btck_BlockHash *);
+using btck_block_hash_equals_signature = int (*)(const btck_BlockHash *,
+                                                 const btck_BlockHash *);
+using btck_block_destroy_signature = void (*)(btck_Block *);
+using btck_transaction_get_txid_signature =
+    const btck_Txid *(*)(const btck_Transaction *);
+using btck_txid_copy_signature = btck_Txid *(*)(const btck_Txid *);
+using btck_txid_equals_signature = int (*)(const btck_Txid *,
+                                           const btck_Txid *);
+using btck_txid_to_bytes_signature = void (*)(const btck_Txid *,
+                                              unsigned char[32]);
+using btck_txid_destroy_signature = void (*)(btck_Txid *);
+using btck_library_tag_signature = const char *(*)(void);
+
+struct KernelApiTable {
+  void *handle{};
+  btck_block_create_signature block_create{};
+  btck_block_copy_signature block_copy{};
+  btck_block_count_transactions_signature block_count_transactions{};
+  btck_block_get_transaction_at_signature block_get_transaction_at{};
+  btck_block_get_hash_signature block_get_hash{};
+  btck_block_to_bytes_signature block_to_bytes{};
+  btck_block_hash_copy_signature block_hash_copy{};
+  btck_block_hash_equals_signature block_hash_equals{};
+  btck_block_hash_to_bytes_signature block_hash_to_bytes{};
+  btck_block_hash_destroy_signature block_hash_destroy{};
+  btck_block_destroy_signature block_destroy{};
+  btck_transaction_get_txid_signature transaction_get_txid{};
+  btck_txid_copy_signature txid_copy{};
+  btck_txid_equals_signature txid_equals{};
+  btck_txid_to_bytes_signature txid_to_bytes{};
+  btck_txid_destroy_signature txid_destroy{};
+  // showcase function, will be removed later
+  btck_library_tag_signature library_tag{};
+};
+
+static void *load_symbol(void *handle, const char *name) {
+  dlerror();
+  void *sym = dlsym(handle, name);
+  const char *err = dlerror();
+  if (err) {
+    throw std::runtime_error(err);
+  }
+  return sym;
+}
+
+static std::string bytes_to_hex(const uint8_t *bytes, int length) {
+  std::stringstream string_stream;
+  string_stream << std::hex;
+  for (int i = length - 1; i >= 0; --i) {
+    string_stream << std::setw(2) << std::setfill('0') << (int)bytes[i];
+  }
+
+  return string_stream.str();
+}
+
+// Is it safe to assume that the tests will always be single threaded?
+// If not, we may need to use thread_local storage here, or a mutex to protect
+// access to this variable.
+static const KernelApiTable *active_api_table = nullptr;
+
+class KernelApiTableGuard {
+public:
+  KernelApiTableGuard(const KernelApiTable &api_table)
+      : previous_api_table(active_api_table) {
+    active_api_table = &api_table;
+  }
+  ~KernelApiTableGuard() { active_api_table = previous_api_table; }
+
+private:
+  const KernelApiTable *previous_api_table;
+};
+
+namespace bitcoinfuzz {
+namespace module {
+
+DynamicKernel::DynamicKernel(std::string const &name,
+                             std::string const &library_path)
+    : BaseModule(name) {
+  // Cache both the dlmopen handle and the resolved function pointers per
+  // library
+  static std::unordered_map<std::string, std::shared_ptr<const KernelApiTable>>
+      api_tables_cache;
+  std::shared_ptr<const KernelApiTable> api_table;
+
+  auto cached_api_table = api_tables_cache.find(library_path);
+  if (cached_api_table != api_tables_cache.end()) {
+    api_table = cached_api_table->second;
+  } else {
+    dlerror();
+    void *handle = dlopen(library_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (!handle) {
+      throw std::runtime_error(dlerror());
+    }
+    auto new_api_table = std::make_shared<KernelApiTable>();
+    new_api_table->handle = handle;
+    try {
+      new_api_table->block_create =
+          (btck_block_create_signature)load_symbol(handle, "btck_block_create");
+      new_api_table->block_copy =
+          (btck_block_copy_signature)load_symbol(handle, "btck_block_copy");
+      new_api_table->block_count_transactions =
+          (btck_block_count_transactions_signature)load_symbol(
+              handle, "btck_block_count_transactions");
+      new_api_table->block_get_transaction_at =
+          (btck_block_get_transaction_at_signature)load_symbol(
+              handle, "btck_block_get_transaction_at");
+      new_api_table->block_get_hash =
+          (btck_block_get_hash_signature)load_symbol(handle,
+                                                     "btck_block_get_hash");
+      new_api_table->block_to_bytes =
+          (btck_block_to_bytes_signature)load_symbol(handle,
+                                                     "btck_block_to_bytes");
+      new_api_table->block_hash_copy =
+          (btck_block_hash_copy_signature)load_symbol(handle,
+                                                      "btck_block_hash_copy");
+      new_api_table->block_hash_equals =
+          (btck_block_hash_equals_signature)load_symbol(
+              handle, "btck_block_hash_equals");
+      new_api_table->block_hash_to_bytes =
+          (btck_block_hash_to_bytes_signature)load_symbol(
+              handle, "btck_block_hash_to_bytes");
+      new_api_table->block_hash_destroy =
+          (btck_block_hash_destroy_signature)load_symbol(
+              handle, "btck_block_hash_destroy");
+      new_api_table->block_destroy = (btck_block_destroy_signature)load_symbol(
+          handle, "btck_block_destroy");
+      new_api_table->transaction_get_txid =
+          (btck_transaction_get_txid_signature)load_symbol(
+              handle, "btck_transaction_get_txid");
+      new_api_table->txid_copy =
+          (btck_txid_copy_signature)load_symbol(handle, "btck_txid_copy");
+      new_api_table->txid_equals =
+          (btck_txid_equals_signature)load_symbol(handle, "btck_txid_equals");
+      new_api_table->txid_to_bytes = (btck_txid_to_bytes_signature)load_symbol(
+          handle, "btck_txid_to_bytes");
+      new_api_table->txid_destroy =
+          (btck_txid_destroy_signature)load_symbol(handle, "btck_txid_destroy");
+      new_api_table->library_tag =
+          (btck_library_tag_signature)load_symbol(handle, "btck_library_tag");
+    } catch (const std::runtime_error &) {
+      dlclose(handle);
+      throw;
+    }
+
+    api_tables_cache.emplace(library_path, new_api_table);
+    api_table = std::move(new_api_table);
+  }
+
+  this->loaded_api_table = api_table;
+}
+DynamicKernel::~DynamicKernel() noexcept {
+  // If we close the handle here, the cached funtcion pointer will become
+  // invalid and we'll have to load the libraries again for each run so we won't
+  // destroy the handle.
+  //
+  // if(this->loaded_api_table && this->loaded_api_table->handle) {
+  //     dlclose(this->loaded_api_table->handle);
+  // }
+}
+
+char *
+DynamicKernel::libbitcoinkernel_block(std::span<const uint8_t> buffer) const {
+  KernelApiTableGuard guard{*loaded_api_table};
+  try {
+    std::span<const std::byte> raw_span{(const std::byte *)buffer.data(),
+                                        buffer.size()};
+    btck::Block block{raw_span};
+
+    const auto block_hash_bytes = block.GetHash().ToBytes();
+    std::string result =
+        bytes_to_hex((const uint8_t *)block_hash_bytes.data(),
+                     static_cast<int>(block_hash_bytes.size()));
+
+    const auto txs = block.Transactions();
+    for (const auto &tx : txs) {
+      const auto txid_bytes = tx.Txid().ToBytes();
+      std::cout << std::endl;
+      result.append("txid=");
+      result.append(bytes_to_hex((const uint8_t *)txid_bytes.data(),
+                                 static_cast<int>(txid_bytes.size())));
+      result.push_back(';');
+    }
+    return strdup(result.c_str());
+
+  } catch (...) {
+    return strdup("0");
+  }
+}
+
+std::optional<std::string>
+DynamicKernel::kernel_block(std::span<const uint8_t> buffer) const {
+
+  auto result_ptr = libbitcoinkernel_block(buffer);
+  if (result_ptr == nullptr)
+    return std::nullopt;
+
+  std::string result(result_ptr);
+  free(result_ptr);
+  return result;
+}
+
+// showcase function
+std::optional<std::string> DynamicKernel::library_tag() const {
+  KernelApiTableGuard guard{*loaded_api_table};
+  return btck_library_tag();
+}
+} // namespace module
+} // namespace bitcoinfuzz
+
+// Function calls match the C API the wrapper expects and forward to the active
+// table.
+extern "C" {
+btck_Block *btck_block_create(const void *raw_block, size_t raw_block_len) {
+  return active_api_table->block_create(raw_block, raw_block_len);
+}
+btck_Block *btck_block_copy(const btck_Block *block) {
+  return active_api_table->block_copy(block);
+}
+size_t btck_block_count_transactions(const btck_Block *block) {
+  return active_api_table->block_count_transactions(block);
+}
+const btck_Transaction *btck_block_get_transaction_at(const btck_Block *block,
+                                                      size_t idx) {
+  return active_api_table->block_get_transaction_at(block, idx);
+}
+btck_BlockHash *btck_block_get_hash(const btck_Block *block) {
+  return active_api_table->block_get_hash(block);
+}
+int btck_block_to_bytes(const btck_Block *block, btck_WriteBytes writer,
+                        void *user_data) {
+  return active_api_table->block_to_bytes(block, writer, user_data);
+}
+void btck_block_destroy(btck_Block *block) {
+  active_api_table->block_destroy(block);
+}
+btck_BlockHash *btck_block_hash_copy(const btck_BlockHash *hash) {
+  return active_api_table->block_hash_copy(hash);
+}
+int btck_block_hash_equals(const btck_BlockHash *h1, const btck_BlockHash *h2) {
+  return active_api_table->block_hash_equals(h1, h2);
+}
+void btck_block_hash_to_bytes(const btck_BlockHash *hash,
+                              unsigned char output[32]) {
+  active_api_table->block_hash_to_bytes(hash, output);
+}
+void btck_block_hash_destroy(btck_BlockHash *hash) {
+  active_api_table->block_hash_destroy(hash);
+}
+const btck_Txid *btck_transaction_get_txid(const btck_Transaction *tx) {
+  return active_api_table->transaction_get_txid(tx);
+}
+btck_Txid *btck_txid_copy(const btck_Txid *txid) {
+  return active_api_table->txid_copy(txid);
+}
+int btck_txid_equals(const btck_Txid *txid1, const btck_Txid *txid2) {
+  return active_api_table->txid_equals(txid1, txid2);
+}
+void btck_txid_to_bytes(const btck_Txid *txid, unsigned char output[32]) {
+  active_api_table->txid_to_bytes(txid, output);
+}
+void btck_txid_destroy(btck_Txid *txid) {
+  active_api_table->txid_destroy(txid);
+}
+const char *btck_library_tag(void) { return active_api_table->library_tag(); }
+}

--- a/modules/dynamicbitcoinkernel/module.h
+++ b/modules/dynamicbitcoinkernel/module.h
@@ -1,0 +1,26 @@
+#include <bitcoinfuzz/basemodule.h>
+#include <memory>
+#include <span>
+
+struct KernelApiTable;
+
+namespace bitcoinfuzz {
+namespace module {
+class DynamicKernel : public BaseModule {
+public:
+  DynamicKernel(const std::string &name, const std::string &library_path);
+
+  std::optional<std::string>
+  kernel_block(std::span<const uint8_t> buffer) const override;
+  // showcase function, will be removed later
+  std::optional<std::string> library_tag() const override;
+
+  ~DynamicKernel() noexcept override;
+
+private:
+  std::shared_ptr<const KernelApiTable> loaded_api_table;
+
+  char *libbitcoinkernel_block(std::span<const uint8_t> data) const;
+};
+} // namespace module
+} // namespace bitcoinfuzz


### PR DESCRIPTION
# Draft PR — dynamic bitcoinkernel loading

## Summary
- Functional prototype to load multiple `libbitcoinkernel` versions dynamically in `bitcoinfuzz`.
- Goal: confirm the flow before automating download/build and load of the libs (currently manual).
- Library and wrapper headers are checked in only for the prototype; once automated, I plan to link them at build/run time to keep them out of history.

## Done so far
- Added the test function `library_tag` to prove two different libraries are loaded dynamically.
- `bitcoinfuzz` uses `FUZZ=library_tag` to exercise the load path for each `libbitcoinkernel*.so`.
- Implemented the `kernel_block` target (C interface) to compare behavior with existing bindings.

## How to validate locally
1) In `bitcoinkernel.cpp`, add before compiling:
   ```cpp
   const char* btck_library_tag(void) {
       return "KERNEL A";
   }
   ```
2) Add the declaration to `bitcoinkernel.h` inside the existing `extern "C"` block:
   ```cpp
   BITCOINKERNEL_API const char* btck_library_tag(void);
   ```
   You can copy the updated header from this PR if easier.
3) Build Bitcoin Core with shared libs: `-DBUILD_SHARED_LIBS=ON`.
4) Produce two variants and rename to `libbitcoinkernelA.so` and `libbitcoinkernelB.so`.
5) Place both in `modules/dynamicbitcoinkernel/libs/`.
6) Run `FUZZ=library_tag ./bitcoinfuzz -runs=1` (or any `-runs=n`); the first test should fail and you’ll see distinct libraries results.

## Additional validation
- You can also build `bitcoinfuzz` with another kernel binding such as `pybitcoinkernel` module and run the `kernel_block` target (already implemented for the C interface) to compare behavior.

## Proposed next steps
- Automate build/download of the `libbitcoinkernel` variants and the library loading.
- Remove headers from the repo and fetch/link them only at build/run time.
- Add automated tests for the new module.

## Feedback:
Every feedback is welcome! And if possible, I would like to clarify these specific topics:
- Confirm if this flow makes sense before continuing current implementation.
- Validate thoughts on keeping headers only at build/run time (avoiding commits).
