### PR TITLE
fix: delegate commit-by-commit builds to a script in the checked-out …

### DIFF
--- a/.github/workflows/commit-by-commit-build.yml
+++ b/.github/workflows/commit-by-commit-build.yml
@@ -99,14 +99,11 @@ jobs:
         with:
           dotnet-version: "9.0.x"
 
-      - name: Setup Python and install embit
+      - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - run: |
-          python -m pip install --upgrade pip
-          pip install -r modules/embit/requirements.txt
-          pip install mako
+      - run: python -m pip install --upgrade pip
 
       - name: Install build dependencies
         run: |
@@ -120,119 +117,13 @@ jobs:
           echo "CC=/usr/bin/clang" >> $GITHUB_ENV
           echo "CXX=/usr/bin/clang++" >> $GITHUB_ENV
 
-      - name: Build - Bitcoin Core
-        timeout-minutes: 40
+      - name: Build all modules
+        timeout-minutes: 60
         run: |
           echo "Building commit ${{ steps.commit-info.outputs.short-sha }}: ${{ steps.commit-info.outputs.subject }}"
-          cd modules/bitcoin && make
-
-      - name: Build - custommutator
-        timeout-minutes: 40
-        run: |
-          cd custommutator && make
-
-      - name: Build - rust bitcoin
-        timeout-minutes: 5
-        run: |
-          rustup default nightly
-          cd modules/rustbitcoin && make
-
-      - name: Build - rust-bitcoinkernel
-        timeout-minutes: 5
-        run: |
-          if [ -d "modules/rustbitcoinkernel" ]; then
-            rustup default nightly
-            cd modules/rustbitcoinkernel && make
+          if [ -f "scripts/build-all.sh" ]; then
+            bash scripts/build-all.sh
           else
-            echo "Skipping rust-bitcoinkernel (not present in this commit)"
+            echo "No build script found at this commit — skipping module builds"
           fi
-
-      - name: Build - pybitcoinkernel
-        timeout-minutes: 5
-        run: |
-          if [ -d "modules/pybitcoinkernel" ]; then
-            cd modules/pybitcoinkernel && make
-          else
-            echo "Skipping pybitcoinkernel (not present in this commit)"
-          fi
-
-      - name: Build - rust miniscript
-        timeout-minutes: 5
-        run: |
-          rustup default nightly
-          cd modules/rustminiscript && make
-
-      - name: Build - btcd
-        timeout-minutes: 5
-        run: |
-          cd modules/btcd && make
-
-      - name: Build - nbitcoin
-        timeout-minutes: 5
-        run: |
-          cd modules/nbitcoin && make
-
-      - name: Build - embit
-        timeout-minutes: 5
-        run: |
-          cd modules/embit && make
-
-      - name: Build - lnd
-        timeout-minutes: 5
-        run: |
-          cd modules/lnd && make
-
-      - name: Build - ldk
-        timeout-minutes: 5
-        run: |
-          rustup default nightly
-          cd modules/ldk && make
-
-      - name: Build - nlightning
-        timeout-minutes: 5
-        run: |
-          cd modules/nlightning && make
-
-      - name: Build - lightning kmp
-        timeout-minutes: 5
-        run: |
-          cd modules/lightningkmp && make
-
-      - name: Build - bitcoinj
-        timeout-minutes: 5
-        run: |
-          cd modules/bitcoinj && make
-
-      - name: Build - clightning
-        timeout-minutes: 5
-        run: |
-          cd modules/clightning && make
-
-      - name: Build - eclair
-        timeout-minutes: 5
-        run: |
-          cd modules/eclair && make
-
-      - name: Build - decredsecp256k1
-        timeout-minutes: 5
-        run: |
-          cd modules/decredsecp256k1 && make
-
-      - name: Build - secp256k1
-        timeout-minutes: 5
-        run: |
-          cd modules/secp256k1 && make
-
-      - name: Build - nbitcoinsecp256k1
-        timeout-minutes: 5
-        run: |
-          cd modules/nbitcoinsecp256k1 && make
-
-      - name: Build - k256
-        timeout-minutes: 5
-        run: |
-          cd modules/rustk256 && make
-
-      - name: Report build success
-        run: |
           echo "✅ Successfully built commit ${{ steps.commit-info.outputs.short-sha }}: ${{ steps.commit-info.outputs.subject }}"

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Build every module present at the current commit.
+# This script is called by CI when doing commit-by-commit builds so that
+# each commit defines its own set of modules rather than relying on the
+# static step list baked into the workflow file.
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+BUILT=0
+FAILED=0
+
+build() {
+    local path="$1"
+    local name
+    name=$(basename "$path")
+
+    if [ ! -d "$path" ]; then
+        return 0
+    fi
+
+    if [ ! -f "$path/Makefile" ]; then
+        echo "==> Skipping $name (no Makefile)"
+        return 0
+    fi
+
+    echo "==> Building $name"
+    if (cd "$path" && make); then
+        BUILT=$((BUILT + 1))
+    else
+        echo "FAILED: $name"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+# Switch to Rust nightly — several modules require it (rustbitcoin, ldk, etc.)
+if command -v rustup &>/dev/null; then
+    rustup default nightly
+fi
+
+# Install embit Python dependencies only when the module is present
+if [ -f "modules/embit/requirements.txt" ]; then
+    echo "==> Installing embit dependencies"
+    pip install -r modules/embit/requirements.txt -q
+    pip install mako -q
+fi
+
+# Build custommutator first; fuzz targets may depend on it
+build "custommutator"
+
+# Build every module present at this commit
+if [ -d "modules" ]; then
+    for module_path in modules/*/; do
+        build "${module_path%/}"
+    done
+fi
+
+echo ""
+echo "Modules built: $BUILT  Modules failed: $FAILED"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
…commit

Fixes #450

The workflow had hardcoded build steps for every known module, so checking out an earlier commit (e.g. before a new module was added) would fail trying to build directories that didn't exist yet.

Add scripts/build-all.sh that dynamically discovers and builds every modules/*/ directory present at the checked-out commit. The workflow now calls this script instead of maintaining a static list of steps, so each commit defines its own set of modules. A graceful fallback is included for commits that predate the script.

Also moves the embit pip install into the script (guarded by a file existence check) to avoid a similar failure when embit is absent.