### PR TITLE
build(clightning): enhance make clean routine

### DIFF
--- a/modules/clightning/Makefile
+++ b/modules/clightning/Makefile
@@ -94,5 +94,6 @@ check-format:
 clean:
 	rm -f *.o *.a module_temp.a secp256k1_symbols.map
 	rm -rf tmp_obj
+	$(MAKE) -C $(LIGHTNING_DIR) clean || true
 
 .PHONY: all format check-format clean


### PR DESCRIPTION
Enhance Clightning's `clean` routine to also clean the correspondent submodule's artifacts.

This is a follow-up to the [previous cleanup PR](https://github.com/bitcoinfuzz/bitcoinfuzz/pull/468), scoped specifically to clightning.