### PR TITLE
refactor(driver): deduplicate repeated response verification logic

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -2,11 +2,34 @@
 #include <fuzzer/FuzzedDataProvider.h>
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <unistd.h>
 
 #include "driver.h"
 #include <bitcoinfuzz/basemodule.h>
 #include <bitcoinfuzz/module_registry.h>
+
+namespace {
+template <typename T>
+void VerifyMatchingResponse(std::optional<T> &last_response,
+                            std::string &last_module_name,
+                            const std::string &module_name, const T &response,
+                            std::string_view failure_message) {
+  if (last_response.has_value()) {
+    if (response != *last_response) {
+      std::cout << failure_message << std::endl;
+      std::cout << "Module: " << module_name << std::endl;
+      std::cout << "Result: " << response << std::endl;
+      std::cout << "Module: " << last_module_name << std::endl;
+      std::cout << "Result: " << *last_response << std::endl;
+    }
+    assert(response == *last_response);
+  }
+
+  last_response = response;
+  last_module_name = module_name;
+}
+} // namespace
 
 namespace bitcoinfuzz {
 void Driver::LoadModule(std::shared_ptr<BaseModule> module) {
@@ -21,18 +44,9 @@ void Driver::ScriptTarget(std::span<const uint8_t> buffer) const {
     std::optional<std::string> res{module.second->script_parse(buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "Script parse failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
-    last_response = *res;
-    last_module_name = module.first;
+
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "Script parse failed");
   }
 }
 
@@ -43,18 +57,9 @@ void Driver::BlockDeserializationTarget(std::span<const uint8_t> buffer) const {
     std::optional<std::string> res{module.second->deserialize_block(buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "Block deserialization failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
-    last_response = res.value();
-    last_module_name = module.first;
+
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "Block deserialization failed");
   }
 }
 
@@ -86,18 +91,9 @@ void Driver::ScriptEvalTarget(std::span<const uint8_t> buffer) const {
         module.second->script_eval(input_data, flags, /*version=*/0)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "Script evaluation failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
-    last_response = *res;
-    last_module_name = module.first;
+
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "Script evaluation failed");
   }
 }
 
@@ -131,18 +127,9 @@ void Driver::VerifyScriptTarget(std::span<const uint8_t> buffer) const {
         module.second->verify_script(script_sig, script_pubkey)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "Script verification failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
-    last_response = *res;
-    last_module_name = module.first;
+
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "Script verification failed");
   }
 }
 
@@ -155,18 +142,9 @@ void Driver::DescriptorParseTarget(std::span<const uint8_t> buffer) const {
     std::optional<bool> res{module.second->descriptor_parse(desc)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "Descriptor parse failed for " << desc << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
-    last_response = *res;
-    last_module_name = module.first;
+
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "Descriptor parse failed for " + desc);
   }
 }
 
@@ -183,18 +161,9 @@ void Driver::MiniscriptParseTarget(std::span<const uint8_t> buffer) const {
     std::optional<bool> res{module.second->miniscript_parse(miniscript)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "Miniscript parse failed for " << miniscript << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
-    last_response = *res;
-    last_module_name = module.first;
+
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "Miniscript parse failed for " + miniscript);
   }
 }
 
@@ -209,20 +178,9 @@ void Driver::InvoiceDeserializationTarget(
     std::optional<std::string> res{module.second->deserialize_invoice(invoice)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "Invoice deserialization failed for " << invoice
-                  << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "Invoice deserialization failed for " + invoice);
   }
 }
 
@@ -364,18 +322,9 @@ void Driver::OfferDeserializationTarget(std::span<const uint8_t> buffer) const {
     std::optional<std::string> res{module.second->deserialize_offer(offer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "Offer deserialization failed for " << offer << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
-    last_response = res.value();
-    last_module_name = module.first;
+
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "Offer deserialization failed for " + offer);
   }
 }
 
@@ -419,19 +368,9 @@ void Driver::ParseP2PMessageTarget(std::span<const uint8_t> buffer) const {
     std::optional<std::string> res{module.second->parse_p2p_message(buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "P2P message parsing failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "P2P message parsing failed");
   }
 }
 
@@ -443,11 +382,9 @@ void Driver::TransactionEvalTarget(std::span<const uint8_t> buffer) const {
     std::optional<std::string> res{module.second->transaction_eval(buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value())
-      assert(*res == *last_response);
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "Transaction evaluation failed");
   }
 }
 
@@ -459,20 +396,10 @@ void Driver::KernelBlockTarget(std::span<const uint8_t> buffer) const {
     std::optional<std::string> res{module.second->kernel_block(buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "Block parsing from libbitcoinkernel binding failed:"
-                  << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(
+        last_response, last_module_name, module.first, *res,
+        "Block parsing from libbitcoinkernel binding failed:");
   }
 }
 
@@ -484,20 +411,10 @@ void Driver::KernelTransactionTarget(std::span<const uint8_t> buffer) const {
     std::optional<std::string> res{module.second->kernel_transaction(buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "Transaction parsing from libbitcoinkernel binding failed:"
-                  << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(
+        last_response, last_module_name, module.first, *res,
+        "Transaction parsing from libbitcoinkernel binding failed:");
   }
 }
 
@@ -511,19 +428,9 @@ void Driver::ParseLightningP2pMessageTarget(
         module.second->parse_p2p_lightning_message(buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "Lightning P2P message parsing failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "Lightning P2P message parsing failed");
   }
 }
 void Driver::Bip32MasterKeygenTarget(std::span<const uint8_t> buffer) const {
@@ -534,19 +441,9 @@ void Driver::Bip32MasterKeygenTarget(std::span<const uint8_t> buffer) const {
     std::optional<std::string> res{module.second->bip32_master_keygen(buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "BIP32 master keygen failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "BIP32 master keygen failed");
   }
 }
 
@@ -564,19 +461,9 @@ void Driver::PrivateToPublicKeyTarget(std::span<const uint8_t> buffer) const {
         module.second->private_to_public_key(privkey_buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "PrivateToPublicKey Target failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "PrivateToPublicKey Target failed");
   }
 }
 
@@ -595,19 +482,9 @@ void Driver::SignCompactTarget(std::span<const uint8_t> buffer) const {
         module.second->sign_compact(privkey_buffer, hash_buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "SignCompact Target failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "SignCompact Target failed");
   }
 }
 
@@ -626,19 +503,9 @@ void Driver::SignDerTarget(std::span<const uint8_t> buffer) const {
         module.second->sign_der(privkey_buffer, hash_buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "SignDer Target failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "SignDer Target failed");
   }
 }
 
@@ -658,19 +525,9 @@ void Driver::SignVerifyTarget(std::span<const uint8_t> buffer) const {
         module.second->sign_verify(privkey_buffer, hash_buffer, sign_buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "SignVerify Target failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "SignVerify Target failed");
   }
 }
 
@@ -689,19 +546,9 @@ void Driver::ECDHTarget(std::span<const uint8_t> buffer) const {
         module.second->ecdh(privkey_buffer, pubkey_buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "ECDH Target failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "ECDH Target failed");
   }
 }
 
@@ -721,19 +568,9 @@ void Driver::SignSchnorrTarget(std::span<const uint8_t> buffer) const {
         module.second->sign_schnorr(privkey_buffer, hash_buffer, aux_buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "SignSchnorr Target failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "SignSchnorr Target failed");
   }
 }
 
@@ -747,19 +584,9 @@ void Driver::Bip32DeserializeExtendedKeyTarget(
         module.second->bip32_deserialize_extended_key(buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "BIP32 deserialize extended key failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "BIP32 deserialize extended key failed");
   }
 }
 
@@ -775,19 +602,9 @@ void Driver::DecodeEllswiftTarget(std::span<const uint8_t> buffer) const {
     std::optional<std::string> res{module.second->decode_ellswift(buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "DecodeEllswiftTarget Target failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "DecodeEllswiftTarget Target failed");
   }
 }
 
@@ -807,19 +624,9 @@ void Driver::SchnorrVerifyTarget(std::span<const uint8_t> buffer) const {
         module.second->schnorr_verify(privkey, hash, sign)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "SchnorrVerifyTarget failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "SchnorrVerifyTarget failed");
   }
 }
 
@@ -831,19 +638,9 @@ void Driver::DecodeOnionTarget(std::span<const uint8_t> buffer) const {
     std::optional<std::string> res{module.second->decode_onion(buffer)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "Onion decoding failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
 
-    last_response = res.value();
-    last_module_name = module.first;
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "Onion decoding failed");
   }
 }
 
@@ -866,18 +663,9 @@ void Driver::StumpModifyAddTarget(std::span<const uint8_t> buffer) const {
     std::optional<std::string> res{module.second->stump_modify_add(add_hashes)};
     if (!res.has_value())
       continue;
-    if (last_response.has_value()) {
-      if (*res != *last_response) {
-        std::cout << "StumpModifyAddTarget failed" << std::endl;
-        std::cout << "Module: " << module.first << std::endl;
-        std::cout << "Result: " << *res << std::endl;
-        std::cout << "Module: " << last_module_name << std::endl;
-        std::cout << "Result: " << *last_response << std::endl;
-      }
-      assert(*res == *last_response);
-    }
-    last_response = res.value();
-    last_module_name = module.first;
+
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "StumpModifyAddTarget failed");
   }
 }
 


### PR DESCRIPTION
This refactors `driver.cpp` by extracting the repeated response verification pattern used across multiple targets into a small helper.

#### Why this is useful

A large part of `driver.cpp` repeated the same verification block across many targets. That made the file noisier to maintain and increased the chance of mismatch-reporting logic drifting over time.

This change reduces that duplication while keeping target-specific parsing and custom mismatch handling untouched.


This is a cleanup-only change and is not intended to change fuzzing behavior.
