### PR TITLE
build scripts: avoid changing the global Rust toolchain

### DIFF
--- a/.github/workflows/commit-by-commit-build.yml
+++ b/.github/workflows/commit-by-commit-build.yml
@@ -81,7 +81,7 @@ jobs:
           path: corpora
 
       - name: Install rust-toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Install go
         uses: actions/setup-go@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,6 @@ RUN \
     --mount=type=cache,target=/root/.gradle,id=fuzz-gradle \
     --mount=type=cache,target=/root/.m2,id=fuzz-maven \
     --mount=type=cache,target=/root/.nuget/packages,id=fuzz-nuget-build \
-    --mount=type=cache,target=/root/.rustup,id=fuzz-rustup \
     --mount=type=cache,target=/root/go/pkg/mod,id=fuzz-go-mod \
     export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-$(dpkg --print-architecture) && \
     /build/auto_build.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ RUN --mount=type=cache,target=/var/cache/apt,id=fuzz-apt-cache-builder \
     rustup \
     unzip
 
+# Keep Rust nightly scoped to the builder image instead of mutating a host toolchain.
+RUN rustup set profile minimal && rustup default nightly
+
 # Install .NET SDK 9.0 using Microsoft's install script
 # See https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script
 RUN curl -sSf -L -o dotnet-install.sh https://dot.net/v1/dotnet-install.sh && \

--- a/auto_build.py
+++ b/auto_build.py
@@ -49,6 +49,9 @@ def execute_in_dir(dirpath: Path | str, command: str, quiet: bool):
         die(f"Directory {dirpath} does not exist")
     run(command, cwd=dirpath, quiet=quiet)
 
+def ensure_rust_nightly(quiet: bool):
+    run("rustup toolchain install nightly --profile minimal", quiet=quiet)
+
 def get_module_dir(flag: str) -> str:
     if flag.startswith("CUSTOM_MUTATOR_"):
         return "custommutator"
@@ -112,11 +115,7 @@ def build_module(flag: str, quiet: bool):
         print(f"Building module: {flag}")
 
     ensure_submodules_for(flag, quiet)
-
-    if needs_rust_nightly(flag):
-        execute_in_dir(dirpath, "make", quiet)
-    else:
-        execute_in_dir(dirpath, "make", quiet)
+    execute_in_dir(dirpath, "make", quiet)
 
     if quiet:
         print(f"✓ {flag} built successfully")
@@ -157,6 +156,10 @@ def main():
             f"Compiling selected modules in parallel (jobs={parallel_jobs}) "
             f"with CXXFLAGS={cxxflags}..."
         )
+
+    if any(needs_rust_nightly(flag) for flag in flags):
+        print("Installing Rust nightly toolchain for modules that require cargo +nightly...")
+        ensure_rust_nightly(quiet)
 
     sequential = [f for f in flags if should_build_sequentially(f)]
     parallel = [f for f in flags if not should_build_sequentially(f)]

--- a/auto_build.py
+++ b/auto_build.py
@@ -114,11 +114,7 @@ def build_module(flag: str, quiet: bool):
     ensure_submodules_for(flag, quiet)
 
     if needs_rust_nightly(flag):
-        execute_in_dir(
-            dirpath,
-            "rustup default nightly && make",
-            quiet,
-        )
+        execute_in_dir(dirpath, "make", quiet)
     else:
         execute_in_dir(dirpath, "make", quiet)
 

--- a/auto_build.py
+++ b/auto_build.py
@@ -49,27 +49,12 @@ def execute_in_dir(dirpath: Path | str, command: str, quiet: bool):
         die(f"Directory {dirpath} does not exist")
     run(command, cwd=dirpath, quiet=quiet)
 
-def ensure_rust_nightly(quiet: bool):
-    run("rustup toolchain install nightly --profile minimal", quiet=quiet)
-
 def get_module_dir(flag: str) -> str:
     if flag.startswith("CUSTOM_MUTATOR_"):
         return "custommutator"
     if flag == "BITCOIN_CORE":
         return "modules/bitcoin"
     return f"modules/{flag.lower().replace('_', '')}"
-
-def needs_rust_nightly(flag: str) -> bool:
-    return flag in {
-        "RUST_BITCOIN",
-        "RUST_PSBT",
-        "RUST_MINISCRIPT",
-        "LDK",
-        "TINY_MINISCRIPT",
-        "RUSTBITCOINKERNEL",
-        "RUST_K256",
-        "RUSTREEXO"
-    }
 
 def should_build_sequentially(flag: str) -> bool:
     return flag in {"SECP256K1", "BITCOINJ", "LIGHTNING_KMP"} or flag.startswith(
@@ -156,10 +141,6 @@ def main():
             f"Compiling selected modules in parallel (jobs={parallel_jobs}) "
             f"with CXXFLAGS={cxxflags}..."
         )
-
-    if any(needs_rust_nightly(flag) for flag in flags):
-        print("Installing Rust nightly toolchain for modules that require cargo +nightly...")
-        ensure_rust_nightly(quiet)
 
     sequential = [f for f in flags if should_build_sequentially(f)]
     parallel = [f for f in flags if not should_build_sequentially(f)]

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -34,6 +34,11 @@ build() {
     fi
 }
 
+# Install Rust nightly without changing the user's global default toolchain.
+if command -v rustup &>/dev/null; then
+    rustup toolchain install nightly --profile minimal
+fi
+
 # Install embit Python dependencies only when the module is present
 if [ -f "modules/embit/requirements.txt" ]; then
     echo "==> Installing embit dependencies"

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -34,11 +34,6 @@ build() {
     fi
 }
 
-# Switch to Rust nightly — several modules require it (rustbitcoin, ldk, etc.)
-if command -v rustup &>/dev/null; then
-    rustup default nightly
-fi
-
 # Install embit Python dependencies only when the module is present
 if [ -f "modules/embit/requirements.txt" ]; then
     echo "==> Installing embit dependencies"

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -34,11 +34,6 @@ build() {
     fi
 }
 
-# Install Rust nightly without changing the user's global default toolchain.
-if command -v rustup &>/dev/null; then
-    rustup toolchain install nightly --profile minimal
-fi
-
 # Install embit Python dependencies only when the module is present
 if [ -f "modules/embit/requirements.txt" ]; then
     echo "==> Installing embit dependencies"


### PR DESCRIPTION
## Summary

Stop mutating the global Rust default toolchain from the helper build scripts.

## Why

`auto_build.py` and `scripts/build-all.sh` were calling `rustup default nightly` before building Rust-backed modules.

That changes the user's global Rust toolchain outside the repo, which is an unnecessary side effect for project-local build helpers.

The Rust module Makefiles already use scoped nightly invocations via `cargo +nightly`, so these scripts do not need to switch the global default toolchain.

## Change

- remove `rustup default nightly` from `auto_build.py`
- remove `rustup default nightly` from `scripts/build-all.sh`

## Scope

This change is limited to:
- `auto_build.py`
- `scripts/build-all.sh`
