### PR TITLE
fix(bitcoin): use CheckBlock in deserialize_block

### DIFF
--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -352,10 +352,16 @@ Bitcoin::deserialize_block(std::span<const uint8_t> buffer) const {
   } catch (const std::ios_base::failure &) {
     return std::nullopt;
   }
-  if (block.vtx.empty()) {
+  static bool initialized = false;
+  if (!initialized) {
+    SelectParams(ChainType::MAIN);
+    initialized = true;
+  }
+  BlockValidationState state;
+  if (!CheckBlock(block, state, Params().GetConsensus(), /*fCheckPOW=*/false)) {
     return "0";
   }
-  if (IsBlockMutated(block, true)) {
+  if (IsBlockMutated(block, /*check_witness_root=*/true)) {
     return "0";
   }
   return block.GetHash().ToString();


### PR DESCRIPTION
Aligns deserialize_block with btcd's BTCDDesBlock, which calls CheckBlockSanity (coinbase checks, per-tx sanity) and ValidateWitnessCommitment. CheckBlock with fCheckPOW=false covers the former; IsBlockMutated(block, true) covers the latter.