### PR TITLE
Fix race condition in auto_build

### DIFF
--- a/auto_build.py
+++ b/auto_build.py
@@ -116,7 +116,7 @@ def build_module(flag: str, quiet: bool):
     if needs_rust_nightly(flag):
         execute_in_dir(
             dirpath,
-            "rustup default nightly && make",
+            "RUSTUP_TOOLCHAIN=nightly make",
             quiet,
         )
     else:


### PR DESCRIPTION
I came across this issue while trying to resolve CI build errors of #531
Basically `rustup default nightly` works by reading, modifying, and writing ~/.rustup/settings.toml, a plain TOML file on disk. There is no file locking on this operation.
When multiple threads race to run rustup default nightly simultaneously, one process can truncate the file to begin writing while another is mid-read, leaving it empty or partially written. This produces the error:
```
error: could not parse settings file: '/home/runner/.rustup/settings.toml':
TOML parse error at line 1, column 1
  |
1 |
  | ^
missing field `version`
```
`RUSTUP_TOOLCHAIN=nightly` is an environment variable that tells cargo/rustup which toolchain to use for that process only, without touching settings.toml at all. This eliminates the race condition entirely: no shared file is written, parallel builds are safe.

