### PR TITLE
fix(stump_modified_add): skip all 0's input

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cassert>
 #include <fuzzer/FuzzedDataProvider.h>
 #include <iostream>
@@ -855,6 +856,13 @@ void Driver::StumpModifyAddTarget(std::span<const uint8_t> buffer) const {
     auto hash = provider.ConsumeBytes<uint8_t>(32);
     if (hash.size() < 32) {
       break;
+    }
+    // Skip all-zero hashes because Utreexod's dynamic accumulator
+    // implementation treats them as a special case (empty tree), but other
+    // implementations may handle that differently.
+    if (std::all_of(hash.begin(), hash.end(),
+                    [](uint8_t byte) { return byte == 0; })) {
+      continue;
     }
     add_hashes.push_back(std::move(hash));
   }


### PR DESCRIPTION
While `utreexo`'s Go implementation considers a hash consisting of all 0 bytes as empty, `rustreexo` has no such restriction, considering it a valid hash, which means that an all 0's input is outside the shared domain of both implementations and should be skipped.

Added a lambda function in `driver.cpp`'s `stump_modified_add` target to skip the case where a hash is composed of all zeros.