### PR TITLE
feat: add bip32_derive_from_path target for rust-bitcoin and Bitcoin Core

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -240,7 +240,10 @@ jobs:
             target: "stump_modify_add"
             cxxflags: "-DRUSTREEXO -DUTREEXO"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
-
+          - corpus: "bip32_derive_from_path"
+            target: "bip32_derive_from_path"
+            cxxflags: "-DRUST_BITCOIN -DBITCOIN_CORE"
+            asan_options: "detect_leaks=0:detect_container_overflow=0"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -418,3 +418,18 @@ services:
     env_file: .env
     volumes:
       - ./docker:/app/data
+  bip32_derive_from_path:
+    build:
+      context: .
+      tags:
+        - bitcoinfuzz:bip32_derive_from_path
+      args:
+        CXXFLAGS: "-DRUST_BITCOIN -DBITCOIN_CORE"
+        FUZZ: bip32_derive_from_path
+    environment:
+      MODULES: ${MODULES:-}
+      LIBFUZZ_DETECT_LEAKS: 0
+      ASAN_OPTIONS: detect_leaks=0
+    env_file: .env
+    volumes:
+      - ./docker:/app/data

--- a/driver.cpp
+++ b/driver.cpp
@@ -677,6 +677,22 @@ void Driver::StumpModifyAddTarget(std::span<const uint8_t> buffer) const {
   }
 }
 
+void Driver::Bip32DeriveFromPathTarget(std::span<const uint8_t> buffer) const {
+  FuzzedDataProvider provider(buffer.data(), buffer.size());
+  std::string path{provider.ConsumeRemainingBytesAsString()};
+  std::optional<std::string> last_response{std::nullopt};
+  std::string last_module_name;
+
+  for (auto &module : modules) {
+    std::optional<std::string> res{
+        module.second->bip32_derive_from_path(buffer)};
+    if (!res.has_value())
+      continue;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "BIP32 derive from path failed");
+  }
+}
+
 void Driver::Run(const uint8_t *data, const size_t size,
                  const std::string &target) const {
   std::span<const uint8_t> buffer{data, size};
@@ -738,6 +754,8 @@ void Driver::Run(const uint8_t *data, const size_t size,
     this->DecodeOnionTarget(buffer);
   } else if (target == "stump_modify_add") {
     this->StumpModifyAddTarget(buffer);
+  } else if (target == "bip32_derive_from_path") {
+    this->Bip32DeriveFromPathTarget(buffer);
   } else {
     std::cout << "Unknown target: " << target << std::endl;
     assert(false);

--- a/driver.h
+++ b/driver.h
@@ -49,5 +49,6 @@ public:
   void SchnorrVerifyTarget(std::span<const uint8_t> buffer) const;
   void DecodeOnionTarget(std::span<const uint8_t> buffer) const;
   void StumpModifyAddTarget(std::span<const uint8_t> buffer) const;
+  void Bip32DeriveFromPathTarget(std::span<const uint8_t> buffer) const;
 };
 } // namespace bitcoinfuzz

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -162,4 +162,9 @@ std::optional<std::string> BaseModule::stump_modify_add(
   return std::nullopt;
 }
 
+std::optional<std::string>
+BaseModule::bip32_derive_from_path(std::span<const uint8_t> /*buffer*/) const {
+  return std::nullopt;
+}
+
 } // namespace bitcoinfuzz

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -80,6 +80,9 @@ public:
   virtual std::optional<std::string>
   stump_modify_add(const std::vector<std::vector<uint8_t>> &add_hashes) const;
 
+  virtual std::optional<std::string>
+  bip32_derive_from_path(std::span<const uint8_t> buffer) const;
+
   virtual ~BaseModule() noexcept;
 };
 } // namespace bitcoinfuzz

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -22,8 +22,10 @@ const TranslateFn G_TRANSLATION_FUN{nullptr};
 #include "script/interpreter.h"
 #include "script/miniscript.h"
 #include "script/script.h"
+#include "secp256k1.h"
 #include "span.h"
 #include "streams.h"
+#include "util/bip32.h"
 #include "util/chaintype.h"
 #include "validation.h"
 
@@ -660,6 +662,44 @@ Bitcoin::bip32_deserialize_extended_key(std::span<const uint8_t> buffer) const {
   } catch (...) {
     return "INVALID";
   }
+}
+
+std::optional<std::string>
+Bitcoin::bip32_derive_from_path(std::span<const uint8_t> buffer) const {
+  std::string path_str(reinterpret_cast<const char *>(buffer.data()),
+                       buffer.size());
+
+  // Reject hardened notation ('h')
+  if (path_str.find('h') != std::string::npos) {
+    return std::nullopt;
+  }
+
+  // Parse derivation path
+  std::vector<uint32_t> path;
+  if (!ParseHDKeypath(path_str, path) || path.empty()) {
+    return "INVALID";
+  }
+
+  static ECC_Context ecc_context;
+  SelectParams(ChainType::MAIN);
+
+  constexpr std::array<uint8_t, 32> seed_raw{
+      0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+      0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
+      0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20};
+
+  CExtKey key;
+  key.SetSeed(std::as_bytes(std::span(seed_raw)));
+
+  for (uint32_t child : path) {
+    CExtKey next;
+    if (!key.Derive(next, child)) {
+      return "INVALID";
+    }
+    key = next;
+  }
+
+  return EncodeExtKey(key);
 }
 
 } // namespace module

--- a/modules/bitcoin/module.h
+++ b/modules/bitcoin/module.h
@@ -35,6 +35,8 @@ public:
   bip32_master_keygen(std::span<const uint8_t> buffer) const override;
   std::optional<std::string> bip32_deserialize_extended_key(
       std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  bip32_derive_from_path(std::span<const uint8_t> buffer) const override;
   ~Bitcoin() noexcept override = default;
 };
 

--- a/modules/rustbitcoin/module.cpp
+++ b/modules/rustbitcoin/module.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <span>
 
 #include "module.h"
@@ -98,5 +99,16 @@ std::optional<std::string> Rustbitcoin::bip32_deserialize_extended_key(
   free_c_string(result_ptr);
   return result;
 }
+std::optional<std::string>
+Rustbitcoin::bip32_derive_from_path(std::span<const uint8_t> buffer) const {
+  auto result_ptr =
+      rust_bitcoin_bip32_derive_from_path(buffer.data(), buffer.size());
+  if (result_ptr == nullptr)
+    return std::nullopt;
+  std::string result(result_ptr);
+  free_c_string(result_ptr);
+  return result;
+}
+
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/rustbitcoin/module.h
+++ b/modules/rustbitcoin/module.h
@@ -28,6 +28,8 @@ public:
   bip32_master_keygen(std::span<const uint8_t> buffer) const override;
   std::optional<std::string> bip32_deserialize_extended_key(
       std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  bip32_derive_from_path(std::span<const uint8_t> buffer) const override;
   ~Rustbitcoin() noexcept override = default;
 };
 

--- a/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
+++ b/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
@@ -14,3 +14,5 @@ extern "C" char *rust_bitcoin_bip32_master_keygen(const uint8_t *data,
                                                   size_t len);
 extern "C" char *
 rust_bitcoin_bip32_deserialize_extended_key(const uint8_t *data, size_t len);
+extern "C" char *rust_bitcoin_bip32_derive_from_path(const uint8_t *data,
+                                                     size_t len);

--- a/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
+++ b/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
@@ -2,6 +2,7 @@ use bitcoin::absolute::Decodable;
 use bitcoin::address::Address;
 use bitcoin::bip32::ChainCode;
 use bitcoin::bip32::ChildNumber;
+use bitcoin::bip32::DerivationPath;
 use bitcoin::bip32::Fingerprint;
 use bitcoin::bip32::Xpriv;
 use bitcoin::bip32::Xpub;
@@ -20,6 +21,7 @@ use std::ffi::CString;
 use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
 use std::os::raw::c_char;
+use std::ptr;
 use std::slice;
 use std::str::{FromStr, Utf8Error};
 
@@ -436,5 +438,85 @@ pub unsafe extern "C" fn rust_bitcoin_bip32_deserialize_extended_key(
         } else {
             str_to_c_string("INVALID")
         }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_bitcoin_bip32_derive_from_path(
+    data: *const u8,
+    len: usize,
+) -> *mut c_char {
+    let data_slice = slice::from_raw_parts(data, len);
+    let path_str = match std::str::from_utf8(data_slice) {
+        Ok(s) => s,
+        Err(_) => return str_to_c_string("INVALID"),
+    };
+
+    // if buffer contains a '+', SKIP
+    if path_str.as_bytes().iter().any(|&b| b == b'+') {
+        return ptr::null_mut();
+    }
+
+    // if buffer contains a trailing slash, SKIP
+    if path_str.as_bytes().last() == Some(&b'/') {
+        return ptr::null_mut();
+    }
+
+    // if buffer contains a whitespace, SKIP
+    if path_str.chars().any(|c| c.is_whitespace()) {
+        return ptr::null_mut();
+    }
+
+    // if index is too large (> 0x7FFFFFFF), SKIP
+    let mut start = 0usize;
+    let path_bytes = path_str.as_bytes();
+
+    while start < path_bytes.len() {
+        let mut end = start;
+        while end < path_bytes.len() && path_bytes[end] != b'/' {
+            end += 1;
+        }
+
+        let part = &path_str[start..end];
+
+        // strip trailing '\'' or 'h' if present
+        let part = part
+            .strip_suffix('\'')
+            .or_else(|| part.strip_suffix('h'))
+            .unwrap_or(part);
+
+        if !part.is_empty() {
+            if let Ok(val) = part.parse::<u64>() {
+                if val > 0x7FFF_FFFF {
+                    return ptr::null_mut();
+                }
+            }
+        }
+
+        if end == path_bytes.len() {
+            break;
+        }
+        start = end + 1;
+    }
+
+    let path = match DerivationPath::from_str(path_str) {
+        Ok(p) => p,
+        Err(_) => return str_to_c_string("INVALID"),
+    };
+
+    if path.as_ref().is_empty() {
+        return str_to_c_string("INVALID");
+    }
+
+    let seed: [u8; 32] = [
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e,
+        0x1f, 0x20,
+    ];
+
+    let master_key = Xpriv::new_master(NetworkKind::Main, &seed);
+    match master_key.derive_priv(&path) {
+        Ok(derived_key) => str_to_c_string(&derived_key.to_string()),
+        Err(_) => str_to_c_string("INVALID"),
     }
 }


### PR DESCRIPTION
Based on the long and fruitful discussion in [PR423](https://github.com/bitcoinfuzz/bitcoinfuzz/pull/423), here is the `bip32_derive_from_path` target (for _rust-bitcoin_ & _Bitcoin Core_ so far).

- Syntax checks are skipped in `module.cpp` as discussed.
- The same master private is used every time (to make sure we are really testing the derivation only), but this can be adjusted if we feel it's better to e.g. generate a new one for each run.
- Target successfully explores deep (>255) paths as intended.

