### PR TITLE
pycoin: add bip32_deserialize_extended_key target

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -222,7 +222,7 @@ jobs:
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "bip32_deserialize_extended_key"
             target: "bip32_deserialize_extended_key"
-            cxxflags: "-DNBITCOIN -DRUST_BITCOIN -DBITCOIN_CORE -DBITCOINJ -DLIBWALLY_CORE -DEMBIT -DCUSTOM_MUTATOR_EXTENDED_KEY"
+            cxxflags: "-DNBITCOIN -DRUST_BITCOIN -DBITCOIN_CORE -DBITCOINJ -DLIBWALLY_CORE -DEMBIT -DPYCOIN -DCUSTOM_MUTATOR_EXTENDED_KEY"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
             setup_java: "true"
           - corpus: "decode_ellswift"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -342,7 +342,7 @@ services:
       tags:
         - bitcoinfuzz:bip32_deserialize_extended_key
       args:
-        CXXFLAGS: "-DBITCOIN_CORE -DRUST_BITCOIN -DNBITCOIN -DBITCOINJ -DLIBWALLY_CORE -DEMBIT -DCUSTOM_MUTATOR_EXTENDED_KEY"
+        CXXFLAGS: "-DBITCOIN_CORE -DRUST_BITCOIN -DNBITCOIN -DBITCOINJ -DLIBWALLY_CORE -DEMBIT -DPYCOIN -DCUSTOM_MUTATOR_EXTENDED_KEY"
         FUZZ: bip32_deserialize_extended_key
     environment:
       LIBFUZZ_DETECT_LEAKS: 0

--- a/modules/pycoin/module.cpp
+++ b/modules/pycoin/module.cpp
@@ -120,6 +120,12 @@ char *bip32_master_keygen_py(const uint8_t *data, size_t len) {
       data, len, "bip32_master_keygen", create_bytes_object, convert_to_string);
 }
 
+char *bip32_deserialize_extended_key_py(const uint8_t *data, size_t len) {
+  return call_python_function<const uint8_t *, char *>(
+      data, len, "bip32_deserialize_extended_key", create_bytes_object,
+      convert_to_string);
+}
+
 namespace bitcoinfuzz {
 namespace module {
 
@@ -128,6 +134,18 @@ Pycoin::Pycoin(void) : BaseModule("Pycoin") {}
 std::optional<std::string>
 Pycoin::bip32_master_keygen(std::span<const uint8_t> buffer) const {
   auto result_ptr = bip32_master_keygen_py(buffer.data(), buffer.size());
+  if (result_ptr == nullptr)
+    return std::nullopt;
+
+  std::string result(result_ptr);
+  free(result_ptr);
+  return result;
+}
+
+std::optional<std::string>
+Pycoin::bip32_deserialize_extended_key(std::span<const uint8_t> buffer) const {
+  auto result_ptr =
+      bip32_deserialize_extended_key_py(buffer.data(), buffer.size());
   if (result_ptr == nullptr)
     return std::nullopt;
 

--- a/modules/pycoin/module.h
+++ b/modules/pycoin/module.h
@@ -12,6 +12,8 @@ public:
   Pycoin(void);
   std::optional<std::string>
   bip32_master_keygen(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string> bip32_deserialize_extended_key(
+      std::span<const uint8_t> buffer) const override;
   ~Pycoin() noexcept override = default;
 };
 

--- a/modules/pycoin/pycoin_lib.py
+++ b/modules/pycoin/pycoin_lib.py
@@ -1,4 +1,5 @@
 from pycoin.symbols.btc import network as BTC
+from pycoin.symbols.xtn import network as XTN
 
 
 def bip32_master_keygen(data: bytes) -> str:
@@ -7,3 +8,71 @@ def bip32_master_keygen(data: bytes) -> str:
         return root.hwif(as_private=True)
     except Exception:
         return "INVALID"
+
+
+def bip32_deserialize_extended_key(data: bytes) -> str:
+    try:
+        s = data.decode()
+    except Exception:
+        return "INVALID"
+
+    key = None
+
+    # TRY BTC PRV
+    try:
+        key = BTC.parse.bip32_prv(s)
+    except Exception:
+        key = None
+
+    # TRY BTC PUB
+    if key is None:
+        try:
+            key = BTC.parse.bip32_pub(s)
+        except Exception:
+            key = None
+
+    # TRY TESTNET PRV (XTN)
+    if key is None:
+        try:
+            key = XTN.parse.bip32_prv(s)
+        except Exception:
+            key = None
+
+    # TRY TESTNET PUB (XTN)
+    if key is None:
+        try:
+            key = XTN.parse.bip32_pub(s)
+        except Exception:
+            key = None
+
+    if key is None:
+        return "INVALID"
+
+    try:
+        depth = key.tree_depth()
+        fp = key.parent_fingerprint()
+        child_index = key.child_index()
+        chaincode = key.chain_code()
+        depth_hex = f"{depth:02x}"
+        fp_hex = fp.hex().rjust(8, "0")
+        child_hex = f"{child_index:08x}"
+        chaincode_hex = chaincode.hex()
+
+        if key.secret_exponent() is not None:
+            se = key.secret_exponent()
+            se_bytes = se.to_bytes(32, "big")
+            key_bytes = se_bytes
+        else:
+            key_bytes = key.sec(is_compressed=True)
+
+        key_hex = key_bytes.hex()
+    except Exception:
+        return "INVALID"
+
+    return (
+        f"depth={depth_hex};"
+        f"fp={fp_hex};"
+        f"child={child_hex};"
+        f"chaincode={chaincode_hex};"
+        f"key={key_hex}"
+    )


### PR DESCRIPTION
- Added `bip32_deserialize_extended_key` target for `Pycoin` .
- `Pycoin` seems to be missing [BIP32 Test Vector 5](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) validation.
- Created [an issue upstream](https://github.com/richardkiss/pycoin/issues/437) to address this.
