### PR TITLE
build(eclair): clean external/eclair Maven artifacts during make clean

### DIFF
--- a/modules/eclair/Makefile
+++ b/modules/eclair/Makefile
@@ -56,5 +56,6 @@ check-format:
 clean:
 	rm -f *.o *.a eclair.zip *.class
 	rm -rf lib eclair_extracted
+	cd $(ECLAIR_DIR) && ./mvnw -q -pl eclair-node -am clean
 
 .PHONY: all lib clean format check-format lib/EclairWrapper.jar eclair.zip


### PR DESCRIPTION
Eclair module depends on Maven artifacts created in `external/eclair/*/targets`. Without cleaning those directories, `make` routine reutilized those artifacts.

This patch enhances the `make clean` routine to ensure deterministic clean builds.