### PR TITLE
libwally: add deserialize extended key target

### DIFF
--- a/modules/libwallycore/module.cpp
+++ b/modules/libwallycore/module.cpp
@@ -114,5 +114,52 @@ LibwallyCore::bip32_master_keygen(std::span<const uint8_t> seed) const {
 
   return result;
 }
+
+std::optional<std::string> LibwallyCore::bip32_deserialize_extended_key(
+    std::span<const uint8_t> buffer) const {
+
+  struct ext_key key;
+
+  int res = bip32_key_from_base58_n(
+      reinterpret_cast<const char *>(buffer.data()), buffer.size(), &key);
+
+  if (res != WALLY_OK) {
+    return "INVALID";
+  }
+
+  std::ostringstream result;
+
+  result << std::hex << std::setfill('0');
+
+  result << "depth=" << std::setw(2) << (int)key.depth << ";";
+  result << "fp=";
+  for (int i = 0; i < 4; ++i)
+    result << std::hex << std::setw(2) << std::setfill('0')
+           << static_cast<int>(key.parent160[i]);
+  result << ";";
+  result << "child=" << std::setw(8) << key.child_num << ";";
+
+  result << "chaincode=";
+  for (size_t i = 0; i < sizeof(key.chain_code); ++i)
+    result << std::hex << std::setw(2) << std::setfill('0')
+           << static_cast<int>(key.chain_code[i]);
+  result << ";";
+
+  bool is_private = key.version == BIP32_VER_MAIN_PRIVATE ||
+                    key.version == BIP32_VER_TEST_PRIVATE;
+
+  result << "key=";
+  if (is_private) {
+    for (size_t i = 1; i < sizeof(key.priv_key); ++i) // skip prefix byte
+      result << std::setw(2) << std::setfill('0')
+             << static_cast<int>(key.priv_key[i]);
+  } else {
+    for (size_t i = 1; i < sizeof(key.pub_key); ++i)
+      result << std::setw(2) << std::setfill('0')
+             << static_cast<int>(key.pub_key[i]);
+  }
+  return result.str();
+}
+
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/libwallycore/module.h
+++ b/modules/libwallycore/module.h
@@ -12,6 +12,8 @@ public:
   psbt_parse(std::span<const uint8_t> buffer) const override;
   std::optional<std::string>
   bip32_master_keygen(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string> bip32_deserialize_extended_key(
+      std::span<const uint8_t> buffer) const override;
   ~LibwallyCore() noexcept override = default;
 };
 } // namespace module


### PR DESCRIPTION
Libwallycore seems to accept some invalid [Test Vector 5 cases](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki). Similarly to what we found with NBitcoin and BitcoinJ. Resulting in these types of errors:
```
tprv8Zgy2Q8Bt4oLiTSCgudFk7PMxiCdAxcEgGTGRmGzfhCdVHPnP5ySPE8ehp174szTZCNtFbGg32DbzmnYbaKEuu41mRgiViDAtCUhpJMVE4T
xprv error: NonZeroParentFingerprintForMasterKey
BIP32 deserialize extended key failed
Module: Rustbitcoin
Result: INVALID
Module: LibwallyCore
Result: depth=00;fp=00070000;child=00000000;chaincode=0000000000000000002e00000000000000000000000000000000000000000000;key=00000000000000ffffffffffffff7f0000000000000000000000000000000000
```
```
xprv9s21ZrQJ3WcBYLtmSeFpHkqYxCt1j5hHytNJhiXjZz7EdjBibkxCAZrTc44GiGZSuiqaLsHKEnNXtFEuHtaJHiSAeUqKLXGZ6EndmUits6T
xprv error: NonZeroChildNumberForMasterKey
BIP32 deserialize extended key failed
Module: Rustbitcoin
Result: INVALID
Module: LibwallyCore
Result: depth=00;fp=00000000;child=10000000;chaincode=0000000000000000000000000000000000000000000000000000000000000000;key=0000003583940000000000000000000000000000000000000000000000000000
```

```
xpub661MyMwAqRbcEYS8w7u3XpxgKfy8Vhzy2d6xc3pYJzqW3oJYDLUS4efD88MkNN19ZY3fyNJ1Su23GPMCzUEzWVeWRw3zhcDr5CEhs5kaq7J
xpub error: Secp256k1(InvalidPublicKey)
BIP32 deserialize extended key failed
Module: Rustbitcoin
Result: INVALID
Module: LibwallyCore
Result: depth=00;fp=00000000;child=00000000;chaincode=00000000f60000000000463933593577767a6455617968676b6b466f6963515a;key=5033790008000000000002000000000000240000000000000080000000000000
```

Can someone doublecheck if my theory is correct? I can then create an upstream PR in libwally repo fixing this. Thanks