### PR TITLE
Add Schnorr signing fuzzing target for K256 module

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -200,7 +200,7 @@ jobs:
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "sign_schnorr"
             target: "sign_schnorr"
-            cxxflags: "-DBTCD -DSECP256K1"
+            cxxflags: "-DBTCD -DSECP256K1 -DRUST_K256"
           - corpus: "bip32_deserialize_extended_key"
             target: "bip32_deserialize_extended_key"
             cxxflags: "-DNBITCOIN -DRUST_BITCOIN -DBITCOIN_CORE -DCUSTOM_MUTATOR_EXTENDED_KEY"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -284,7 +284,7 @@ services:
       tags:
         - bitcoinfuzz:sign_schnorr
       args:
-        CXXFLAGS: "-DSECP256K1 -DBTCD"
+        CXXFLAGS: "-DSECP256K1 -DBTCD -DRUST_K256"
         FUZZ: sign_schnorr
     env_file: .env
     volumes:

--- a/modules/rustk256/k256_lib/Cargo.toml
+++ b/modules/rustk256/k256_lib/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 
 [dependencies]
 hex = "0.4.3"
-k256 = { git = "https://github.com/RustCrypto/elliptic-curves.git", rev = "a4af4fa03caaa135bac7ca04fd8b0d00e1c87592", package = "k256", features=["sha2"]}
+k256 = { git = "https://github.com/RustCrypto/elliptic-curves.git", rev = "a4af4fa03caaa135bac7ca04fd8b0d00e1c87592", package = "k256", features=["sha2", "schnorr"]}

--- a/modules/rustk256/k256_lib/k256_lib.h
+++ b/modules/rustk256/k256_lib/k256_lib.h
@@ -6,4 +6,6 @@ extern "C" char *k256_sign_der(const uint8_t *buffer, const uint8_t *hash);
 extern "C" bool k256_sign_verify(const uint8_t *buffer, const uint8_t *hash,
                                  const uint8_t *sign, size_t len);
 extern "C" char *k256_ecdh(const uint8_t *buffer, const uint8_t *pubkey);
+extern "C" char *k256_sign_schnorr(const uint8_t *buffer, const uint8_t *hash,
+                                   const uint8_t *aux);
 extern "C" void k256_free_string(void *ptr);

--- a/modules/rustk256/k256_lib/src/lib.rs
+++ b/modules/rustk256/k256_lib/src/lib.rs
@@ -1,6 +1,7 @@
 use k256::ecdsa::signature::hazmat::{PrehashSigner, PrehashVerifier};
 use k256::ecdsa::{Signature, SigningKey, VerifyingKey};
 use k256::elliptic_curve::ops::Reduce;
+use k256::schnorr::SigningKey as SchnorrSigningKey;
 use k256::sha2::{Digest, Sha256};
 use k256::{EncodedPoint, ProjectivePoint, Scalar, U256};
 use std::ffi::CString;
@@ -129,6 +130,37 @@ pub unsafe extern "C" fn k256_ecdh(buffer: *const u8, pubkey: *const u8) -> *mut
     let shared_secret = Sha256::digest(EncodedPoint::from(&shared_point).as_bytes());
 
     return str_to_c_string(&hex::encode(shared_secret));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn k256_sign_schnorr(
+    buffer: *const u8,
+    hash: *const u8,
+    aux: *const u8,
+) -> *mut c_char {
+    let privkey_slice = slice::from_raw_parts(buffer, 32);
+    let hash_slice = slice::from_raw_parts(hash, 32);
+    let aux_slice = slice::from_raw_parts(aux, 32);
+
+    let aux_bytes: [u8; 32] = aux_slice
+        .try_into()
+        .expect("aux_slice is guaranteed to be 32 bytes");
+
+    let priv_key = match SchnorrSigningKey::from_slice(privkey_slice) {
+        Ok(k) => k,
+        Err(_) => {
+            return ptr::null_mut();
+        }
+    };
+
+    let signature = match priv_key.sign_raw(hash_slice, &aux_bytes) {
+        Ok(s) => s,
+        Err(_) => {
+            return str_to_c_string("");
+        }
+    };
+
+    return str_to_c_string(&hex::encode(signature.to_bytes()));
 }
 
 unsafe fn str_to_c_string(input: &str) -> *mut c_char {

--- a/modules/rustk256/module.cpp
+++ b/modules/rustk256/module.cpp
@@ -53,5 +53,17 @@ std::optional<std::string> K256::ecdh(std::span<const uint8_t> buffer,
   return s;
 }
 
+std::optional<std::string>
+K256::sign_schnorr(std::span<const uint8_t> buffer,
+                   std::span<const uint8_t> hash,
+                   std::span<const uint8_t> aux) const {
+  char *p = k256_sign_schnorr(buffer.data(), hash.data(), aux.data());
+  if (!p)
+    return std::nullopt;
+  std::string s(p);
+  k256_free_string(p);
+  return s;
+}
+
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/rustk256/module.h
+++ b/modules/rustk256/module.h
@@ -21,6 +21,9 @@ public:
   std::optional<std::string>
   ecdh(std::span<const uint8_t> buffer,
        std::span<const uint8_t> pubkey) const override;
+  std::optional<std::string>
+  sign_schnorr(std::span<const uint8_t> buffer, std::span<const uint8_t> hash,
+               std::span<const uint8_t> aux) const override;
   ~K256() noexcept override = default;
 };
 } // namespace module


### PR DESCRIPTION
This PR adds the sign_schnorr fuzzing target for K256 module.

Fixes #405 