### PR TITLE
main: reject missing FUZZ target during init

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -951,7 +951,7 @@ void Driver::Run(const uint8_t *data, const size_t size,
   } else if (target == "stump_modify_add") {
     this->StumpModifyAddTarget(buffer);
   } else {
-    std::cout << "Target not defined!" << std::endl;
+    std::cout << "Unknown target: " << target << std::endl;
     assert(false);
   }
 };

--- a/main.cpp
+++ b/main.cpp
@@ -2,12 +2,17 @@
 
 static std::shared_ptr<bitcoinfuzz::Driver> driver = nullptr;
 static bitcoinfuzz::ModuleLogger module_logger;
-static const char *g_target = nullptr;
+static std::string g_target;
 
 extern "C" int LLVMFuzzerInitialize([[maybe_unused]] int *argc,
                                     [[maybe_unused]] char ***argv) {
   bitcoinfuzz::InitializeRegistry();
-  g_target = std::getenv("FUZZ");
+  const char *target = std::getenv("FUZZ");
+  if (target == nullptr || target[0] == '\0') {
+    std::cerr << "FUZZ environment variable must be set" << std::endl;
+    std::exit(1);
+  }
+  g_target = target;
   driver = std::make_shared<bitcoinfuzz::Driver>(module_logger);
   bitcoinfuzz::LoadModules(driver, module_logger);
   return 0;


### PR DESCRIPTION
## Summary

Fail fast when `FUZZ` is missing or empty during fuzzer initialization.

## Why

`bitcoinfuzz` requires `FUZZ` to select the target to run. Previously, `main.cpp` read it with `std::getenv("FUZZ")` and stored the raw pointer directly. If `FUZZ` was unset, that left a null value flowing into target dispatch.

## Change

- store the target as a `std::string`
- validate that `FUZZ` is present and non-empty in `LLVMFuzzerInitialize()`
- print a clear error and exit early when it is missing
