### PR TITLE
Add ubsan msan ci

### DIFF
--- a/.github/workflows/msan.yml
+++ b/.github/workflows/msan.yml
@@ -1,0 +1,66 @@
+name: MSan
+
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  msan:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - corpus: "script"
+            target: "script"
+            cxxflags: "-DBITCOIN_CORE"
+          - corpus: "private_to_public_key"
+            target: "private_to_public_key"
+            cxxflags: "-DSECP256K1"
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Checkout corpora repo
+        uses: actions/checkout@v4
+        with:
+          repository: bitcoinfuzz/corpora
+          path: corpora
+          ref: main
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang \
+            libc++-dev \
+            libc++abi-dev \
+            lowdown \
+            libsodium-dev \
+            libboost-all-dev
+
+      - name: Setup common environment
+        run: |
+          echo "CC=/usr/bin/clang" >> $GITHUB_ENV
+          echo "CXX=/usr/bin/clang++" >> $GITHUB_ENV
+
+      - name: Build and run MSan smoke target
+        timeout-minutes: 20
+        env:
+          BASE_SANITIZERS: "memory,fuzzer"
+          MODULE_SANITIZERS: "memory,fuzzer"
+          MODULE_NO_LINK_SANITIZERS: "memory,fuzzer-no-link"
+          MSAN_OPTIONS: "halt_on_error=1:print_stats=1:poison_in_dtor=1"
+        run: |
+          export CXX=/usr/bin/clang++
+          export CXXFLAGS="-stdlib=libc++ -fno-omit-frame-pointer -g"
+          export LDFLAGS="-stdlib=libc++"
+          FUZZ=${{ matrix.test.target }} ./.github/scripts/run-fuzz.sh "${{ matrix.test.corpus }}" "${{ matrix.test.target }}" "${{ matrix.test.cxxflags }}" "" "$CXX"

--- a/.github/workflows/msan.yml
+++ b/.github/workflows/msan.yml
@@ -51,8 +51,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             clang \
-            libc++-dev \
-            libc++abi-dev \
             lowdown \
             libsodium-dev \
             libboost-all-dev
@@ -68,9 +66,8 @@ jobs:
           BASE_SANITIZERS: "memory,fuzzer"
           MODULE_SANITIZERS: "memory,fuzzer"
           MODULE_NO_LINK_SANITIZERS: "memory,fuzzer-no-link"
-          CXXFLAGS: "${{ matrix.test.cxxflags }} -stdlib=libc++ -fno-omit-frame-pointer -g"
+          CXXFLAGS: "${{ matrix.test.cxxflags }} -fno-omit-frame-pointer -g"
           ONLY_MODULES: "1"
-          LDFLAGS: "-stdlib=libc++"
         run: |
           python3 ./auto_build.py
         shell: bash
@@ -85,5 +82,4 @@ jobs:
           MSAN_OPTIONS: "halt_on_error=1:print_stats=1:poison_in_dtor=1"
         run: |
           export CXX=/usr/bin/clang++
-          export LDFLAGS="-stdlib=libc++"
-          FUZZ=${{ matrix.test.target }} ./.github/scripts/run-fuzz.sh "${{ matrix.test.corpus }}" "${{ matrix.test.target }}" "${{ matrix.test.cxxflags }} -stdlib=libc++ -fno-omit-frame-pointer -g" "" "$CXX"
+          FUZZ=${{ matrix.test.target }} ./.github/scripts/run-fuzz.sh "${{ matrix.test.corpus }}" "${{ matrix.test.target }}" "${{ matrix.test.cxxflags }} -fno-omit-frame-pointer -g" "" "$CXX"

--- a/.github/workflows/msan.yml
+++ b/.github/workflows/msan.yml
@@ -36,6 +36,16 @@ jobs:
           path: corpora
           ref: main
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python build helpers
+        run: |
+          python -m pip install --upgrade pip
+          pip install mako
+
       - name: Install build dependencies
         run: |
           sudo apt-get update
@@ -52,6 +62,20 @@ jobs:
           echo "CC=/usr/bin/clang" >> $GITHUB_ENV
           echo "CXX=/usr/bin/clang++" >> $GITHUB_ENV
 
+      - name: Build selected modules with MSan
+        timeout-minutes: 20
+        env:
+          BASE_SANITIZERS: "memory,fuzzer"
+          MODULE_SANITIZERS: "memory,fuzzer"
+          MODULE_NO_LINK_SANITIZERS: "memory,fuzzer-no-link"
+          CXXFLAGS: "${{ matrix.test.cxxflags }} -stdlib=libc++ -fno-omit-frame-pointer -g"
+          ONLY_MODULES: "1"
+          LDFLAGS: "-stdlib=libc++"
+        run: |
+          python3 ./auto_build.py
+        shell: bash
+        working-directory: ${{ github.workspace }}
+
       - name: Build and run MSan smoke target
         timeout-minutes: 20
         env:
@@ -61,6 +85,5 @@ jobs:
           MSAN_OPTIONS: "halt_on_error=1:print_stats=1:poison_in_dtor=1"
         run: |
           export CXX=/usr/bin/clang++
-          export CXXFLAGS="-stdlib=libc++ -fno-omit-frame-pointer -g"
           export LDFLAGS="-stdlib=libc++"
-          FUZZ=${{ matrix.test.target }} ./.github/scripts/run-fuzz.sh "${{ matrix.test.corpus }}" "${{ matrix.test.target }}" "${{ matrix.test.cxxflags }}" "" "$CXX"
+          FUZZ=${{ matrix.test.target }} ./.github/scripts/run-fuzz.sh "${{ matrix.test.corpus }}" "${{ matrix.test.target }}" "${{ matrix.test.cxxflags }} -stdlib=libc++ -fno-omit-frame-pointer -g" "" "$CXX"

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -1,0 +1,79 @@
+name: UBSan
+
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  ubsan:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - corpus: "script"
+            target: "script"
+            cxxflags: "-DBITCOIN_CORE"
+          - corpus: "private_to_public_key"
+            target: "private_to_public_key"
+            cxxflags: "-DSECP256K1"
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Checkout corpora repo
+        uses: actions/checkout@v4
+        with:
+          repository: bitcoinfuzz/corpora
+          path: corpora
+          ref: main
+
+      - name: Install go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lowdown libsodium-dev libboost-all-dev
+
+      - name: Setup common environment
+        run: |
+          echo "CC=/usr/bin/clang" >> $GITHUB_ENV
+          echo "CXX=/usr/bin/clang++" >> $GITHUB_ENV
+
+      - name: Build and run UBSan smoke target
+        timeout-minutes: 20
+        env:
+          BASE_SANITIZERS: "undefined,fuzzer"
+          MODULE_SANITIZERS: "undefined,fuzzer"
+          MODULE_NO_LINK_SANITIZERS: "undefined,fuzzer-no-link"
+          UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
+        run: |
+          export CXX=/usr/bin/clang++
+          FUZZ=${{ matrix.test.target }} ./.github/scripts/run-fuzz.sh "${{ matrix.test.corpus }}" "${{ matrix.test.target }}" "${{ matrix.test.cxxflags }}" "" "$CXX"

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -57,6 +57,11 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install Python build helpers
+        run: |
+          python -m pip install --upgrade pip
+          pip install mako
+
       - name: Install build dependencies
         run: |
           sudo apt-get update
@@ -66,6 +71,19 @@ jobs:
         run: |
           echo "CC=/usr/bin/clang" >> $GITHUB_ENV
           echo "CXX=/usr/bin/clang++" >> $GITHUB_ENV
+
+      - name: Build selected modules with UBSan
+        timeout-minutes: 20
+        env:
+          BASE_SANITIZERS: "undefined,fuzzer"
+          MODULE_SANITIZERS: "undefined,fuzzer"
+          MODULE_NO_LINK_SANITIZERS: "undefined,fuzzer-no-link"
+          CXXFLAGS: ${{ matrix.test.cxxflags }}
+          ONLY_MODULES: "1"
+        run: |
+          python3 ./auto_build.py
+        shell: bash
+        working-directory: ${{ github.workspace }}
 
       - name: Build and run UBSan smoke target
         timeout-minutes: 20

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,9 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=fuzz-pip \
 
 # Get the source
 COPY . .
+RUN find /build \
+    \( -name "*.sh" -o -name "*.py" -o -name "gradlew" \) \
+    -type f -exec sed -i 's/\r$//' {} +
 
 # Lastly envs
 ENV CC=/usr/bin/clang-18 \
@@ -92,7 +95,7 @@ RUN \
     --mount=type=cache,target=/root/.rustup,id=fuzz-rustup \
     --mount=type=cache,target=/root/go/pkg/mod,id=fuzz-go-mod \
     export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-$(dpkg --print-architecture) && \
-    /build/auto_build.py
+    python3 /build/auto_build.py
 
 FROM base AS runner
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 all: bitcoinfuzz
 
-BASE_CXXFLAGS := -fsanitize=address,fuzzer -Wall -Wextra -std=c++20 -I include -I .
+BASE_SANITIZERS ?= address,fuzzer
+BASE_CXXFLAGS := -fsanitize=$(BASE_SANITIZERS) -Wall -Wextra -std=c++20 -I include -I .
 UNAME_S := $(shell uname -s)
 BITCOINFUZZ_SRC := basemodule modulelogger
 BITCOINFUZZ_OBJS := $(addprefix include/bitcoinfuzz/, $(addsuffix .o, $(BITCOINFUZZ_SRC)))

--- a/bitcoinfuzz.sln
+++ b/bitcoinfuzz.sln
@@ -1,0 +1,52 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "modules", "modules", "{CA253913-39DE-BFD0-C9A3-4B7EC6FBDF17}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nbitcoin", "nbitcoin", "{85DF0AA6-0A87-1875-5553-FE68BCCEEEF2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBitcoin.CppBridge", "modules\nbitcoin\NBitcoin.CppBridge.csproj", "{2FE5ADA6-CE4B-4463-6B55-BEB35A66F9CD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nbitcoinsecp256k1", "nbitcoinsecp256k1", "{406B0FFA-A7D8-5939-1A44-F300C3C6468E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBitcoinSecp256k1.CppBridge", "modules\nbitcoinsecp256k1\NBitcoinSecp256k1.CppBridge.csproj", "{7F30188F-D86B-DEED-295A-1C374E88C475}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nlightning", "nlightning", "{9F83666B-CEE6-D499-BC47-D706BEFD868B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLightning.CppBridge", "modules\nlightning\NLightning.CppBridge.csproj", "{C4789F9B-FC6F-E5AD-5AEF-6BBB58D52791}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2FE5ADA6-CE4B-4463-6B55-BEB35A66F9CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FE5ADA6-CE4B-4463-6B55-BEB35A66F9CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2FE5ADA6-CE4B-4463-6B55-BEB35A66F9CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2FE5ADA6-CE4B-4463-6B55-BEB35A66F9CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F30188F-D86B-DEED-295A-1C374E88C475}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F30188F-D86B-DEED-295A-1C374E88C475}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F30188F-D86B-DEED-295A-1C374E88C475}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F30188F-D86B-DEED-295A-1C374E88C475}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4789F9B-FC6F-E5AD-5AEF-6BBB58D52791}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4789F9B-FC6F-E5AD-5AEF-6BBB58D52791}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4789F9B-FC6F-E5AD-5AEF-6BBB58D52791}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4789F9B-FC6F-E5AD-5AEF-6BBB58D52791}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{85DF0AA6-0A87-1875-5553-FE68BCCEEEF2} = {CA253913-39DE-BFD0-C9A3-4B7EC6FBDF17}
+		{2FE5ADA6-CE4B-4463-6B55-BEB35A66F9CD} = {85DF0AA6-0A87-1875-5553-FE68BCCEEEF2}
+		{406B0FFA-A7D8-5939-1A44-F300C3C6468E} = {CA253913-39DE-BFD0-C9A3-4B7EC6FBDF17}
+		{7F30188F-D86B-DEED-295A-1C374E88C475} = {406B0FFA-A7D8-5939-1A44-F300C3C6468E}
+		{9F83666B-CEE6-D499-BC47-D706BEFD868B} = {CA253913-39DE-BFD0-C9A3-4B7EC6FBDF17}
+		{C4789F9B-FC6F-E5AD-5AEF-6BBB58D52791} = {9F83666B-CEE6-D499-BC47-D706BEFD868B}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A44DE5E5-AD96-49F1-AEF6-879A5D2D540F}
+	EndGlobalSection
+EndGlobal

--- a/modules/bitcoin/Makefile
+++ b/modules/bitcoin/Makefile
@@ -1,6 +1,8 @@
 all: module.a
 
 SYMBOL_PREFIX ?= bitcoin_core
+MODULE_SANITIZERS ?= address,fuzzer
+MODULE_NO_LINK_SANITIZERS ?= address,fuzzer-no-link
 
 # Detect objcopy command
 OBJCOPY := $(shell command -v objcopy 2> /dev/null)
@@ -14,7 +16,7 @@ UNIVALUE_DIR = $(BITCOIN_SRC)/univalue
 LEVELDB_DIR = $(BITCOIN_SRC)/leveldb
 
 CXXFLAGS += -Wall -Wextra -std=c++20 \
-            -fsanitize=fuzzer,address \
+            -fsanitize=$(MODULE_SANITIZERS) \
             -I . \
             -I $(BITCOIN_SRC) \
             -I ../../include \
@@ -175,7 +177,7 @@ $(SECP256K1_LIB):
 		--enable-module-musig \
 		--disable-shared \
 		--with-pic \
-		CFLAGS="-fsanitize=address,fuzzer-no-link" && \
+		CFLAGS="-fsanitize=$(MODULE_NO_LINK_SANITIZERS)" && \
 	$(MAKE)
 	@test -f $(SECP256K1_LIB) || { echo "ERROR: $(SECP256K1_LIB) not created"; exit 1; }
 
@@ -185,7 +187,7 @@ UNIVALUE_OBJS := $(addprefix build/univalue/, $(UNIVALUE_SRCS:.cpp=.o))
 
 build/univalue/%.o: $(UNIVALUE_DIR)/lib/%.cpp
 	@mkdir -p $(dir $@)
-	$(CXX) -std=c++20 -fPIC -fsanitize=fuzzer-no-link -I$(UNIVALUE_DIR)/include -c $< -o $@
+	$(CXX) -std=c++20 -fPIC -fsanitize=$(MODULE_NO_LINK_SANITIZERS) -I$(UNIVALUE_DIR)/include -c $< -o $@
 
 $(UNIVALUE_LIB): $(UNIVALUE_OBJS)
 	@echo "Building univalue..."

--- a/modules/secp256k1/Makefile
+++ b/modules/secp256k1/Makefile
@@ -1,7 +1,10 @@
 all: module.a
 
+MODULE_SANITIZERS ?= address,fuzzer
+MODULE_NO_LINK_SANITIZERS ?= address,fuzzer-no-link
+
 CXXFLAGS += -Wall -Wextra -std=c++20 \
-            -fsanitize=fuzzer,address \
+            -fsanitize=$(MODULE_SANITIZERS) \
             -I . \
             -I ../../include \
             -I /opt/homebrew/include \
@@ -20,7 +23,7 @@ $(SECP256K1_LIB):
 		--enable-module-schnorrsig \
 		--disable-shared \
 		--with-pic \
-		CFLAGS="-fsanitize=address,fuzzer-no-link" && \
+		CFLAGS="-fsanitize=$(MODULE_NO_LINK_SANITIZERS)" && \
 	$(MAKE)
 
 module.a: $(SECP256K1_LIB) module.o

--- a/tests/test_listtargets.py
+++ b/tests/test_listtargets.py
@@ -1,0 +1,58 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from tools.listtargets import extract_targets
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "tools" / "listtargets.py"
+DRIVER_PATH = REPO_ROOT / "driver.cpp"
+EXPECTED_TARGETS = [
+    "script",
+    "deserialize_block",
+    "script_eval",
+    "verify_script",
+    "descriptor_parse",
+    "miniscript_parse",
+    "deserialize_invoice",
+    "address_parse",
+    "psbt_parse",
+    "addrv2",
+    "deserialize_offer",
+    "cmpctblocks_parse",
+    "parse_p2p_message",
+    "parse_p2p_lightning_message",
+    "transaction_eval",
+    "bip32_master_keygen",
+    "kernel_block",
+    "kernel_transaction",
+    "private_to_public_key",
+    "sign_compact",
+    "sign_der",
+    "sign_verify",
+    "ecdh",
+    "sign_schnorr",
+    "bip32_deserialize_extended_key",
+    "decode_ellswift",
+    "schnorr_verify",
+    "decode_onion",
+    "stump_modify_add",
+]
+
+
+def test_extract_targets_matches_driver_dispatch():
+    assert extract_targets(DRIVER_PATH) == EXPECTED_TARGETS
+
+
+def test_cli_json_output():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--format=json"],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert json.loads(result.stdout) == EXPECTED_TARGETS

--- a/tools/listtargets.py
+++ b/tools/listtargets.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""List bitcoinfuzz targets by parsing the Driver::Run dispatch block."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+RUN_BLOCK_PATTERN = re.compile(
+    r"void Driver::Run\(.*?\) const \{(?P<body>.*?)\n\};",
+    re.DOTALL,
+)
+TARGET_PATTERN = re.compile(r'target == "([^"]+)"')
+
+
+def default_driver_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "driver.cpp"
+
+
+def extract_targets(driver_path: Path) -> list[str]:
+    source = driver_path.read_text(encoding="utf-8")
+    match = RUN_BLOCK_PATTERN.search(source)
+    if match is None:
+        raise ValueError(f"Could not locate Driver::Run dispatch block in {driver_path}")
+
+    targets = TARGET_PATTERN.findall(match.group("body"))
+    if not targets:
+        raise ValueError(f"Could not find any targets in {driver_path}")
+
+    return targets
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Parse driver.cpp and list supported bitcoinfuzz targets."
+    )
+    parser.add_argument(
+        "--driver",
+        type=Path,
+        default=default_driver_path(),
+        help="Path to driver.cpp (defaults to the repo root driver.cpp).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        targets = extract_targets(args.driver)
+    except (OSError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if args.format == "json":
+        json.dump(targets, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        for target in targets:
+            print(target)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Description
This PR adds experimental CI support for UBSan and MSan on a small supported subset of `bitcoinfuzz` targets/modules.

### What changed
- adds a dedicated `UBSan` GitHub Actions workflow
- adds a dedicated `MSan` GitHub Actions workflow
- makes sanitizer selection configurable in the top-level build
- makes the `bitcoin` and `secp256k1` module builds accept configurable sanitizer flags

### Initial scope
To keep the first iteration reviewable and reduce false failures in the mixed-language build matrix, the new sanitizer lanes are intentionally limited to a pure C/C++-leaning subset:
- `script` with `BITCOIN_CORE`
- `private_to_public_key` with `SECP256K1`

## Motivation and Context
`bitcoinfuzz` currently relies primarily on ASan-centered fuzzing builds. That catches many memory safety issues, but it leaves other important bug classes under-tested in CI:
- undefined behavior issues that UBSan can catch
- uninitialized memory usage that MSan can catch

Because this repository integrates multiple runtimes and languages, enabling these sanitizers across the full matrix at once would be brittle. This PR introduces a narrow, explicit first step by adding sanitizer coverage for supported core/module subsets and making sanitizer flags configurable for those builds.

## How Has This Been Tested?
- validated workflow YAML and sanitizer flag wiring locally by inspection
- confirmed new sanitizer knobs are plumbed through:
  - top-level `Makefile`
  - `modules/bitcoin/Makefile`
  - `modules/secp256k1/Makefile`

CI validation still needs to come from GitHub Actions on this branch, especially for the experimental MSan lane.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Non-functional change (CI/build tooling)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
