### PR TITLE
driver: add LOG_OUTPUTS env var to log every module response

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,23 @@ FUZZ=target_name ./bitcoinfuzz
 - The fuzzer will abort with an error if you request a module that was not compiled
 - Whitespace around module names is trimmed (e.g., `"BTCD, LND"` works)
 
+## Logging Module Outputs
+
+Set `LOG_OUTPUTS=1` to print every accepted module response in the form:
+
+```
+Module: <module_name>
+Result: <response>
+```
+
+This is independent of mismatch reporting (which always runs) and is useful for
+debugging or manually inspecting what each module returns for a given input.
+Expect very noisy output during fuzzing.
+
+```bash
+LOG_OUTPUTS=1 FUZZ=address_parse ./bitcoinfuzz crash-xxxx
+```
+
 -------------------------------------------
 ### Bugs/inconsistences/mismatches found by Bitcoinfuzz
 

--- a/driver.cpp
+++ b/driver.cpp
@@ -10,29 +10,36 @@
 #include <bitcoinfuzz/basemodule.h>
 #include <bitcoinfuzz/module_registry.h>
 
-namespace {
+namespace bitcoinfuzz {
 template <typename T>
-void VerifyMatchingResponse(std::optional<T> &last_response,
-                            std::string &last_module_name,
-                            const std::string &module_name, const T &response,
-                            std::string_view failure_message) {
-  if (last_response.has_value()) {
-    if (response != *last_response) {
-      std::cout << failure_message << std::endl;
-      std::cout << "Module: " << module_name << std::endl;
-      std::cout << "Result: " << response << std::endl;
-      std::cout << "Module: " << last_module_name << std::endl;
-      std::cout << "Result: " << *last_response << std::endl;
-    }
-    assert(response == *last_response);
+void Driver::LogResponse(const std::string &module_name,
+                         const T &response) const {
+  if (!log_outputs)
+    return;
+  std::cout << "Module: " << module_name << std::endl;
+  std::cout << "Result: " << response << std::endl;
+}
+
+template <typename T>
+void Driver::VerifyMatchingResponse(std::optional<T> &last_response,
+                                    std::string &last_module_name,
+                                    const std::string &module_name,
+                                    const T &response,
+                                    std::string_view failure_message) const {
+  if (last_response.has_value() && response != *last_response) {
+    std::cout << failure_message << std::endl;
+    std::cout << "Module: " << module_name << std::endl;
+    std::cout << "Result: " << response << std::endl;
+    std::cout << "Module: " << last_module_name << std::endl;
+    std::cout << "Result: " << *last_response << std::endl;
+    assert(false);
   }
 
+  LogResponse(module_name, response);
   last_response = response;
   last_module_name = module_name;
 }
-} // namespace
 
-namespace bitcoinfuzz {
 void Driver::LoadModule(std::shared_ptr<BaseModule> module) {
   modules[module->name] = module;
   module_logger.addModule(module->name);
@@ -197,6 +204,8 @@ void Driver::AddressParseTarget(std::span<const uint8_t> buffer) const {
     if (!res.has_value() || res->starts_with("UNK:"))
       continue;
 
+    LogResponse(module.first, *res);
+
     if (last_response.has_value()) {
       if (*res != *last_response) {
         std::cout << "Input address: " << address << "\n";
@@ -228,6 +237,8 @@ void Driver::PSBTParseTarget(std::span<const uint8_t> buffer) const {
         return;
     }
 #endif
+
+    LogResponse(module.first, *res);
 
     if (last_response.has_value()) {
       if (*res != *last_response) {
@@ -282,6 +293,9 @@ void Driver::AddrV2Target(std::span<const uint8_t> buffer) const {
     std::optional<std::string> res{module.second->addrv2_parse(buffer)};
     if (!res.has_value())
       continue;
+
+    LogResponse(module.first, *res);
+
     if (last_response.has_value()) {
       if (*res != *last_response) {
 #ifdef BTCD
@@ -337,6 +351,8 @@ void Driver::CompactBlocksTarget(std::span<const uint8_t> buffer) const {
     std::optional<int> res{module.second->cmpctblocks_parse(buffer)};
     if (!res.has_value() || *res == -2)
       continue;
+
+    LogResponse(module.first, *res);
 
     if (last_response.has_value()) {
       if (*res != *last_response) {

--- a/driver.h
+++ b/driver.h
@@ -4,7 +4,10 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <span>
+#include <string>
+#include <string_view>
 
 #include <bitcoinfuzz/basemodule.h>
 #include <bitcoinfuzz/modulelogger.h>
@@ -14,9 +17,20 @@ class Driver {
 private:
   ModuleLogger &module_logger;
   std::map<std::string, std::shared_ptr<BaseModule>> modules;
+  bool log_outputs;
+
+  template <typename T>
+  void LogResponse(const std::string &module_name, const T &response) const;
+
+  template <typename T>
+  void VerifyMatchingResponse(std::optional<T> &last_response,
+                              std::string &last_module_name,
+                              const std::string &module_name, const T &response,
+                              std::string_view failure_message) const;
 
 public:
-  Driver(ModuleLogger &logger) : module_logger(logger) {}
+  Driver(ModuleLogger &logger, bool log_outputs = false)
+      : module_logger(logger), log_outputs(log_outputs) {}
   void LoadModule(std::shared_ptr<BaseModule> module);
   void ScriptTarget(std::span<const uint8_t>) const;
   void ScriptEvalTarget(std::span<const uint8_t> buffer) const;

--- a/main.cpp
+++ b/main.cpp
@@ -13,7 +13,11 @@ extern "C" int LLVMFuzzerInitialize([[maybe_unused]] int *argc,
     std::exit(1);
   }
   g_target = target;
-  driver = std::make_shared<bitcoinfuzz::Driver>(module_logger);
+  const char *log_outputs_env = std::getenv("LOG_OUTPUTS");
+  const bool log_outputs = log_outputs_env != nullptr &&
+                           log_outputs_env[0] != '\0' &&
+                           std::string_view(log_outputs_env) != "0";
+  driver = std::make_shared<bitcoinfuzz::Driver>(module_logger, log_outputs);
   bitcoinfuzz::LoadModules(driver, module_logger);
   return 0;
 }


### PR DESCRIPTION
When set, each accepted module response is printed as "Module: X / Result: Y" alongside the existing mismatch reporting. Useful for debugging replays where you want to see what every module returned for a given input.

The flag is read once in LLVMFuzzerInitialize (alongside FUZZ) and plumbed through the Driver constructor. LogResponse and VerifyMatchingResponse are private member templates so call sites don't need to thread the flag around.