### PR TITLE
Align Compose and CI fuzz target configs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -237,7 +237,7 @@ jobs:
             cxxflags: "-DCLIGHTNING -DLND -DLDK -DCUSTOM_MUTATOR_ONION"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "stump_modify"
-            target: "stump_modify"
+            target: "stump_modify_add"
             cxxflags: "-DRUSTREEXO -DUTREEXO"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -236,7 +236,7 @@ jobs:
             target: "decode_onion"
             cxxflags: "-DCLIGHTNING -DLND -DLDK -DCUSTOM_MUTATOR_ONION"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
-          - corpus: "stump_modify"
+          - corpus: "stump_modify_add"
             target: "stump_modify_add"
             cxxflags: "-DRUSTREEXO -DUTREEXO"
             asan_options: "detect_leaks=0:detect_container_overflow=0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       tags:
         - bitcoinfuzz:kernel_block
       args:
-        CXXFLAGS: "-DPYBITCOINKERNEL -DRUSTBITCOINKERNEL"
+        CXXFLAGS: "-DPYBITCOINKERNEL -DRUSTBITCOINKERNEL -DBITCOINKERNEL"
         FUZZ: kernel_block
     env_file: .env
     environment:
@@ -93,10 +93,27 @@ services:
       tags:
         - bitcoinfuzz:kernel_transaction
       args:
-        CXXFLAGS: "-DPYBITCOINKERNEL -DRUSTBITCOINKERNEL"
+        CXXFLAGS: "-DPYBITCOINKERNEL -DRUSTBITCOINKERNEL -DBITCOINKERNEL"
         FUZZ: kernel_transaction
     env_file: .env
     environment:
+      MODULES: ${MODULES:-}
+      LIBFUZZ_DETECT_LEAKS: 0
+      ASAN_OPTIONS: detect_leaks=0
+    volumes:
+      - ./docker:/app/data
+
+  cmpctblocks_parse:
+    build:
+      context: .
+      tags:
+        - bitcoinfuzz:cmpctblocks_parse
+      args:
+        CXXFLAGS: "-DBITCOIN_CORE -DRUST_BITCOIN"
+        FUZZ: cmpctblocks_parse
+    env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
       LIBFUZZ_DETECT_LEAKS: 0
       ASAN_OPTIONS: detect_leaks=0
     volumes:
@@ -228,7 +245,7 @@ services:
       tags:
         - bitcoinfuzz:parse_p2p_lightning_message
       args:
-        CXXFLAGS: "-DLDK -DCLIGHTNING -DLND"
+        CXXFLAGS: "-DLDK -DCLIGHTNING -DLND -DCUSTOM_MUTATOR_P2P_LIGHTNING_MESSAGE"
         FUZZ: parse_p2p_lightning_message
     env_file: .env
     environment:


### PR DESCRIPTION
This PR fixes drift between docker-compose.yml and the CI workflow so local Docker runs and GitHub Actions target the same fuzz configurations.

Changes
Add missing cmpctblocks_parse service to Compose
Align kernel_block and kernel_transaction Compose flags with CI by including -DBITCOINKERNEL
Add missing MODULES env wiring for kernel_transaction
Align parse_p2p_lightning_message Compose flags with CI by including -DCUSTOM_MUTATOR_P2P_LIGHTNING_MESSAGE
Rename the CI target from stump_modify to stump_modify_add to match the actual target name
Why
A few target definitions had drifted across Compose, CI, and the runtime target registry. This could make local orchestration behavior differ from CI and adds friction for future automation work.

Validation
Verified docker compose config --services parses successfully
Confirmed the updated services/targets now match the names and flags used by the binary and workflow
Follow-up
This helps establish a cleaner base for future work around campaign orchestration, scheduling, and monitoring.
Kindly review @brunoerg , If Compose, CI, and the actual binary target names don’t match, you may get annoying failures, This PR basically makes the repo tell one consistent story. Do let me know if I missed something or needs changes.
Thanks