### PR TITLE
driver: scope NBitcoin PSBT workaround and avoid early target exit

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -73,8 +73,10 @@ void Driver::ScriptEvalTarget(std::span<const uint8_t> buffer) const {
 #endif
 
 #ifdef NBITCOIN
-  if (std::ranges::find(input_data, 0xB2) != input_data.end())
-    return;
+  if (ModuleRegistry::instance().isEnabled("NBITCOIN")) {
+    if (std::ranges::find(input_data, 0xB2) != input_data.end())
+      return;
+  }
 #endif
 
   auto flags = provider.ConsumeIntegral<unsigned int>();
@@ -263,10 +265,11 @@ void Driver::PSBTParseTarget(std::span<const uint8_t> buffer) const {
       continue;
 
 #ifdef NBITCOIN
-    if (ModuleRegistry::instance().isEnabled("NBITCOIN")) {
+    if (module.first == "NBitcoin" &&
+        ModuleRegistry::instance().isEnabled("NBITCOIN")) {
       if (res->find("in=0") != std::string::npos ||
           res->find("out=0") != std::string::npos)
-        return;
+        continue;
     }
 #endif
 


### PR DESCRIPTION
This PR fixes a control-flow issue in `Driver::PSBTParseTarget` (`driver.cpp`).

Before this change, when NBitcoin-specific PSBT output contained `in=0` or `out=0`, the code used `return;` inside the module loop. That exited the whole target early and skipped comparisons for remaining loaded modules.

Changes:
- scope the workaround to NBitcoin module output (`module.first == "NBitcoin"`).
- replace `return` with `continue` so only that module result is skipped while other module comparisons continue.

How this might help:
early target exit can hide downstream mismatches, reducing differential fuzzing effectiveness by giving false negatives.

Validation (WSL/Linux):
- A/B check with old logic reproduced failure:
  `Assertion 'reference->psbt_calls == 1' failed.`
- with this fix:
  `driver psbt nbitcoin regression tests: PASS`

attached `test_driver_psbt_nbitcoin_regression.cpp` to lock this behavior.
[test_driver_psbt_nbitcoin_regression.txt](https://github.com/user-attachments/files/26665711/test_driver_psbt_nbitcoin_regression.txt)

The test uses a minimal `CountingPSBTModule` mock and checks:
1. NBitcoin `in=0` output is skipped **without** aborting comparisons for later modules.
2. Non-NBitcoin modules returning `in=0` are **not** filtered by the NBitcoin workaround.

This catches the old `return` behavior (loop abort) and validates the new `continue` behavior.
