### PR TITLE
BIP-32 path parse

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -247,6 +247,11 @@ jobs:
             target: "bip32_derive_from_path"
             cxxflags: "-DRUST_BITCOIN -DBITCOIN_CORE -DNBITCOIN"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
+          - corpus: "bip32_path_parse"
+            target: "bip32_path_parse"
+            cxxflags: "-DRUST_BITCOIN -DBITCOIN_CORE -DNBITCOIN -DBITCOINJ -DLIBWALLY_CORE -DEMBIT -DBITCOINS"
+            asan_options: "detect_leaks=0:detect_container_overflow=0"
+            setup_java: "true"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -433,3 +433,19 @@ services:
     env_file: .env
     volumes:
       - ./docker:/app/data
+
+  bip32_path_parse:
+    build:
+      context: .
+      tags:
+        - bitcoinfuzz:bip32_path_parse
+      args:
+        CXXFLAGS: "-DRUST_BITCOIN -DBITCOIN_CORE -DNBITCOIN -DBITCOINJ -DLIBWALLY_CORE -DEMBIT -DBITCOINS"
+        FUZZ: bip32_path_parse
+    environment:
+      MODULES: ${MODULES:-}
+      LIBFUZZ_DETECT_LEAKS: 0
+      ASAN_OPTIONS: detect_leaks=0
+    env_file: .env
+    volumes:
+      - ./docker:/app/data

--- a/driver.cpp
+++ b/driver.cpp
@@ -709,6 +709,18 @@ void Driver::Bip32DeriveFromPathTarget(std::span<const uint8_t> buffer) const {
   }
 }
 
+void Driver::Bip32PathParseTarget(std::span<const uint8_t> buffer) const {
+  std::optional<std::string> last_response{std::nullopt};
+  std::string last_module_name;
+  for (auto &module : modules) {
+    std::optional<std::string> res{module.second->bip32_path_parse(buffer)};
+    if (!res.has_value())
+      continue;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "BIP32 path parse failed");
+  }
+}
+
 void Driver::Run(const uint8_t *data, const size_t size,
                  const std::string &target) const {
   std::span<const uint8_t> buffer{data, size};
@@ -772,6 +784,8 @@ void Driver::Run(const uint8_t *data, const size_t size,
     this->StumpModifyAddTarget(buffer);
   } else if (target == "bip32_derive_from_path") {
     this->Bip32DeriveFromPathTarget(buffer);
+  } else if (target == "bip32_path_parse") {
+    this->Bip32PathParseTarget(buffer);
   } else {
     std::cout << "Unknown target: " << target << std::endl;
     assert(false);

--- a/driver.h
+++ b/driver.h
@@ -64,5 +64,6 @@ public:
   void DecodeOnionTarget(std::span<const uint8_t> buffer) const;
   void StumpModifyAddTarget(std::span<const uint8_t> buffer) const;
   void Bip32DeriveFromPathTarget(std::span<const uint8_t> buffer) const;
+  void Bip32PathParseTarget(std::span<const uint8_t> buffer) const;
 };
 } // namespace bitcoinfuzz

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -167,4 +167,9 @@ BaseModule::bip32_derive_from_path(std::span<const uint8_t> /*buffer*/) const {
   return std::nullopt;
 }
 
+std::optional<std::string>
+BaseModule::bip32_path_parse(std::span<const uint8_t> /*buffer*/) const {
+  return std::nullopt;
+}
+
 } // namespace bitcoinfuzz

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -83,6 +83,9 @@ public:
   virtual std::optional<std::string>
   bip32_derive_from_path(std::span<const uint8_t> buffer) const;
 
+  virtual std::optional<std::string>
+  bip32_path_parse(std::span<const uint8_t> buffer) const;
+
   virtual ~BaseModule() noexcept;
 };
 } // namespace bitcoinfuzz

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -712,5 +712,18 @@ Bitcoin::bip32_derive_from_path(std::span<const uint8_t> buffer) const {
   return EncodeExtKey(key);
 }
 
+std::optional<std::string>
+Bitcoin::bip32_path_parse(std::span<const uint8_t> buffer) const {
+  const std::string path_str(reinterpret_cast<const char *>(buffer.data()),
+                             buffer.size());
+  std::vector<uint32_t> keypath;
+  if (!ParseHDKeypath(path_str, keypath)) {
+    // Failed to parse
+    return "INVALID";
+  }
+
+  return "CORRECT";
+}
+
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/bitcoin/module.h
+++ b/modules/bitcoin/module.h
@@ -37,6 +37,8 @@ public:
       std::span<const uint8_t> buffer) const override;
   std::optional<std::string>
   bip32_derive_from_path(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  bip32_path_parse(std::span<const uint8_t> buffer) const override;
   ~Bitcoin() noexcept override = default;
 };
 

--- a/modules/bitcoinj/app/src/main/kotlin/wrapper/Wrapper.kt
+++ b/modules/bitcoinj/app/src/main/kotlin/wrapper/Wrapper.kt
@@ -3,6 +3,7 @@ package wrapper
 import org.bitcoinj.base.BitcoinNetwork
 import org.bitcoinj.crypto.DeterministicKey
 import org.bitcoinj.crypto.HDKeyDerivation
+import org.bitcoinj.crypto.HDPath
 import java.math.BigInteger
 
 object Wrapper {
@@ -125,5 +126,22 @@ object Wrapper {
         } catch (_: Exception) {
             null
         }
+    }
+
+    @JvmStatic
+    fun pathParse(bytes: ByteArray): String {
+        val path =
+            try {
+                String(bytes, Charsets.UTF_8)
+            } catch (e: Exception) {
+                return "INVALID"
+            }
+        val hdPath =
+            try {
+                HDPath.parsePath(path)
+            } catch (e: Exception) {
+                return "INVALID"
+            }
+        return "CORRECT"
     }
 }

--- a/modules/bitcoinj/module.cpp
+++ b/modules/bitcoinj/module.cpp
@@ -16,6 +16,7 @@ static bool jvm_initialized = false;
 static jclass bitcoinJWrapperClass = nullptr;
 static jmethodID createMasterKeyMethod = nullptr;
 static jmethodID deserializeExtendedKeyMethod = nullptr;
+static jmethodID pathParseMethod = nullptr;
 
 static void clear_pending_exception(JNIEnv *env) {
   if (env->ExceptionCheck()) {
@@ -68,9 +69,18 @@ static bool init_jvm() {
     return false;
   }
 
+  jmethodID pathParseMethodRef = env->GetStaticMethodID(
+      globalWrapperClass, "pathParse", "([B)Ljava/lang/String;");
+  if (!pathParseMethodRef) {
+    clear_pending_exception(env);
+    env->DeleteGlobalRef(globalWrapperClass);
+    return false;
+  }
+
   bitcoinJWrapperClass = globalWrapperClass;
   createMasterKeyMethod = createMasterKeyMethodRef;
   deserializeExtendedKeyMethod = deserializeExtendedKeyMethodRef;
+  pathParseMethod = pathParseMethodRef;
   jvm_initialized = true;
   return true;
 }
@@ -136,6 +146,11 @@ BitcoinJ::bip32_master_keygen(std::span<const uint8_t> buffer) const {
 std::optional<std::string> BitcoinJ::bip32_deserialize_extended_key(
     std::span<const uint8_t> buffer) const {
   return call_wrapper_method(deserializeExtendedKeyMethod, buffer);
+}
+
+std::optional<std::string>
+BitcoinJ::bip32_path_parse(std::span<const uint8_t> buffer) const {
+  return call_wrapper_method(pathParseMethod, buffer);
 }
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/bitcoinj/module.h
+++ b/modules/bitcoinj/module.h
@@ -14,6 +14,8 @@ public:
   bip32_master_keygen(std::span<const uint8_t> buffer) const override;
   std::optional<std::string> bip32_deserialize_extended_key(
       std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  bip32_path_parse(std::span<const uint8_t> buffer) const override;
   ~BitcoinJ() noexcept override = default;
 };
 } // namespace module

--- a/modules/bitcoins/BitcoinSWrapper.java
+++ b/modules/bitcoins/BitcoinSWrapper.java
@@ -128,4 +128,14 @@ public class BitcoinSWrapper {
       return "";
     }
   }
+
+  public static String parseBIP32Path(byte[] bytes) {
+    try {
+      String pathStr = new String(bytes, "UTF-8");
+      BIP32Path path = BIP32Path$.MODULE$.fromString(pathStr);
+      return "CORRECT";
+    } catch (Exception e) {
+      return "INVALID";
+    }
+  }
 }

--- a/modules/bitcoins/module.cpp
+++ b/modules/bitcoins/module.cpp
@@ -10,6 +10,7 @@ static jclass wrapperClass = nullptr;
 static jmethodID createMasterKeyMethod = nullptr;
 static jmethodID deserializeExtendedKeyMethod = nullptr;
 static jmethodID parsePSBTMethod = nullptr;
+static jmethodID parseBIP32PathMethod = nullptr;
 static bool init_attempted = false;
 static bool init_ok = false;
 
@@ -75,6 +76,18 @@ static bool init_jvm() {
                                            "([B)Ljava/lang/String;");
   if (!parsePSBTMethod) {
     std::cerr << "[BitcoinS] GetStaticMethodID(parsePSBT) failed" << std::endl;
+    if (env->ExceptionCheck()) {
+      env->ExceptionDescribe();
+      env->ExceptionClear();
+    }
+    return false;
+  }
+
+  parseBIP32PathMethod = env->GetStaticMethodID(wrapperClass, "parseBIP32Path",
+                                                "([B)Ljava/lang/String;");
+  if (!parseBIP32PathMethod) {
+    std::cerr << "[BitcoinS] GetStaticMethodID(parseBIP32Path) failed"
+              << std::endl;
     if (env->ExceptionCheck()) {
       env->ExceptionDescribe();
       env->ExceptionClear();
@@ -156,6 +169,11 @@ std::optional<std::string> BitcoinS::bip32_deserialize_extended_key(
 std::optional<std::string>
 BitcoinS::psbt_parse(std::span<const uint8_t> buffer) const {
   return call_static_bytes_method(&parsePSBTMethod, buffer);
+}
+
+std::optional<std::string>
+BitcoinS::bip32_path_parse(std::span<const uint8_t> buffer) const {
+  return call_static_bytes_method(&parseBIP32PathMethod, buffer);
 }
 
 } // namespace module

--- a/modules/bitcoins/module.h
+++ b/modules/bitcoins/module.h
@@ -23,6 +23,9 @@ public:
   std::optional<std::string>
   psbt_parse(std::span<const uint8_t> buffer) const override;
 
+  std::optional<std::string>
+  bip32_path_parse(std::span<const uint8_t> buffer) const override;
+
   ~BitcoinS() noexcept override = default;
 };
 

--- a/modules/embit/embit_lib.py
+++ b/modules/embit/embit_lib.py
@@ -1,7 +1,7 @@
 from embit.descriptor.miniscript import Miniscript
 from embit.descriptor import Descriptor
 from embit.psbt import PSBT
-from embit.bip32 import HDKey
+from embit.bip32 import HDKey, parse_path
 from embit.networks import NETWORKS
 
 
@@ -110,3 +110,15 @@ def bip32_deserialize_extended_key(data: str) -> str:
         f"key={key_hex}"
     )
     return result
+
+
+def bip32_path_parse(input):
+    try:
+        if isinstance(input, bytes):
+            input = input.decode("ascii", errors="strict")
+        result = parse_path(input)
+        if len(result) == 0 and input.strip() != "m" and input.strip() != "m/":
+            return "INVALID"
+        return "CORRECT"
+    except Exception:
+        return "INVALID"

--- a/modules/embit/module.cpp
+++ b/modules/embit/module.cpp
@@ -153,6 +153,18 @@ char *embit_bip32_deserialize_extended_key(const uint8_t *data, size_t len) {
       convert_to_string);
 }
 
+// Send raw bytes to Python instead of PyUnicode_FromString, which
+// rejects non-UTF-8 input with noisy stderr errors
+static PyObject *create_bytes_from_string(const char *input, size_t len) {
+  return PyBytes_FromStringAndSize(input, len);
+}
+
+char *embit_bip32_path_parse(const std::string &input) {
+  return call_python_function<const char *, char *>(
+      input.c_str(), input.size(), "bip32_path_parse", create_bytes_from_string,
+      convert_to_string);
+}
+
 namespace bitcoinfuzz {
 namespace module {
 Embit::Embit(void) : BaseModule("Embit") {}
@@ -201,6 +213,19 @@ Embit::bip32_deserialize_extended_key(std::span<const uint8_t> buffer) const {
       embit_bip32_deserialize_extended_key(buffer.data(), buffer.size());
   if (result_ptr == nullptr)
     return std::nullopt;
+  std::string result(result_ptr);
+  free(result_ptr);
+  return result;
+}
+
+std::optional<std::string>
+Embit::bip32_path_parse(std::span<const uint8_t> buffer) const {
+  const std::string path_str(reinterpret_cast<const char *>(buffer.data()),
+                             buffer.size());
+  auto result_ptr = embit_bip32_path_parse(path_str);
+  if (result_ptr == nullptr)
+    return std::nullopt;
+
   std::string result(result_ptr);
   free(result_ptr);
   return result;

--- a/modules/embit/module.h
+++ b/modules/embit/module.h
@@ -18,6 +18,8 @@ public:
   bip32_master_keygen(std::span<const uint8_t> buffer) const override;
   std::optional<std::string> bip32_deserialize_extended_key(
       std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  bip32_path_parse(std::span<const uint8_t> buffer) const override;
   ~Embit() noexcept override = default;
 };
 

--- a/modules/libwallycore/module.cpp
+++ b/modules/libwallycore/module.cpp
@@ -161,5 +161,25 @@ std::optional<std::string> LibwallyCore::bip32_deserialize_extended_key(
   return result.str();
 }
 
+std::optional<std::string>
+LibwallyCore::bip32_path_parse(std::span<const uint8_t> buffer) const {
+  const std::string path_str(reinterpret_cast<const char *>(buffer.data()),
+                             buffer.size());
+
+  uint32_t child_path[512]; //
+  size_t written = 0;
+
+  int res = bip32_path_from_str_n(
+      path_str.c_str(), path_str.size(), 0, /* child_num (no wildcard) */
+      0,                                    /* multi_index (no multi-path) */
+      BIP32_FLAG_KEY_PRIVATE | BIP32_FLAG_ALLOW_UPPER, child_path, 512,
+      &written);
+
+  if (res != WALLY_OK) {
+    return "INVALID";
+  }
+  return "CORRECT";
+}
+
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/libwallycore/module.h
+++ b/modules/libwallycore/module.h
@@ -14,6 +14,8 @@ public:
   bip32_master_keygen(std::span<const uint8_t> buffer) const override;
   std::optional<std::string> bip32_deserialize_extended_key(
       std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  bip32_path_parse(std::span<const uint8_t> buffer) const override;
   ~LibwallyCore() noexcept override = default;
 };
 } // namespace module

--- a/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
+++ b/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
@@ -424,6 +424,25 @@ public static class Bridge
         return true;
     }
 
+    [UnmanagedCallersOnly(EntryPoint = "nbitcoin_bip32_path_parse")]
+    public static IntPtr BIP32PathParse(IntPtr pathPtr, int len)
+    {
+        string input;
+        input = Marshal.PtrToStringUTF8(pathPtr, len);
+        try
+        {
+            if (KeyPath.TryParse(input, out var keyPath) && keyPath != null)
+            {
+                return Marshal.StringToCoTaskMemUTF8("CORRECT");
+            }
+        }
+        catch
+        {
+
+        }
+        return Marshal.StringToCoTaskMemUTF8("INVALID");
+    }
+
     [UnmanagedCallersOnly(EntryPoint = "nbitcoin_free_c_string")]
     public static void FreeString(IntPtr ptr)
     {

--- a/modules/nbitcoin/NBitcoin/nbitcoin_lib.h
+++ b/modules/nbitcoin/NBitcoin/nbitcoin_lib.h
@@ -26,4 +26,6 @@ extern "C" char *nbitcoin_sign_schnorr(const uint8_t *privkey,
 extern "C" char *nbitcoin_bip32_derive_from_path(const uint8_t *data,
                                                  size_t len);
 
+extern "C" char *nbitcoin_bip32_path_parse(const uint8_t *data, size_t len);
+
 extern "C" void nbitcoin_free_c_string(void *ptr);

--- a/modules/nbitcoin/module.cpp
+++ b/modules/nbitcoin/module.cpp
@@ -72,5 +72,14 @@ NBitcoin::bip32_derive_from_path(std::span<const uint8_t> buffer) const {
   nbitcoin_free_c_string(p);
   return s;
 }
+std::optional<std::string>
+NBitcoin::bip32_path_parse(std::span<const uint8_t> buffer) const {
+  char *p = nbitcoin_bip32_path_parse(buffer.data(), buffer.size());
+  if (!p)
+    return std::nullopt;
+  std::string s(p);
+  nbitcoin_free_c_string(p);
+  return s;
+}
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/nbitcoin/module.h
+++ b/modules/nbitcoin/module.h
@@ -29,6 +29,8 @@ public:
                std::span<const uint8_t> aux) const override;
   std::optional<std::string>
   bip32_derive_from_path(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  bip32_path_parse(std::span<const uint8_t> buffer) const override;
   ~NBitcoin() noexcept override = default;
 };
 } // namespace module

--- a/modules/rustbitcoin/module.cpp
+++ b/modules/rustbitcoin/module.cpp
@@ -110,5 +110,15 @@ Rustbitcoin::bip32_derive_from_path(std::span<const uint8_t> buffer) const {
   return result;
 }
 
+std::optional<std::string>
+Rustbitcoin::bip32_path_parse(std::span<const uint8_t> buffer) const {
+  auto result_ptr = rust_bitcoin_bip32_path_parse(buffer.data(), buffer.size());
+  if (result_ptr == nullptr)
+    return std::nullopt;
+  std::string result(result_ptr);
+  free_c_string(result_ptr);
+  return result;
+}
+
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/rustbitcoin/module.h
+++ b/modules/rustbitcoin/module.h
@@ -30,6 +30,8 @@ public:
       std::span<const uint8_t> buffer) const override;
   std::optional<std::string>
   bip32_derive_from_path(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  bip32_path_parse(std::span<const uint8_t> buffer) const override;
   ~Rustbitcoin() noexcept override = default;
 };
 

--- a/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
+++ b/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
@@ -16,3 +16,4 @@ extern "C" char *
 rust_bitcoin_bip32_deserialize_extended_key(const uint8_t *data, size_t len);
 extern "C" char *rust_bitcoin_bip32_derive_from_path(const uint8_t *data,
                                                      size_t len);
+extern "C" char *rust_bitcoin_bip32_path_parse(const uint8_t *data, size_t len);

--- a/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
+++ b/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
@@ -518,3 +518,17 @@ pub unsafe extern "C" fn rust_bitcoin_bip32_derive_from_path(
         Err(_) => str_to_c_string("INVALID"),
     }
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_bitcoin_bip32_path_parse(data: *const u8, len: usize) -> *mut c_char {
+    // Safety: Accepts any bytes, does not assume null termination.
+    let bytes = std::slice::from_raw_parts(data, len);
+    let s = match std::str::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(_) => return str_to_c_string("INVALID"), // Not UTF8
+    };
+    match bitcoin::bip32::DerivationPath::from_str(s) {
+        Ok(_) => str_to_c_string("CORRECT"),
+        Err(_) => str_to_c_string("INVALID"),
+    }
+}


### PR DESCRIPTION
**DRAFT PR**
This is a WIP on the custom mutator for path parsing. 
I am trying to find an equilibrium between tying the path generation to the input bytes (maximalize libFuzzer coverage and utilization) and targeting edgecases (results in repeated paths). 
Added the target for RUST_BITCOIN and BITCOIN_CORE so far.