### PR TITLE
fix(driver): improve error handling for undefined targets instead of assert(false)

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -909,8 +909,8 @@ void Driver::Run(const uint8_t *data, const size_t size,
   } else if (target == "decode_onion") {
     this->DecodeOnionTarget(buffer);
   } else {
-    std::cout << "Target not defined!" << std::endl;
-    assert(false);
+    std::cerr << "Target not defined: " << target << std::endl;
+    return;
   }
 };
 


### PR DESCRIPTION
Fixes : #462 
## About
In `driver.cpp` call [`assert(false)`] for unexpected runtime conditions (e.g. unknown Driver targets). If any of these code paths are reached the process aborts immediately with no useful diagnostics, making fuzzing results and debugging unrecoverable.

## Fix 
<img width="780" height="116" alt="image" src="https://github.com/user-attachments/assets/733c3c4f-c6b0-4134-8413-f922de38ce8c" />

