### PR TITLE
fix: init secp256k1 submodule for custom mutators

### DIFF
--- a/auto_build.py
+++ b/auto_build.py
@@ -75,9 +75,17 @@ SUBMODULES_BY_FLAG = {
 
 def ensure_submodules_for_flags(flags, quiet: bool):
     paths = []
+    has_custom_mutator = False
     for flag in flags:
         paths += SUBMODULES_BY_FLAG.get(flag, [])
-
+        if flag.startswith("CUSTOM_MUTATOR_"):
+            has_custom_mutator = True
+            
+    if has_custom_mutator:
+        paths.append("external/secp256k1")
+            
+    # Deduplicate paths and preserve order
+    paths = list(dict.fromkeys(paths))
     if not paths:
         return
     if not quiet:


### PR DESCRIPTION
### Description

This PR addresses local build failures for targets utilizing custom mutators and introduces a dynamic smoke testing script to validate the local Docker setup for all fuzz targets.



**1. Fix `auto_build.py` Submodule Initialization**

Certain fuzz targets were failing to build locally via Docker, specifically during the `auto_build.py` execution phase. The build would terminate with the following error:

```

failed to solve: process "/bin/sh -c export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-$(dpkg --print-architecture) &&     /build/auto_build.py" did not complete successfully: exit code: 1

error: Recipe `run` failed on line 15 with exit code 17

```



This occurred because the `CUSTOM_MUTATOR_*` flags (e.g., `CUSTOM_MUTATOR_ONION` or `CUSTOM_MUTATOR_P2P_MESSAGE`) were not being recognized by `auto_build.py` as triggers to initialize the `external/secp256k1` submodule.

* **Change:** Updated `ensure_submodules_for` in `auto_build.py` to append and deduplicate the `secp256k1` path for any flag starting with the `CUSTOM_MUTATOR_` prefix. This systemic fix ensures all current and future mutator-based targets initialize their dependencies correctly.





### Motivation

A user(@mowgli_2002) recently reported hitting the `secp256k1` error on Discord when trying to run `decode_onion` on `v2`. I wrote the smoke test to verify repository health and immediately caught the exact same regression on `parse_p2p_message`. Combining the test and the fix ensures no custom mutator targets silently break local development environments going forward.



### Testing Done


- [x] Verified `parse_p2p_message` and `decode_onion` now successfully build, start, and run until the timeout without submodule errors.