### PR TITLE
fix(btcd): handle null result in transaction_eval method

### DIFF
--- a/modules/btcd/module.cpp
+++ b/modules/btcd/module.cpp
@@ -109,7 +109,8 @@ Btcd::transaction_eval(std::span<const uint8_t> buffer) const {
   tx.length = buffer.size();
 
   char *result = BTCDTransactionEval(tx);
-
+  if (!result)
+    return std::nullopt;
   std::string res(result);
   BTCDFreeString(result);
   return res;


### PR DESCRIPTION
Ready for review . Null pointer handling