### PR TITLE
fix(driver): use reference in AddressParseTarget module loop

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -232,7 +232,7 @@ void Driver::AddressParseTarget(std::span<const uint8_t> buffer) const {
   std::optional<std::string> last_response{std::nullopt};
   std::string last_module_name;
 
-  for (auto module : modules) {
+  for (auto &module : modules) {
     std::optional<std::string> res{module.second->address_parse(address)};
     if (!res.has_value() || res->starts_with("UNK:"))
       continue;


### PR DESCRIPTION
Fixes : #460 

In Driver::AddressParseTarget in driver.cpp uses for(auto module : modules) (copy) instead of for(auto module : modules) (refernce) like all other targets . Unnecessary and incosistent .

## After Code
<img width="371" height="48" alt="image" src="https://github.com/user-attachments/assets/ef152eec-584c-432e-9ccf-15c42579d62c" />
