### PR TITLE
fix: correct loop condition in CompactBlocksTarget function

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -392,7 +392,7 @@ void Driver::CompactBlocksTarget(std::span<const uint8_t> buffer) const {
     if (last_response.has_value()) {
       if (*res != *last_response) {
         if (!buffer.empty()) {
-          for (size_t i = 0; std::min(size_t(32), buffer.size()); ++i)
+          for (size_t i = 0; i < std::min(size_t(32), buffer.size()); ++i)
             printf("%02x", buffer[i]);
           if (buffer.size() > 32)
             std::cout << "...";


### PR DESCRIPTION
Fixes : #456 

## About PR 
- Fixes an infinite loop and potential out-of-bounds read in `Driver::CompactBlocksTarget` by correcting the for-loop condition in `driver.cpp`.
- The loop header was missing the `i <` comparison, causing the loop to evaluate the wrong expression and iterate incorrectly. This could lead to a non-terminating loop and read past buffer bounds.

## Changes 
corrected loop from `for (size_t i = 0; std::min(size_t(32), buffer.size()); ++i)` to `for (size_t i = 0; i < std::min(size_t(32), buffer.size()); ++i)`.

## Before 
<img width="663" height="72" alt="Screenshot 2026-03-04 210155" src="https://github.com/user-attachments/assets/4a0bb3c1-32d5-4ea9-a1bb-cdcf2f5eefc0" />

## After
<img width="713" height="70" alt="Screenshot 2026-03-04 210557" src="https://github.com/user-attachments/assets/0b1dccd0-e74e-4b2e-847a-e6e776c427c4" />
 