### PR TITLE
fix(just): remove legacy docker-compose requirement

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -2,18 +2,15 @@
 
 ## Environment Preparation
 
-Install Docker, Docker Compose, jq, and just before interacting with this repository:
+Install Docker with the `docker compose` plugin, jq, and just before interacting with this repository:
 
 ```bash
 # macOS (Homebrew)
 brew install docker jq just
-brew install docker-compose # if not bundled with Docker Desktop
 
 # Ubuntu / Debian
 sudo apt-get update
 sudo apt-get install -y docker.io jq just
-sudo curl -L "https://github.com/docker/compose/releases/download/v5.0.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
 
 docker --version
 docker compose version

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S just --justfile
 
-required_bins := require("docker") + require("docker-compose") + require("jq")
+required_bins := require("docker") + require("jq")
 
 [default]
 _default:


### PR DESCRIPTION
This removes the `docker-compose` binary requirement from the `justfile` and aligns the setup docs with the commands the repo already uses.

The `just` recipes invoke `docker compose`, but `required_bins` still checked for the standalone `docker-compose` executable. This could block users with a working Compose v2 plugin setup.

for verification I did the following :
- ran `just list-targets`
- verified `docker compose` config parsing still works

This is a small consistency fix that removes an unnecessary prerequisite and makes the documented setup match the actual `just` workflow.