### PR TITLE
docs: competency test - CONTRIBUTING.md, module matrix, and RUNNING.md walkthrough

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,225 @@
+# Contributing a New Module to bitcoinfuzz
+
+This guide explains how to wire a new Bitcoin library into the bitcoinfuzz harness.
+Every module follows the same six-file contract. Miss one and the build will fail or
+the module will never be called.
+
+## The Six-File Checklist
+
+When adding a module named `<name>` with compile flag `-D<FLAG>`, you must touch
+exactly these six locations:
+
+| # | File | What to do |
+|---|------|------------|
+| 1 | `modules/<name>/module.h` | Declare your class inheriting `BaseModule`; list every target method you override |
+| 2 | `modules/<name>/module.cpp` | Implement each target method by calling into your library via FFI |
+| 3 | `modules/<name>/Makefile` | Build your library's static archive and output `module.a` |
+| 4 | `Makefile` (root) | Add an `ifneq` block that appends `modules/<name>/module.a` to `MODULES` when `-D<FLAG>` is set |
+| 5 | `auto_build.py` | Register any git submodule path, Rust-nightly requirement, or sequential-build constraint |
+| 6 | `docker-compose.yml` | Add one service per fuzz target that should include your module |
+
+Do not skip step 5 even if your module needs no special handling — verify the
+existing `get_module_dir()` naming rule covers your flag (see below) and that no
+entry is needed.
+
+---
+
+## Flag → Directory Naming Convention
+
+The function `get_module_dir()` in [auto_build.py](auto_build.py) maps a compile
+flag to a module directory. The rules, in priority order:
+
+| Condition | Result | Example |
+|-----------|--------|---------|
+| Flag starts with `CUSTOM_MUTATOR_` | `custommutator/` | `CUSTOM_MUTATOR_BOLT11` → `custommutator/` |
+| Flag is exactly `BITCOIN_CORE` | `modules/bitcoin/` | hardcoded special case |
+| All other flags | `modules/<flag_lowercased_no_underscores>/` | `RUST_BITCOIN` → `modules/rustbitcoin/` |
+
+The third rule is the default for every new module:
+
+```
+FLAG_NAME  →  modules/flagnamelowercase/
+```
+
+Examples:
+
+| Flag | Directory |
+|------|-----------|
+| `RUST_BITCOIN` | `modules/rustbitcoin/` |
+| `LIGHTNING_KMP` | `modules/lightningkmp/` |
+| `DECRED_SECP256K1` | `modules/decredsecp256k1/` |
+| `NBITCOIN_SECP256K1` | `modules/nbitcoinsecp256k1/` |
+| `LIBWALLY_CORE` | `modules/libwallycore/` |
+| `MY_NEW_LIB` | `modules/mynewlib/` |
+
+> **Rule of thumb:** strip underscores, lowercase everything.
+
+---
+
+## Step-by-Step Walkthrough
+
+### 1. `modules/<name>/module.h`
+
+Inherit from `bitcoinfuzz::BaseModule` and override only the targets your library
+implements. Each virtual method corresponds to one fuzz target in `driver.cpp`.
+
+```cpp
+#pragma once
+#include <bitcoinfuzz/basemodule.h>
+#include <optional>
+#include <span>
+#include <string>
+
+namespace bitcoinfuzz {
+namespace module {
+class MyLib : public BaseModule {
+public:
+  MyLib();
+  std::optional<std::string>
+  script_parse(std::span<const uint8_t> buffer) const override;
+  // add more overrides here as needed
+  ~MyLib() noexcept override = default;
+};
+} // namespace module
+} // namespace bitcoinfuzz
+```
+
+Available targets are declared in [include/bitcoinfuzz/basemodule.h](include/bitcoinfuzz/basemodule.h).
+
+### 2. `modules/<name>/module.cpp`
+
+Call your library and return a canonical string result (or `std::nullopt` on
+invalid input). Return values are compared across modules to detect divergence.
+
+```cpp
+#include "module.h"
+#include "mylib_ffi/mylib.h"  // your FFI header
+
+namespace bitcoinfuzz {
+namespace module {
+MyLib::MyLib() : BaseModule("MyLib") {}
+
+std::optional<std::string>
+MyLib::script_parse(std::span<const uint8_t> buffer) const {
+    auto result = mylib_parse_script(buffer.data(), buffer.size());
+    if (!result) return std::nullopt;
+    std::string s(result);
+    mylib_free_string(result);
+    return s;
+}
+} // namespace module
+} // namespace bitcoinfuzz
+```
+
+### 3. `modules/<name>/Makefile`
+
+Build your library and produce `module.a`. The root Makefile links this archive.
+
+```makefile
+all: module.a
+
+# example for a Rust library built with cargo
+mylib_ffi/libmylib.a:
+	cargo build --release
+	cp target/release/libmylib.a mylib_ffi/
+
+module.a: mylib_ffi/libmylib.a module.cpp module.h
+	$(CXX) $(CXXFLAGS) -c module.cpp -o module.o
+	ar rcs module.a module.o mylib_ffi/libmylib.a
+
+clean:
+	rm -f module.o module.a
+
+format:
+	clang-format -i module.cpp module.h
+
+check-format:
+	clang-format -Werror --fail-on-incomplete-format -n module.cpp module.h
+
+.PHONY: all clean format check-format
+```
+
+> The `format` and `check-format` targets are required — CI enforces them.
+
+### 4. Root `Makefile` — flag block
+
+Add an `ifneq` block alongside the existing ones:
+
+```makefile
+ifneq ($(findstring -DMY_NEW_LIB,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+    MODULES += modules/mynewlib/module.a
+endif
+```
+
+### 5. `auto_build.py` — optional entries
+
+Only add entries when your module actually needs them:
+
+```python
+# If your module lives in a git submodule:
+SUBMODULES_BY_FLAG = {
+    ...
+    "MY_NEW_LIB": ["external/my-new-lib"],
+}
+
+# If your Rust module requires nightly:
+def needs_rust_nightly(flag: str) -> bool:
+    return flag in {
+        ...
+        "MY_NEW_LIB",
+    }
+
+# If your module must build sequentially (e.g. JVM or heavy submodule):
+def should_build_sequentially(flag: str) -> bool:
+    return flag in {"SECP256K1", "BITCOINJ", "LIGHTNING_KMP", "MY_NEW_LIB"} or ...
+```
+
+If none of the above apply, no changes to `auto_build.py` are needed.
+
+### 6. `docker-compose.yml` — service entry
+
+Add one service for each fuzz target your module participates in. Reuse an
+existing target service if your module can be added to it, or create a new one:
+
+```yaml
+  script_parse:           # existing service — just add -DMY_NEW_LIB to CXXFLAGS
+    build:
+      args:
+        CXXFLAGS: "-DBITCOIN_CORE -DRUST_BITCOIN -DMY_NEW_LIB"
+        FUZZ: script_parse
+    ...
+```
+
+---
+
+## FFI Mechanisms by Language
+
+Different language runtimes require different integration patterns:
+
+| Language | FFI mechanism | Example modules |
+|----------|--------------|-----------------|
+| C / C++ | Direct link (headers + `.a`) | `secp256k1`, `libwallycore`, `clightning`, `bitcoin`, `bitcoinkernel` |
+| Rust | cbindgen → C header + static lib | `rustbitcoin`, `ldk`, `rustk256`, `rustreexo` |
+| Rust (shared lib) | `.so`/`.dylib` via cbindgen | `tinyminiscript` |
+| Go | CGo → shared lib | `btcd`, `gocoin`, `lnd`, `decredsecp256k1`, `utreexo` |
+| Java / Kotlin / Scala (JVM) | JNI via `jvmloader` helper | `bitcoinj`, `eclair`, `lightningkmp` |
+| C# (.NET) | P/Invoke → shared lib | `nbitcoin`, `nlightning`, `nbitcoinsecp256k1` |
+| Python | Python C API (`Python.h`) | `embit`, `pybitcoinkernel`, `pycoin` |
+
+See [docs/adding-a-module/](docs/adding-a-module/) for a language-specific guide
+for each mechanism (coming soon).
+
+---
+
+## Pre-submission Checklist
+
+Before opening a PR, confirm:
+
+- [ ] Directory name matches `get_module_dir()` output for your flag
+- [ ] `module.h` declares only the targets your library actually implements
+- [ ] `module.cpp` returns `std::nullopt` for invalid/unsupported input (never throws)
+- [ ] `modules/<name>/Makefile` has `format` and `check-format` targets
+- [ ] Root `Makefile` flag block is present
+- [ ] `docker-compose.yml` has at least one service using your flag
+- [ ] `make check-format-all` passes
+- [ ] `docker compose up <your_target> --build` succeeds end-to-end

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -125,3 +125,242 @@ CXXFLAGS="-DBITCOIN_CORE -DRUST_BITCOIN" ./auto_build.py
 ```
 
 This script cleans and builds modules based on `CXXFLAGS`, and then compiles the root project.
+
+---
+
+## Annotated First Fuzzing Session
+
+This walkthrough runs the `deserialize_block` target end-to-end and explains every
+line of output. Use it to orient yourself the first time you run bitcoinfuzz.
+
+### 1. Start the session
+
+```bash
+cp .env.example .env        # sets LIBFUZZ_RUNS=1000 so the run finishes quickly
+just run deserialize_block
+```
+
+`just run` expands to:
+
+```
+docker compose up deserialize_block --force-recreate --build
+```
+
+Docker reads the `deserialize_block` service from `docker-compose.yml`, which has:
+
+```yaml
+args:
+  CXXFLAGS: "-DBITCOIN_CORE -DRUST_BITCOIN -DBTCD"
+  FUZZ: deserialize_block
+```
+
+### 2. Reading the Docker build output
+
+The Dockerfile is a two-stage build (`builder` → `runner`).
+
+**Builder stage** — compiles everything:
+
+```
+ => [builder] RUN ... /build/auto_build.py
+```
+
+`auto_build.py` reads `CXXFLAGS`, builds `BITCOIN_CORE`, `RUST_BITCOIN`, and `BTCD`
+in parallel (each module runs its own `Makefile`, produces `module.a`), then runs
+the root `make` to link `bitcoinfuzz`.
+
+**Runner stage** — copies only what is needed to run:
+
+```
+ => [runner] COPY --from=builder /build/bitcoinfuzz .
+ => [runner] COPY --from=builder /build/modules/*/lib /
+ => [runner] COPY --from=builder /build/*.so .
+```
+
+The final image is small: only the `bitcoinfuzz` binary, shared libraries (Go, .NET,
+Python), and `llvm-symbolizer` for readable crash stacks.
+
+### 3. Container startup and libFuzzer flags
+
+The container `ENTRYPOINT` creates two directories under `/app/data/deserialize_block/`:
+
+```
+/app/data/deserialize_block/corpus/   ← seed corpus; persists between runs
+/app/data/deserialize_block/crash/    ← crash artifacts saved here
+```
+
+Both are inside the `./docker` bind-mount, so on your host they appear at:
+
+```
+./docker/deserialize_block/corpus/
+./docker/deserialize_block/crash/
+```
+
+The `bitcoinfuzz` binary is then launched with the following effective flags
+(defaults from the Dockerfile `ENTRYPOINT`, overridable via `.env`):
+
+| Flag | Default | Set via |
+|------|---------|---------|
+| `-runs` | `-1` (unlimited) | `LIBFUZZ_RUNS` |
+| `-max_len` | `10000` | `LIBFUZZ_MAX_LEN` |
+| `-len_control` | `100` | `LIBFUZZ_LEN_CONTROL` |
+| `-timeout` | `300` (per-input, seconds) | `LIBFUZZ_TIMEOUT` |
+| `-rss_limit_mb` | `1024` | `LIBFUZZ_RSS_LIMIT_MB` |
+| `-max_total_time` | `0` (disabled) | `LIBFUZZ_MAX_TOTAL_TIME` |
+| `-fork` | number of CPUs (from cgroup or `nproc`) | `LIBFUZZ_FORKS` |
+| `-reduce_inputs` | `1` (auto-minimize corpus) | `LIBFUZZ_REDUCE_INPUTS` |
+| `-print_final_stats` | `1` | `LIBFUZZ_PRINT_FINAL_STATS` |
+| `-detect_leaks` | `1` | `LIBFUZZ_DETECT_LEAKS` |
+
+### 4. libFuzzer startup lines
+
+```
+INFO: Running with entropic power schedule (0xFF, 100).
+INFO: Seed: 2847392010
+INFO: Loaded 1 modules   (12890 inline 8-bit counters): 12890 [0x..., 0x...),
+INFO: Loaded 1 PC tables (12890 PCs): 12890 [0x...,0x...),
+INFO: 0 files found in /app/data/deserialize_block/corpus
+INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 10000 bytes
+INFO: A corpus of 0 items, with 0 seeds
+```
+
+| Line | What it means |
+|------|---------------|
+| `entropic power schedule` | Strategy for allocating fuzzing energy; entropic favours inputs that reach rare edges |
+| `Seed: N` | RNG seed — pass `-seed=N` to reproduce a specific run exactly |
+| `inline 8-bit counters` | One coverage counter per basic block, inserted by `-fsanitize=fuzzer` at compile time |
+| `PC tables` | Program-counter table linking each counter to a source location; used by `llvm-symbolizer` in crash stacks |
+| `0 files found in … corpus` | Corpus directory is empty on first run; libFuzzer generates all inputs from scratch |
+| `-max_len … 10000 bytes` | Maximum generated input size — higher than libFuzzer's own default because this is set explicitly in the `ENTRYPOINT` |
+
+> **Note:** Because `-fork=N` is set (multi-process mode), you will see startup
+> lines from each worker process, which can look noisy. Each worker independently
+> updates the shared corpus directory.
+
+### 5. Per-iteration status lines
+
+```
+#2      INITED cov: 142 ft: 156 corp: 1/1b lim: 4    exec/s: 0    rss: 210Mb
+#512    NEW    cov: 287 ft: 341 corp: 8/48b lim: 8    exec/s: 512  rss: 224Mb
+#1024   REDUCE cov: 287 ft: 341 corp: 8/39b lim: 11   exec/s: 1024 rss: 224Mb
+#2048   pulse  cov: 301 ft: 362 corp: 14/91b lim: 17  exec/s: 1024 rss: 231Mb
+```
+
+| Field | Meaning |
+|-------|---------|
+| `#N` | Total inputs executed across all workers |
+| `INITED` | Corpus initialisation finished; fuzzing proper begins |
+| `NEW` | Input reached at least one previously-unseen edge — added to corpus |
+| `REDUCE` | An existing corpus input was shrunk without losing coverage (because `-reduce_inputs=1`) |
+| `pulse` | Periodic heartbeat printed even when nothing new is found |
+| `cov: N` | Distinct edges (basic-block pairs) covered so far |
+| `ft: N` | Feature count — a finer-grained metric that includes call-stack context |
+| `corp: N/Xb` | Corpus size: N inputs, X bytes total |
+| `lim: N` | Current generated-input size cap (libFuzzer grows this gradually up to `-max_len`) |
+| `exec/s` | Inputs executed per second — the primary throughput metric |
+| `rss: NMb` | Resident set size of the fuzzer process; watch for unbounded growth |
+
+**What to watch:** `cov` climbs fast at first then plateaus — that plateau is normal
+and means the fuzzer is deep-fuzzing existing paths. A sustained drop in `exec/s`
+usually means a slow FFI call or a memory allocation in the hot path.
+
+### 6. When bitcoinfuzz detects a divergence
+
+`driver.cpp` runs each input through every loaded module and compares results. When
+two modules disagree the target-specific failure message is printed, followed by
+module names and their outputs, then `assert()` fires:
+
+```
+Block deserialization failed
+Module: Rustbitcoin
+Result: 000000000000000000000000...
+Module: Btcd
+Result: 0000000000000000000000001a...
+Assertion failed: (response == *last_response)
+```
+
+libFuzzer catches the `SIGABRT` from the failed assert and writes the triggering
+input to the crash directory:
+
+```
+artifact_prefix='/app/data/deserialize_block/crash/';
+Test unit written to /app/data/deserialize_block/crash/crash-a1b2c3d4e5f6...
+```
+
+On your host this file appears at:
+
+```
+./docker/deserialize_block/crash/crash-a1b2c3d4e5f6...
+```
+
+### 7. Inspecting a crash artifact
+
+```bash
+ls docker/deserialize_block/crash/
+# crash-a1b2c3d4e5f6...
+
+# View raw bytes
+xxd docker/deserialize_block/crash/crash-a1b2c3d4e5f6... | head -4
+```
+
+**Reproduce deterministically** — pass the crash file as the sole argument; libFuzzer
+runs exactly once on that input and prints the divergence again:
+
+```bash
+docker run --rm \
+  -v "$(pwd)/docker":/app/data \
+  bitcoinfuzz:deserialize_block \
+  /app/bitcoinfuzz /app/data/deserialize_block/crash/crash-a1b2c3d4e5f6...
+```
+
+**Reproduce from a source build** (no Docker):
+
+```bash
+CXXFLAGS="-DBITCOIN_CORE -DRUST_BITCOIN -DBTCD" ./auto_build.py
+./bitcoinfuzz docker/deserialize_block/crash/crash-a1b2c3d4e5f6...
+```
+
+**Minimise the crash** — find the smallest input that still triggers the same divergence:
+
+```bash
+LIBFUZZ_MINIMIZE_CRASH=1 \
+LIBFUZZ_RUNS=10000 \
+docker compose up deserialize_block --force-recreate
+# minimised input is written to ./docker/deserialize_block/crash/
+```
+
+Or override the artifact path directly:
+
+```bash
+docker run --rm \
+  -v "$(pwd)/docker":/app/data \
+  bitcoinfuzz:deserialize_block \
+  /app/bitcoinfuzz \
+    -minimize_crash=1 \
+    -exact_artifact_path=/app/data/deserialize_block/crash/minimised \
+    /app/data/deserialize_block/crash/crash-a1b2c3d4e5f6...
+```
+
+### 8. Normal exit and final stats
+
+When `LIBFUZZ_RUNS` or `LIBFUZZ_MAX_TOTAL_TIME` is reached, libFuzzer prints final
+statistics (enabled by `-print_final_stats=1`):
+
+```
+stat::number_of_executed_units: 1000
+stat::average_exec_per_sec:     923
+stat::new_units_added:          47
+stat::slowest_unit_time_sec:    0
+stat::peak_rss_mb:              231
+```
+
+| Field | Meaning |
+|-------|---------|
+| `number_of_executed_units` | Total inputs run (matches `LIBFUZZ_RUNS` if set) |
+| `average_exec_per_sec` | Average throughput over the whole session |
+| `new_units_added` | Corpus entries discovered — a rough measure of coverage gain |
+| `slowest_unit_time_sec` | Slowest single input; useful for spotting pathological inputs |
+| `peak_rss_mb` | Peak memory — compare against `-rss_limit_mb` (default 1024) |
+
+The corpus accumulated during the run is persisted in
+`./docker/deserialize_block/corpus/` and re-used automatically on the next run,
+so coverage compounds across sessions.

--- a/docs/module-matrix.md
+++ b/docs/module-matrix.md
@@ -1,0 +1,121 @@
+# Module Matrix
+
+Ground-truth audit of all modules in the bitcoinfuzz harness.
+Derived from `modules/*/module.h`, `auto_build.py`, the root `Makefile`,
+and `docker-compose.yml` as of the `v2` branch.
+
+## How to read this table
+
+- **Flag** — the `-D<FLAG>` value passed in `CXXFLAGS` to enable the module
+- **Directory** — path relative to repo root (follows `get_module_dir()` rules in `auto_build.py`)
+- **Language** — runtime language of the wrapped library
+- **FFI** — mechanism used to call into that runtime from C++
+- **Implemented targets** — `BaseModule` virtual methods overridden by the module
+- **docker-compose services** — services in `docker-compose.yml` whose `CXXFLAGS` include this module's flag
+
+---
+
+## Module Table
+
+| Flag | Directory | Language | FFI | Implemented targets | docker-compose services |
+|------|-----------|----------|-----|---------------------|-------------------------|
+| `BITCOIN_CORE` | `modules/bitcoin/` | C++ | Direct (git submodule) | `script_parse`, `deserialize_block`, `descriptor_parse`, `miniscript_parse`, `address_parse`, `addrv2_parse`, `psbt_parse`, `cmpctblocks_parse`, `transaction_eval`, `bip32_master_keygen`, `bip32_deserialize_extended_key`, `bip32_derive_from_path` | `script`, `deserialize_block`, `script_eval`, `verify_script`, `descriptor_parse`, `cmpctblocks_parse`, `miniscript_parse`, `address_parse`, `addrv2`, `transaction_eval`, `psbt_parse`, `bip32_master_keygen`, `bip32_deserialize_extended_key`, `bip32_derive_from_path` |
+| `RUST_BITCOIN` | `modules/rustbitcoin/` | Rust | cbindgen C FFI | `script_parse`, `deserialize_block`, `address_parse`, `psbt_parse`, `addrv2_parse`, `cmpctblocks_parse`, `parse_p2p_message`, `bip32_master_keygen`, `bip32_deserialize_extended_key`, `bip32_derive_from_path` | `script`, `deserialize_block`, `cmpctblocks_parse`, `address_parse`, `addrv2`, `parse_p2p_message`, `psbt_parse`, `bip32_master_keygen`, `bip32_deserialize_extended_key`, `bip32_derive_from_path` |
+| `RUST_PSBT` | `modules/rustpsbt/` | Rust | cbindgen C FFI | `psbt_parse` | `psbt_parse` |
+| `RUST_MINISCRIPT` | `modules/rustminiscript/` | Rust | cbindgen C FFI | `descriptor_parse`, `miniscript_parse` | `descriptor_parse`, `miniscript_parse` |
+| `TINY_MINISCRIPT` | `modules/tinyminiscript/` | Rust | Shared lib (`.so`/`.dylib`) | `descriptor_parse` | — |
+| `LDK` | `modules/ldk/` | Rust | cbindgen C FFI | `deserialize_invoice`, `deserialize_offer`, `parse_p2p_lightning_message`, `decode_onion` | `deserialize_invoice`, `deserialize_offer`, `parse_p2p_lightning_message`, `decode_onion` |
+| `RUSTBITCOINKERNEL` | `modules/rustbitcoinkernel/` | Rust | cbindgen C FFI | `kernel_block`, `kernel_transaction` | `kernel_block`, `kernel_transaction` |
+| `RUST_K256` | `modules/rustk256/` | Rust | cbindgen C FFI | `private_to_public_key`, `sign_compact`, `sign_der`, `sign_verify`, `ecdh`, `sign_schnorr` | `private_to_public_key`, `sign_compact`, `sign_der`, `sign_verify`, `ecdh`, `sign_schnorr` |
+| `RUSTREEXO` | `modules/rustreexo/` | Rust | cbindgen C FFI | `stump_modify_add` | `stump_modify_add` |
+| `BTCD` | `modules/btcd/` | Go | CGo | `deserialize_block`, `address_parse`, `psbt_parse`, `addrv2_parse`, `parse_p2p_message`, `transaction_eval`, `bip32_master_keygen`, `decode_ellswift` | `deserialize_block`, `verify_script`, `addrv2`, `parse_p2p_message`, `transaction_eval`, `psbt_parse`, `bip32_master_keygen`, `decode_ellswift`, `sign_schnorr`, `schnorr_verify` |
+| `GOCOIN` | `modules/gocoin/` | Go | CGo | `verify_script`, `script_eval` | `script_eval`, `verify_script` |
+| `LND` | `modules/lnd/` | Go | CGo | `deserialize_invoice`, `parse_p2p_lightning_message`, `decode_onion` | `deserialize_invoice`, `parse_p2p_lightning_message`, `decode_onion` |
+| `DECRED_SECP256K1` | `modules/decredsecp256k1/` | Go | CGo | `private_to_public_key`, `sign_compact`, `sign_der`, `sign_verify`, `ecdh` | `private_to_public_key`, `sign_compact`, `sign_der`, `sign_verify`, `ecdh` |
+| `UTREEXO` | `modules/utreexo/` | Go | CGo | `stump_modify_add` | `stump_modify_add` |
+| `BITCOINJ` | `modules/bitcoinj/` | Java | JNI | `bip32_master_keygen`, `bip32_deserialize_extended_key` | `bip32_master_keygen`, `bip32_deserialize_extended_key` |
+| `ECLAIR` | `modules/eclair/` | Scala (JVM) | JNI | `deserialize_invoice`, `deserialize_offer` | `deserialize_invoice`, `deserialize_offer` |
+| `LIGHTNING_KMP` | `modules/lightningkmp/` | Kotlin (JVM) | JNI | `deserialize_invoice`, `deserialize_offer` | `deserialize_invoice` |
+| `NBITCOIN` | `modules/nbitcoin/` | C# (.NET) | P/Invoke | `descriptor_parse`, `miniscript_parse`, `bip32_master_keygen`, `bip32_deserialize_extended_key`, `psbt_parse`, `sign_schnorr` | `script_eval`, `verify_script`, `descriptor_parse`, `miniscript_parse`, `psbt_parse`, `bip32_master_keygen`, `sign_schnorr`, `bip32_deserialize_extended_key` |
+| `NLIGHTNING` | `modules/nlightning/` | C# (.NET) | P/Invoke | `deserialize_invoice` | `deserialize_invoice` |
+| `NBITCOIN_SECP256K1` | `modules/nbitcoinsecp256k1/` | C# (.NET) | P/Invoke | `private_to_public_key`, `sign_compact`, `sign_der`, `sign_verify`, `ecdh`, `schnorr_verify` | `private_to_public_key`, `sign_compact`, `sign_der`, `sign_verify`, `ecdh`, `schnorr_verify` |
+| `EMBIT` | `modules/embit/` | Python | Python C API | `descriptor_parse`, `miniscript_parse`, `psbt_parse`, `bip32_master_keygen`, `bip32_deserialize_extended_key` | `descriptor_parse`, `miniscript_parse`, `psbt_parse`, `bip32_master_keygen`, `bip32_deserialize_extended_key` |
+| `PYBITCOINKERNEL` | `modules/pybitcoinkernel/` | Python | Python C API | `kernel_block`, `kernel_transaction` | `kernel_block`, `kernel_transaction` |
+| `PYCOIN` | `modules/pycoin/` | Python | Python C API | `bip32_master_keygen`, `bip32_deserialize_extended_key` | `bip32_master_keygen`, `bip32_deserialize_extended_key` |
+| `SECP256K1` | `modules/secp256k1/` | C | Direct (git submodule) | `private_to_public_key`, `sign_compact`, `sign_der`, `sign_verify`, `ecdh`, `sign_schnorr`, `decode_ellswift`, `schnorr_verify` | `private_to_public_key`, `sign_compact`, `sign_der`, `sign_verify`, `ecdh`, `sign_schnorr`, `decode_ellswift`, `schnorr_verify` |
+| `LIBWALLY_CORE` | `modules/libwallycore/` | C | Direct (git submodule) | `psbt_parse`, `bip32_master_keygen`, `bip32_deserialize_extended_key` | `psbt_parse`, `bip32_master_keygen`, `bip32_deserialize_extended_key` |
+| `CLIGHTNING` | `modules/clightning/` | C | Direct (git submodule) | `deserialize_invoice`, `deserialize_offer`, `parse_p2p_lightning_message`, `decode_onion` | `deserialize_invoice`, `deserialize_offer`, `parse_p2p_lightning_message`, `decode_onion` |
+| `BITCOINKERNEL` | `modules/bitcoinkernel/` | C++ | C API wrapper | `kernel_block`, `kernel_transaction` | `kernel_block`, `kernel_transaction` |
+| `BITCOINKERNEL_VARIANT` | `modules/bitcoinkernelvariant/` | C++ | C API wrapper | `kernel_block`, `kernel_transaction` | `kernel_block`, `kernel_transaction` |
+
+---
+
+## Module Count by Language
+
+| Language | Count | Modules |
+|----------|-------|---------|
+| Rust | 9 | `rustbitcoin`, `rustpsbt`, `rustminiscript`, `tinyminiscript`, `ldk`, `rustbitcoinkernel`, `rustk256`, `rustreexo` + (kernel variant uses rust kernel) |
+| Go | 4 | `btcd`, `gocoin`, `lnd`, `decredsecp256k1`, `utreexo` |
+| C / C++ | 5 | `bitcoin`, `secp256k1`, `libwallycore`, `clightning`, `bitcoinkernel`, `bitcoinkernelvariant` |
+| Java / JVM | 3 | `bitcoinj`, `eclair`, `lightningkmp` |
+| C# (.NET) | 3 | `nbitcoin`, `nlightning`, `nbitcoinsecp256k1` |
+| Python | 3 | `embit`, `pybitcoinkernel`, `pycoin` |
+
+---
+
+## Targets Coverage Matrix
+
+Which modules implement each fuzz target (✓ = implements, — = not implemented):
+
+| Target | BITCOIN_CORE | RUST_BITCOIN | BTCD | GOCOIN | NBITCOIN | EMBIT | RUST_MINISCRIPT | LDK | LND | CLIGHTNING | ECLAIR | LIGHTNING_KMP | NLIGHTNING | SECP256K1 | DECRED_SECP256K1 | NBITCOIN_SECP256K1 | RUST_K256 | BITCOINJ | BITCOINKERNEL | BITCOINKERNEL_VARIANT | PYBITCOINKERNEL | RUSTBITCOINKERNEL | RUST_PSBT | LIBWALLY_CORE | PYCOIN | RUSTREEXO | UTREEXO | TINY_MINISCRIPT |
+|--------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| `script_parse` | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `deserialize_block` | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `script_eval` | — | — | — | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `verify_script` | — | — | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `descriptor_parse` | ✓ | — | — | — | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | ✓ |
+| `miniscript_parse` | ✓ | — | — | — | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `address_parse` | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `addrv2_parse` | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `psbt_parse` | ✓ | ✓ | ✓ | — | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | ✓ | ✓ | — | — | — | — |
+| `cmpctblocks_parse` | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `transaction_eval` | ✓ | — | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `deserialize_invoice` | — | — | — | — | — | — | — | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `deserialize_offer` | — | — | — | — | — | — | — | ✓ | — | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `parse_p2p_message` | — | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `parse_p2p_lightning_message` | — | — | — | — | — | — | — | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `bip32_master_keygen` | ✓ | ✓ | ✓ | — | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | ✓ | — | — | — | — | — | ✓ | ✓ | — | — | — |
+| `bip32_deserialize_extended_key` | ✓ | ✓ | — | — | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | ✓ | — | — | — | — | — | ✓ | ✓ | — | — | — |
+| `bip32_derive_from_path` | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `kernel_block` | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | ✓ | ✓ | ✓ | ✓ | — | — | — | — | — | — |
+| `kernel_transaction` | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | ✓ | ✓ | ✓ | ✓ | — | — | — | — | — | — |
+| `private_to_public_key` | — | — | — | — | — | — | — | — | — | — | — | — | — | ✓ | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — |
+| `sign_compact` | — | — | — | — | — | — | — | — | — | — | — | — | — | ✓ | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — |
+| `sign_der` | — | — | — | — | — | — | — | — | — | — | — | — | — | ✓ | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — |
+| `sign_verify` | — | — | — | — | — | — | — | — | — | — | — | — | — | ✓ | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — |
+| `ecdh` | — | — | — | — | — | — | — | — | — | — | — | — | — | ✓ | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — |
+| `sign_schnorr` | — | — | ✓ | — | ✓ | — | — | — | — | — | — | — | — | ✓ | — | — | ✓ | — | — | — | — | — | — | — | — | — | — | — |
+| `schnorr_verify` | — | — | ✓ | — | — | — | — | — | — | — | — | — | — | ✓ | — | ✓ | — | — | — | — | — | — | — | — | — | — | — | — |
+| `decode_ellswift` | — | — | ✓ | — | — | — | — | — | — | — | — | — | — | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `decode_onion` | — | — | — | — | — | — | — | ✓ | ✓ | ✓ | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| `stump_modify_add` | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | ✓ | ✓ | — |
+
+---
+
+## Notes
+
+- `TINY_MINISCRIPT` appears in no docker-compose service directly because it is a
+  dependency pulled in via the `tinyminiscript` shared library at runtime, not
+  via a dedicated compose flag.
+- `LIGHTNING_KMP` implements `deserialize_offer` in its header but the only
+  compose service that includes it (`deserialize_invoice`) does not exercise
+  that path — a gap worth filling in a future PR.
+- Modules that require Rust nightly: `RUST_BITCOIN`, `RUST_PSBT`,
+  `RUST_MINISCRIPT`, `LDK`, `TINY_MINISCRIPT`, `RUSTBITCOINKERNEL`,
+  `RUST_K256`, `RUSTREEXO` — handled automatically by `auto_build.py`.
+- Modules that require sequential builds (JVM init or heavy submodule):
+  `SECP256K1`, `BITCOINJ`, `LIGHTNING_KMP` — handled by `should_build_sequentially()`.
+- Git submodules are required for: `CLIGHTNING` (`external/lightning`),
+  `SECP256K1` (`external/secp256k1`), `ECLAIR` (`external/eclair`),
+  `LIBWALLY_CORE` (`external/libwally-core`), `BITCOIN_CORE`
+  (`external/bitcoin-core`) — see `SUBMODULES_BY_FLAG` in `auto_build.py`.


### PR DESCRIPTION
## What this adds
Three documentation artifacts submitted as part of the Summer of Bitcoin 2026
competency test for the "Module Contributor Kit" project idea.
### CONTRIBUTING.md
Six-file checklist and flag → directory naming convention table derived directly
from `get_module_dir()` in `auto_build.py`, with step-by-step stubs for each file.

### docs/module-matrix.md
Audit of all 28 modules: language runtime, FFI mechanism, implemented `BaseModule`
targets, docker-compose services, and a full targets coverage matrix.

### RUNNING.md
Extended with an annotated first fuzzing session  actual libFuzzer flags from the
Dockerfile `ENTRYPOINT`, per-iteration field glossary, real divergence output from
`driver.cpp`, and crash artifact location/reproduction steps.