### PR TITLE
fix(nbitcoin): deserialize all bytes on extended_key target

### DIFF
--- a/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
+++ b/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
@@ -174,14 +174,13 @@ public static class Bridge
     }
 
     [UnmanagedCallersOnly(EntryPoint = "nbitcoin_bip32_deserialize_extended_key")]
-    public static IntPtr BIP32DeserializeExtendedKeyTarget(IntPtr inputPtr)
+    public static IntPtr BIP32DeserializeExtendedKeyTarget(IntPtr inputPtr, int len)
     {
-        if (inputPtr == IntPtr.Zero) return Marshal.StringToCoTaskMemUTF8("INVALID");
+        if (inputPtr == IntPtr.Zero || len <= 0) return Marshal.StringToCoTaskMemUTF8("INVALID");
 
-        string input = Marshal.PtrToStringUTF8(inputPtr) ?? "";
-        string result;
+        string input = Marshal.PtrToStringUTF8(inputPtr, len) ?? "";
 
-        if (TryParseXprv(input, Network.Main, out result) ||
+        if (TryParseXprv(input, Network.Main, out string result) ||
             TryParseXprv(input, Network.TestNet, out result) ||
             TryParseXpub(input, Network.Main, out result) ||
             TryParseXpub(input, Network.TestNet, out result))


### PR DESCRIPTION
The same issue as in:

https://github.com/bitcoinfuzz/bitcoinfuzz/pull/396#pullrequestreview-3729662005


> It's working, but I found one edge case in the way it sends input from C++ code to Java. It removes everything from the NUL byte onwards, resulting in BitcoinJ receiving only part of the input, which will cause the fuzzer to crash later when BitcoinJ parses it and accept as valid.
> 
> It's better to send a byte array to the JVM, which interprets the bytes as a string. This makes the decodeBase58 in BitcoinJ receive the same string/bytes as other implementations.
> 
> example of input that would make the fuzzer crash:
> 
> xxd -p crash-a4c9dea519d7fafdbcd5f6b0b067d8084c354cc4
> 
> 7470756245677762737772566637677234724457396e39624e5554377544
> 37536f6a366a385879745a3771537742416932613934444a796868655672
> 425558386550325a6d644c775875517350694c41656334344b76534d7232
> 516f676955477a6b355772717858466a687a356f51000000000000000000
> 000000000000000000000000000000000000000000000000000000000000
> 000000000000000000000000000000000000000000000000000000000000
> 00000000000000000000000000000000