### PR TITLE
fix(pybitcoinkernel): add python cleanup function to pybitcoinkernel module

### DIFF
--- a/modules/embit/module.cpp
+++ b/modules/embit/module.cpp
@@ -1,9 +1,16 @@
 #include "module.h"
 #include <Python.h>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <span>
 #include <string>
+
+void python_cleanup() {
+  if (Py_IsInitialized()) {
+    Py_Finalize();
+  }
+}
 
 template <typename InputType, typename ReturnType>
 static ReturnType
@@ -11,9 +18,14 @@ call_python_function(const InputType input, size_t input_len,
                      const char *function_name,
                      PyObject *(*create_input_object)(const InputType, size_t),
                      ReturnType (*convert_result)(PyObject *)) {
+  static bool cleanup_registered = false;
   if (!Py_IsInitialized()) {
     Py_Initialize();
     PyRun_SimpleString("import sys; sys.path.append('.')");
+    if (!cleanup_registered) {
+      atexit(python_cleanup);
+      cleanup_registered = true;
+    }
   }
 
   PyGILState_STATE gstate = PyGILState_Ensure();

--- a/modules/pybitcoinkernel/module.cpp
+++ b/modules/pybitcoinkernel/module.cpp
@@ -1,9 +1,16 @@
 #include "module.h"
 #include <Python.h>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <span>
 #include <string>
+
+void python_cleanup() {
+  if (Py_IsInitialized()) {
+    Py_Finalize();
+  }
+}
 
 template <typename InputType, typename ReturnType>
 static ReturnType
@@ -11,9 +18,14 @@ call_python_function(const InputType input, size_t input_len,
                      const char *function_name,
                      PyObject *(*create_input_object)(const InputType, size_t),
                      ReturnType (*convert_result)(PyObject *)) {
+  static bool cleanup_registered = false;
   if (!Py_IsInitialized()) {
     Py_Initialize();
     PyRun_SimpleString("import sys; sys.path.append('.')");
+    if (!cleanup_registered) {
+      atexit(python_cleanup);
+      cleanup_registered = true;
+    }
   }
 
   PyGILState_STATE gstate = PyGILState_Ensure();


### PR DESCRIPTION
Closes #368

Added @erickcestari's [solution](https://github.com/bitcoinfuzz/bitcoinfuzz/pull/415#pullrequestreview-3759000511) for indirect leak on `kernel_block` target due to [`pybitcoinkernel`](https://github.com/bitcoinfuzz/bitcoinfuzz/blob/v2/modules/pybitcoinkernel/module.cpp)'s absence of cleanup routine.

