### PR TITLE
Ignore workflows when changing documentation

### DIFF
--- a/.github/workflows/commit-by-commit-build.yml
+++ b/.github/workflows/commit-by-commit-build.yml
@@ -3,6 +3,8 @@ name: Commit-by-Commit Build
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   get-commits:

--- a/.github/workflows/docker-image-check.yml
+++ b/.github/workflows/docker-image-check.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, synchronize, reopened]
     paths-ignore:
       - '**/*.md'
-      - LICENSE
 
 jobs:
   select-modules:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,7 +1,13 @@
 name: Format Check
 
-on: [push, pull_request]
-
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**/*.md'
 jobs:
   format-check:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   build:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,6 +1,13 @@
 name: Check
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   build:


### PR DESCRIPTION
- Standardized an ignore rule in all workflows when all the chages are documentation-only.
- Removed `LICENSE` from `docker-image-check.yml` ignore rule since it realistically makes no practical difference.