### PR TITLE
Add `list-targets` recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,15 +4,18 @@ required_bins := require("docker") + require("docker-compose") + require("jq")
 
 [default]
 _default:
-  @just --list
+  @just --list --unsorted
 
-
-# Run all fuzzing targets
-run-all: (run '')
+# Lists all available fuzz targets
+list-targets:
+    @docker compose config --format=json | jq -r '.services[].build.args.FUZZ'
 
 # Starts a fuzzing target using docker and docker compose
 run TARGET:
     docker compose up {{TARGET}} --force-recreate --build
+
+# Run all fuzzing targets
+run-all: (run '')
 
 # Cleans docker build cache
 docker-clean:


### PR DESCRIPTION
Adds a recipe to list all fuzz targets, sourced from docker compose's configuration.

Also adds the `--unsorted` flag to the `_default` recipe so recipes are displayed in the order they are defined in the `justfile`, instead of alphabetically.

```console
bitcoinfuzz % just list-targets
address_parse
addrv2
bip32_deserialize_extended_key
bip32_master_keygen
decode_ellswift
decode_onion
descriptor_parse
deserialize_block
deserialize_invoice
deserialize_offer
ecdh
kernel_block
kernel_transaction
miniscript_parse
parse_p2p_lightning_message
parse_p2p_message
private_to_public_key
psbt_parse
schnorr_verify
script
script_eval
sign_compact
sign_der
sign_schnorr
sign_verify
transaction_eval
verify_script
```