### PR TITLE
Add listtargets helper script

### DIFF
--- a/tests/test_listtargets.py
+++ b/tests/test_listtargets.py
@@ -1,0 +1,58 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from tools.listtargets import extract_targets
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "tools" / "listtargets.py"
+DRIVER_PATH = REPO_ROOT / "driver.cpp"
+EXPECTED_TARGETS = [
+    "script",
+    "deserialize_block",
+    "script_eval",
+    "verify_script",
+    "descriptor_parse",
+    "miniscript_parse",
+    "deserialize_invoice",
+    "address_parse",
+    "psbt_parse",
+    "addrv2",
+    "deserialize_offer",
+    "cmpctblocks_parse",
+    "parse_p2p_message",
+    "parse_p2p_lightning_message",
+    "transaction_eval",
+    "bip32_master_keygen",
+    "kernel_block",
+    "kernel_transaction",
+    "private_to_public_key",
+    "sign_compact",
+    "sign_der",
+    "sign_verify",
+    "ecdh",
+    "sign_schnorr",
+    "bip32_deserialize_extended_key",
+    "decode_ellswift",
+    "schnorr_verify",
+    "decode_onion",
+    "stump_modify_add",
+]
+
+
+def test_extract_targets_matches_driver_dispatch():
+    assert extract_targets(DRIVER_PATH) == EXPECTED_TARGETS
+
+
+def test_cli_json_output():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--format=json"],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert json.loads(result.stdout) == EXPECTED_TARGETS

--- a/tools/listtargets.py
+++ b/tools/listtargets.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""List bitcoinfuzz targets by parsing the Driver::Run dispatch block."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+RUN_BLOCK_PATTERN = re.compile(
+    r"void Driver::Run\(.*?\) const \{(?P<body>.*?)\n\};",
+    re.DOTALL,
+)
+TARGET_PATTERN = re.compile(r'target == "([^"]+)"')
+
+
+def default_driver_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "driver.cpp"
+
+
+def extract_targets(driver_path: Path) -> list[str]:
+    source = driver_path.read_text(encoding="utf-8")
+    match = RUN_BLOCK_PATTERN.search(source)
+    if match is None:
+        raise ValueError(f"Could not locate Driver::Run dispatch block in {driver_path}")
+
+    targets = TARGET_PATTERN.findall(match.group("body"))
+    if not targets:
+        raise ValueError(f"Could not find any targets in {driver_path}")
+
+    return targets
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Parse driver.cpp and list supported bitcoinfuzz targets."
+    )
+    parser.add_argument(
+        "--driver",
+        type=Path,
+        default=default_driver_path(),
+        help="Path to driver.cpp (defaults to the repo root driver.cpp).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        targets = extract_targets(args.driver)
+    except (OSError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if args.format == "json":
+        json.dump(targets, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        for target in targets:
+            print(target)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This PR adds a standalone helper script at tools/listtargets.py that parses the Driver::Run() dispatch block in driver.cpp and outputs the available fuzz targets.

It includes:

--format=json support for machine-readable output
a reusable parsing function for future tooling
a pytest test covering both direct parsing and CLI JSON output