### PR TITLE
tools: add listtargets.py to parse fuzz targets from driver.cpp

### DIFF
--- a/tests/test_listtargets.py
+++ b/tests/test_listtargets.py
@@ -1,0 +1,150 @@
+"""
+tests/test_listtargets.py
+
+Tests for tools/listtargets.py — ensures all known driver.cpp
+targets are parsed correctly.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Path to the tool and driver relative to repo root
+REPO_ROOT = Path(__file__).parent.parent
+TOOL_PATH = REPO_ROOT / "tools" / "listtargets.py"
+DRIVER_PATH = REPO_ROOT / "driver.cpp"
+
+# The exact count of targets in driver.cpp at the time of this PR.
+# Update this number if new targets are added.
+EXPECTED_TARGET_COUNT = 29
+
+# Spot-check: a sample of targets that must always be present.
+KNOWN_TARGETS = [
+    "address_parse",
+    "bip32_master_keygen",
+    "deserialize_block",
+    "deserialize_invoice",
+    "psbt_parse",
+    "script",
+    "script_eval",
+    "sign_schnorr",
+    "stump_modify_add",
+    "verify_script",
+]
+
+
+class TestListTargetsText:
+    """Tests for --format text (default) output."""
+
+    def run_tool(self, *args):
+        result = subprocess.run(
+            [sys.executable, str(TOOL_PATH), "--driver", str(DRIVER_PATH), *args],
+            capture_output=True,
+            text=True,
+        )
+        return result
+
+    def test_exits_zero(self):
+        result = self.run_tool()
+        assert result.returncode == 0, f"Tool exited with error: {result.stderr}"
+
+    def test_outputs_nonempty(self):
+        result = self.run_tool()
+        lines = [l for l in result.stdout.strip().splitlines() if l]
+        assert len(lines) > 0
+
+    def test_target_count(self):
+        result = self.run_tool()
+        lines = [l for l in result.stdout.strip().splitlines() if l]
+        assert len(lines) == EXPECTED_TARGET_COUNT, (
+            f"Expected {EXPECTED_TARGET_COUNT} targets, got {len(lines)}. "
+            f"Targets found: {lines}"
+        )
+
+    def test_known_targets_present(self):
+        result = self.run_tool()
+        lines = set(result.stdout.strip().splitlines())
+        for target in KNOWN_TARGETS:
+            assert target in lines, f"Expected target '{target}' not found"
+
+    def test_output_is_sorted(self):
+        result = self.run_tool()
+        lines = [l for l in result.stdout.strip().splitlines() if l]
+        assert lines == sorted(lines), "Output should be sorted alphabetically"
+
+    def test_no_duplicates(self):
+        result = self.run_tool()
+        lines = [l for l in result.stdout.strip().splitlines() if l]
+        assert len(lines) == len(set(lines)), "Output should have no duplicate targets"
+
+
+class TestListTargetsJSON:
+    """Tests for --format json output."""
+
+    def run_tool_json(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(TOOL_PATH),
+                "--driver",
+                str(DRIVER_PATH),
+                "--format",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        return json.loads(result.stdout)
+
+    def test_json_is_list(self):
+        targets = self.run_tool_json()
+        assert isinstance(targets, list)
+
+    def test_json_count(self):
+        targets = self.run_tool_json()
+        assert len(targets) == EXPECTED_TARGET_COUNT
+
+    def test_json_all_strings(self):
+        targets = self.run_tool_json()
+        assert all(isinstance(t, str) for t in targets)
+
+    def test_json_sorted(self):
+        targets = self.run_tool_json()
+        assert targets == sorted(targets)
+
+    def test_json_known_targets(self):
+        targets = self.run_tool_json()
+        for t in KNOWN_TARGETS:
+            assert t in targets
+
+
+class TestListTargetsEdgeCases:
+    """Edge case tests."""
+
+    def test_missing_driver_exits_nonzero(self, tmp_path):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(TOOL_PATH),
+                "--driver",
+                str(tmp_path / "nonexistent.cpp"),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "Error" in result.stderr or "not found" in result.stderr.lower()
+
+    def test_empty_file_exits_nonzero(self, tmp_path):
+        empty = tmp_path / "driver.cpp"
+        empty.write_text("")
+        result = subprocess.run(
+            [sys.executable, str(TOOL_PATH), "--driver", str(empty)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0

--- a/tools/listtargets.py
+++ b/tools/listtargets.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+tools/listtargets.py
+
+Parses driver.cpp's Run() dispatch block and outputs a list of
+all known fuzz target names.
+
+Usage:
+    python tools/listtargets.py
+    python tools/listtargets.py --format json
+    python tools/listtargets.py --driver path/to/driver.cpp
+"""
+
+import re
+import json
+import argparse
+import sys
+from pathlib import Path
+
+
+def parse_targets(driver_path: str = "driver.cpp") -> list[str]:
+    """
+    Parse all fuzz target names from the Run() dispatch block in driver.cpp.
+
+    Looks for patterns like:  target == "target_name"
+    Returns a sorted, deduplicated list of target name strings.
+    """
+    path = Path(driver_path)
+    if not path.exists():
+        raise FileNotFoundError(f"driver.cpp not found at: {path.resolve()}")
+
+    content = path.read_text(encoding="utf-8")
+
+    # Match: target == "some_target_name"
+    targets = re.findall(r'target\s*==\s*"([^"]+)"', content)
+
+    if not targets:
+        raise ValueError(
+            f"No targets found in {driver_path}. "
+            "Check that the file contains 'target == \"...\"' patterns."
+        )
+
+    return sorted(set(targets))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="List all fuzz targets defined in driver.cpp"
+    )
+    parser.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    parser.add_argument(
+        "--driver",
+        default="driver.cpp",
+        metavar="PATH",
+        help="Path to driver.cpp (default: driver.cpp)",
+    )
+    args = parser.parse_args()
+
+    try:
+        targets = parse_targets(args.driver)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.format == "json":
+        print(json.dumps(targets, indent=2))
+    else:
+        for target in targets:
+            print(target)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

I’ve added `tools/listtargets.py`, a standalone Python script that parses the `Run()` dispatch block in `driver.cpp` and lists all known fuzz target names. You can get the output in either text or JSON format.

This is the competency test deliverable for the **MCP Server for bitcoinfuzz** project (Summer of Bitcoin 2026).

## Usage

Here’s how you can use it:

```bash
# Default output (text format)
python tools/listtargets.py

# Output in JSON format
python tools/listtargets.py --format json

# Use a custom path for the driver file
python tools/listtargets.py --driver path/to/driver.cpp --format json


## Sample output

```json
[
  "bip32_master_keygen",
  "deserialize_block",
  "deserialize_invoice",
  ...
]
```

## Testing

```bash
pytest tests/test_listtargets.py -v
```

All 13 tests pass across 3 test classes:
- **Text output** (6 tests): count, known targets, sorted, no duplicates
- **JSON output** (5 tests): valid JSON, count, all strings, sorted, known targets  
- **Edge cases** (2 tests): missing file exits non-zero, empty file exits non-zero

## Notes

- The SoB competency description mentions 28 targets; `driver.cpp` currently
  has **29 targets** (lines 892–957). This script reflects the actual codebase.
- This script is designed as the foundation for the MCP Server's `listtargets`
  tool — tested independently here before MCP framing is added.