### PR TITLE
java modules: harden JVM init failure paths

### DIFF
--- a/modules/bitcoinj/module.cpp
+++ b/modules/bitcoinj/module.cpp
@@ -17,6 +17,12 @@ static jclass bitcoinJWrapperClass = nullptr;
 static jmethodID createMasterKeyMethod = nullptr;
 static jmethodID deserializeExtendedKeyMethod = nullptr;
 
+static void clear_pending_exception(JNIEnv *env) {
+  if (env->ExceptionCheck()) {
+    env->ExceptionClear();
+  }
+}
+
 static bool init_jvm() {
   if (jvm_initialized) {
     return true;
@@ -33,25 +39,38 @@ static bool init_jvm() {
     return false;
   }
 
-  bitcoinJWrapperClass = env->FindClass("wrapper/Wrapper");
-  if (!bitcoinJWrapperClass) {
-    return false;
-  }
-  bitcoinJWrapperClass =
-      static_cast<jclass>(env->NewGlobalRef(bitcoinJWrapperClass));
-
-  createMasterKeyMethod = env->GetStaticMethodID(
-      bitcoinJWrapperClass, "createMasterKey", "([B)Ljava/lang/String;");
-  if (!createMasterKeyMethod) {
+  jclass localWrapperClass = env->FindClass("wrapper/Wrapper");
+  if (!localWrapperClass) {
+    clear_pending_exception(env);
     return false;
   }
 
-  deserializeExtendedKeyMethod = env->GetStaticMethodID(
-      bitcoinJWrapperClass, "deserializeExtendedKey", "([B)Ljava/lang/String;");
-  if (!deserializeExtendedKeyMethod) {
+  jclass globalWrapperClass =
+      static_cast<jclass>(env->NewGlobalRef(localWrapperClass));
+  env->DeleteLocalRef(localWrapperClass);
+  if (!globalWrapperClass) {
     return false;
   }
 
+  jmethodID createMasterKeyMethodRef = env->GetStaticMethodID(
+      globalWrapperClass, "createMasterKey", "([B)Ljava/lang/String;");
+  if (!createMasterKeyMethodRef) {
+    clear_pending_exception(env);
+    env->DeleteGlobalRef(globalWrapperClass);
+    return false;
+  }
+
+  jmethodID deserializeExtendedKeyMethodRef = env->GetStaticMethodID(
+      globalWrapperClass, "deserializeExtendedKey", "([B)Ljava/lang/String;");
+  if (!deserializeExtendedKeyMethodRef) {
+    clear_pending_exception(env);
+    env->DeleteGlobalRef(globalWrapperClass);
+    return false;
+  }
+
+  bitcoinJWrapperClass = globalWrapperClass;
+  createMasterKeyMethod = createMasterKeyMethodRef;
+  deserializeExtendedKeyMethod = deserializeExtendedKeyMethodRef;
   jvm_initialized = true;
   return true;
 }

--- a/modules/eclair/module.cpp
+++ b/modules/eclair/module.cpp
@@ -61,8 +61,9 @@ static bool init_jvm() {
     return false;
   }
 
-  jmethodID decodeOfferMethodRef = env->GetStaticMethodID(
-      globalDecoderClass, "decodeOffer", "(Ljava/lang/String;)Ljava/lang/String;");
+  jmethodID decodeOfferMethodRef =
+      env->GetStaticMethodID(globalDecoderClass, "decodeOffer",
+                             "(Ljava/lang/String;)Ljava/lang/String;");
   if (!decodeOfferMethodRef) {
     clear_pending_exception(env);
     env->DeleteGlobalRef(globalDecoderClass);

--- a/modules/eclair/module.cpp
+++ b/modules/eclair/module.cpp
@@ -11,51 +11,82 @@
 namespace fs = std::filesystem;
 
 static JavaVM *jvm = nullptr;
+static bool jvm_initialized = false;
 static jclass decoderClass = nullptr;
 static jmethodID decodeBolt11InvoiceMethod = nullptr;
 static jmethodID decodeOfferMethod = nullptr;
 
 static std::string cached_classpath;
 
+static void clear_pending_exception(JNIEnv *env) {
+  if (env->ExceptionCheck()) {
+    env->ExceptionClear();
+  }
+}
+
 static bool init_jvm() {
-  if (jvm != nullptr)
+  if (jvm_initialized)
     return true;
 
   jvm = JvmLoader::get_jvm();
+  if (!jvm) {
+    return false;
+  }
+
   JNIEnv *env = nullptr;
   jint ge = jvm->GetEnv((void **)&env, JNI_VERSION_1_8);
-
-  decoderClass = env->FindClass("EclairWrapper");
-  if (!decoderClass) {
+  if (ge != JNI_OK || !env) {
     return false;
   }
 
-  decoderClass = static_cast<jclass>(env->NewGlobalRef(decoderClass));
+  jclass localDecoderClass = env->FindClass("EclairWrapper");
+  if (!localDecoderClass) {
+    clear_pending_exception(env);
+    return false;
+  }
 
-  decodeBolt11InvoiceMethod =
-      env->GetStaticMethodID(decoderClass, "decodeBolt11Invoice",
+  jclass globalDecoderClass =
+      static_cast<jclass>(env->NewGlobalRef(localDecoderClass));
+  env->DeleteLocalRef(localDecoderClass);
+  if (!globalDecoderClass) {
+    return false;
+  }
+
+  jmethodID decodeBolt11InvoiceMethodRef =
+      env->GetStaticMethodID(globalDecoderClass, "decodeBolt11Invoice",
                              "(Ljava/lang/String;)Ljava/lang/String;");
-  if (!decodeBolt11InvoiceMethod) {
+  if (!decodeBolt11InvoiceMethodRef) {
+    clear_pending_exception(env);
+    env->DeleteGlobalRef(globalDecoderClass);
     return false;
   }
 
-  decodeOfferMethod = env->GetStaticMethodID(
-      decoderClass, "decodeOffer", "(Ljava/lang/String;)Ljava/lang/String;");
-  if (!decodeOfferMethod) {
+  jmethodID decodeOfferMethodRef = env->GetStaticMethodID(
+      globalDecoderClass, "decodeOffer", "(Ljava/lang/String;)Ljava/lang/String;");
+  if (!decodeOfferMethodRef) {
+    clear_pending_exception(env);
+    env->DeleteGlobalRef(globalDecoderClass);
     return false;
   }
 
+  decoderClass = globalDecoderClass;
+  decodeBolt11InvoiceMethod = decodeBolt11InvoiceMethodRef;
+  decodeOfferMethod = decodeOfferMethodRef;
+  jvm_initialized = true;
   return true;
 }
 
 static std::optional<std::string>
 eclair_decode_invoice(const char *invoiceStr) {
   if (!init_jvm() || !jvm) {
-    std::abort();
+    return "";
   }
 
   JNIEnv *env = nullptr;
   jint status = jvm->GetEnv((void **)&env, JNI_VERSION_1_8);
+  if (status != JNI_OK || !env) {
+    return "";
+  }
 
   jstring jInvoiceStr = env->NewStringUTF(invoiceStr);
   if (!jInvoiceStr) {
@@ -92,11 +123,14 @@ eclair_decode_invoice(const char *invoiceStr) {
 
 static std::optional<std::string> eclair_decode_offer(const char *offerStr) {
   if (!init_jvm() || !jvm) {
-    std::abort();
+    return "";
   }
 
   JNIEnv *env = nullptr;
   jint status = jvm->GetEnv((void **)&env, JNI_VERSION_1_8);
+  if (status != JNI_OK || !env) {
+    return "";
+  }
 
   jstring jOfferStr = env->NewStringUTF(offerStr);
   if (!jOfferStr) {

--- a/modules/lightningkmp/module.cpp
+++ b/modules/lightningkmp/module.cpp
@@ -136,8 +136,8 @@ lightning_kmp_decode_offer(const char *offerStr) {
     return "";
   }
 
-  jstring jResult = static_cast<jstring>(env->CallStaticObjectMethod(
-      decoderClass, decodeMethodOffer, jOfferStr));
+  jstring jResult = static_cast<jstring>(
+      env->CallStaticObjectMethod(decoderClass, decodeMethodOffer, jOfferStr));
   env->DeleteLocalRef(jOfferStr);
 
   if (!jResult) {

--- a/modules/lightningkmp/module.cpp
+++ b/modules/lightningkmp/module.cpp
@@ -12,40 +12,68 @@
 namespace fs = std::filesystem;
 
 static JavaVM *jvm = nullptr;
+static bool jvm_initialized = false;
 static jclass decoderClass = nullptr;
 static jmethodID decodeMethodInvoice = nullptr;
 static jmethodID decodeMethodOffer = nullptr;
 
+static void clear_pending_exception(JNIEnv *env) {
+  if (env->ExceptionCheck()) {
+    env->ExceptionClear();
+  }
+}
+
 static bool init_jvm() {
-  if (jvm != nullptr) {
+  if (jvm_initialized) {
     return true;
   }
 
   jvm = JvmLoader::get_jvm();
+  if (!jvm) {
+    return false;
+  }
+
   JNIEnv *env = nullptr;
   jint ge = jvm->GetEnv((void **)&env, JNI_VERSION_1_8);
-
-  decoderClass = env->FindClass("wrapper/Wrapper");
-  if (!decoderClass) {
+  if (ge != JNI_OK || !env) {
     return false;
   }
 
-  decoderClass = static_cast<jclass>(env->NewGlobalRef(decoderClass));
+  jclass localDecoderClass = env->FindClass("wrapper/Wrapper");
+  if (!localDecoderClass) {
+    clear_pending_exception(env);
+    return false;
+  }
 
-  decodeMethodInvoice =
-      env->GetStaticMethodID(decoderClass, "decodeBolt11Invoice",
+  jclass globalDecoderClass =
+      static_cast<jclass>(env->NewGlobalRef(localDecoderClass));
+  env->DeleteLocalRef(localDecoderClass);
+  if (!globalDecoderClass) {
+    return false;
+  }
+
+  jmethodID decodeMethodInvoiceRef =
+      env->GetStaticMethodID(globalDecoderClass, "decodeBolt11Invoice",
                              "(Ljava/lang/String;)Ljava/lang/String;");
-  if (!decodeMethodInvoice) {
+  if (!decodeMethodInvoiceRef) {
+    clear_pending_exception(env);
+    env->DeleteGlobalRef(globalDecoderClass);
     return false;
   }
 
-  decodeMethodOffer =
-      env->GetStaticMethodID(decoderClass, "decodeBolt12Offer",
+  jmethodID decodeMethodOfferRef =
+      env->GetStaticMethodID(globalDecoderClass, "decodeBolt12Offer",
                              "(Ljava/lang/String;)Ljava/lang/String;");
-  if (!decodeMethodOffer) {
+  if (!decodeMethodOfferRef) {
+    clear_pending_exception(env);
+    env->DeleteGlobalRef(globalDecoderClass);
     return false;
   }
 
+  decoderClass = globalDecoderClass;
+  decodeMethodInvoice = decodeMethodInvoiceRef;
+  decodeMethodOffer = decodeMethodOfferRef;
+  jvm_initialized = true;
   return true;
 }
 
@@ -57,6 +85,9 @@ lightning_kmp_decode_invoice(const char *invoiceStr) {
 
   JNIEnv *env = nullptr;
   jint status = jvm->GetEnv((void **)&env, JNI_VERSION_1_8);
+  if (status != JNI_OK || !env) {
+    return "";
+  }
 
   jstring jInvoiceStr = env->NewStringUTF(invoiceStr);
   if (!jInvoiceStr) {
@@ -96,15 +127,18 @@ lightning_kmp_decode_offer(const char *offerStr) {
 
   JNIEnv *env = nullptr;
   jint status = jvm->GetEnv((void **)&env, JNI_VERSION_1_8);
+  if (status != JNI_OK || !env) {
+    return "";
+  }
 
-  jstring jInvoiceStr = env->NewStringUTF(offerStr);
-  if (!jInvoiceStr) {
+  jstring jOfferStr = env->NewStringUTF(offerStr);
+  if (!jOfferStr) {
     return "";
   }
 
   jstring jResult = static_cast<jstring>(env->CallStaticObjectMethod(
-      decoderClass, decodeMethodOffer, jInvoiceStr));
-  env->DeleteLocalRef(jInvoiceStr);
+      decoderClass, decodeMethodOffer, jOfferStr));
+  env->DeleteLocalRef(jOfferStr);
 
   if (!jResult) {
     return "";


### PR DESCRIPTION
## Summary

Harden JVM/JNI initialization in the Java-backed modules.

## Why

`bitcoinj`, `eclair`, and `lightningkmp` were all exposing partially initialized JNI state during setup.

In the current flow, a module could:
- create a global class reference
- fail a later `GetStaticMethodID(...)`
- return failure while leaving partially initialized state behind

`eclair` also aborted the whole process when JVM initialization failed, and `eclair` / `lightningkmp` were using `GetEnv(...)` results without validating success.

## Change

- build JNI init state in local temporaries first
- assign static class/method handles only after the full init path succeeds
- delete global refs on partial init failure
- clear pending JNI exceptions after failed class/method lookups
- validate `GetEnv(...)` before using `JNIEnv*`
- return normal module failure for `eclair` init errors instead of aborting the process

## Scope

This change is limited to:
- `modules/bitcoinj/module.cpp`
- `modules/eclair/module.cpp`
- `modules/lightningkmp/module.cpp`
