### PR TITLE
auto_build.py: accept -D flags in CLEAN_BUILD

### DIFF
--- a/auto_build.py
+++ b/auto_build.py
@@ -76,6 +76,15 @@ def should_build_sequentially(flag: str) -> bool:
 def get_flags(cxxflags: str):
     return re.findall(r"-D([A-Z0-9_]+)", cxxflags)
 
+def parse_clean_flags(clean_build: str):
+    flags = []
+    for token in clean_build.split():
+        if token.startswith("-D"):
+            token = token[2:]
+        if token:
+            flags.append(token)
+    return flags
+
 # Maps module flags to required git submodule paths defined in .gitmodules.
 SUBMODULES_BY_FLAG = {
     "CLIGHTNING": ["external/lightning"],
@@ -142,7 +151,7 @@ def main():
         elif clean_build == "CLEAN":
             clean_by_flags(get_flags(cxxflags))
         else:
-            clean_by_flags(clean_build.split())
+            clean_by_flags(parse_clean_flags(clean_build))
     else:
         print("No CLEAN_BUILD option specified. Skipping clean step.")
 


### PR DESCRIPTION
## Summary

Normalize custom `CLEAN_BUILD` values before passing them to `clean_by_flags()`.

This makes the script accept both of these forms:

- `CLEAN_BUILD="LDK BTCD"`
- `CLEAN_BUILD="-DLDK -DBTCD"`

## Why

The README currently documents the `-D...` form for selective clean:

```bash
CLEAN_BUILD="-DLDK -DBTCD" CXXFLAGS="-DLDK -DLND" ./auto_build.py
```

But in the custom clean path, `auto_build.py` was splitting raw tokens and using them directly as flags, which produces invalid module paths for values like `-DLDK`.

## Change

- add a small parser for custom `CLEAN_BUILD` values
- strip the `-D` prefix when present
- keep plain flag names working as before

## Verification

- `python -m py_compile auto_build.py`
- checked that both `"-DLDK -DBTCD"` and `"LDK BTCD"` normalize to `["LDK", "BTCD"]`
