### PR TITLE
feat: add NBitcoin to bip32_derive_from_path target

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -245,7 +245,7 @@ jobs:
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "bip32_derive_from_path"
             target: "bip32_derive_from_path"
-            cxxflags: "-DRUST_BITCOIN -DBITCOIN_CORE"
+            cxxflags: "-DRUST_BITCOIN -DBITCOIN_CORE -DNBITCOIN"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
     steps:
       - name: Checkout repo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -424,7 +424,7 @@ services:
       tags:
         - bitcoinfuzz:bip32_derive_from_path
       args:
-        CXXFLAGS: "-DRUST_BITCOIN -DBITCOIN_CORE"
+        CXXFLAGS: "-DRUST_BITCOIN -DBITCOIN_CORE -DNBITCOIN"
         FUZZ: bip32_derive_from_path
     environment:
       MODULES: ${MODULES:-}

--- a/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
+++ b/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
@@ -309,6 +309,121 @@ public static class Bridge
         }
     }
 
+    [UnmanagedCallersOnly(EntryPoint = "nbitcoin_bip32_derive_from_path")]
+    public static IntPtr BIP32DeriveFromPath(IntPtr dataPtr, UIntPtr len)
+    {
+        var data = new byte[(int)len];
+        Marshal.Copy(dataPtr, data, 0, (int)len);
+
+        string pathStr;
+        try
+        {
+            pathStr = Encoding.UTF8.GetString(data);
+        }
+        catch
+        {
+            return Marshal.StringToCoTaskMemUTF8("INVALID");
+        }
+
+        //filtering to overcome path parsing inconsistencies between modules
+        if (!IsValidPathString(pathStr))
+            return IntPtr.Zero;
+
+        if (!IsValidIndexes(pathStr))
+            return IntPtr.Zero;
+
+        KeyPath path;
+        try
+        {
+            path = KeyPath.Parse(pathStr);
+        }
+        catch
+        {
+            return Marshal.StringToCoTaskMemUTF8("INVALID");
+        }
+
+        if (path.Indexes.Length == 0)
+            return Marshal.StringToCoTaskMemUTF8("INVALID");
+
+        byte[] seed = new byte[32]
+        {
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+            0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+            0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+            0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20
+        };
+
+        try
+        {
+            var masterKey = ExtKey.CreateFromSeed(seed);
+            var derivedKey = masterKey.Derive(path);
+            return Marshal.StringToCoTaskMemUTF8(derivedKey.ToString(Network.Main));
+        }
+        catch
+        {
+            return Marshal.StringToCoTaskMemUTF8("INVALID");
+        }
+    }
+
+    private static bool IsValidPathString(string s)
+    {
+        if (string.IsNullOrEmpty(s))
+            return false;
+
+        if (s[0] == '/' || s[^1] == '/' || s.Contains("//"))
+            return false;
+
+        for (int i = 0; i < s.Length; i++)
+        {
+            char c = s[i];
+
+            if (c == '\0' ||
+                c == '+' ||
+                c == '-' ||
+                c == '\'' ||
+                c == 'h' ||
+                char.IsWhiteSpace(c))
+            {
+                return false;
+            }
+
+            if (c == 'm' && i != 0)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsValidIndexes(string s)
+    {
+        int start = 0;
+
+        while (start < s.Length)
+        {
+            int end = start;
+            while (end < s.Length && s[end] != '/')
+                end++;
+
+            var part = s.Substring(start, end - start);
+
+            if (part.Length > 0)
+            {
+                if (ulong.TryParse(part, out var val))
+                {
+                    if (val > 0x7FFFFFFF)
+                        return false;
+                }
+            }
+
+            if (end == s.Length)
+                break;
+
+            start = end + 1;
+        }
+
+        return true;
+    }
+
     [UnmanagedCallersOnly(EntryPoint = "nbitcoin_free_c_string")]
     public static void FreeString(IntPtr ptr)
     {

--- a/modules/nbitcoin/NBitcoin/nbitcoin_lib.h
+++ b/modules/nbitcoin/NBitcoin/nbitcoin_lib.h
@@ -23,4 +23,7 @@ extern "C" char *nbitcoin_bip32_deserialize_extended_key(const uint8_t *data,
 extern "C" char *nbitcoin_sign_schnorr(const uint8_t *privkey,
                                        const uint8_t *hash, const uint8_t *aux);
 
+extern "C" char *nbitcoin_bip32_derive_from_path(const uint8_t *data,
+                                                 size_t len);
+
 extern "C" void nbitcoin_free_c_string(void *ptr);

--- a/modules/nbitcoin/module.cpp
+++ b/modules/nbitcoin/module.cpp
@@ -63,5 +63,14 @@ NBitcoin::sign_schnorr(std::span<const uint8_t> buffer,
   nbitcoin_free_c_string(p);
   return s;
 }
+std::optional<std::string>
+NBitcoin::bip32_derive_from_path(std::span<const uint8_t> buffer) const {
+  char *p = nbitcoin_bip32_derive_from_path(buffer.data(), buffer.size());
+  if (!p)
+    return std::nullopt;
+  std::string s(p);
+  nbitcoin_free_c_string(p);
+  return s;
+}
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/nbitcoin/module.h
+++ b/modules/nbitcoin/module.h
@@ -27,6 +27,8 @@ public:
   std::optional<std::string>
   sign_schnorr(std::span<const uint8_t> buffer, std::span<const uint8_t> hash,
                std::span<const uint8_t> aux) const override;
+  std::optional<std::string>
+  bip32_derive_from_path(std::span<const uint8_t> buffer) const override;
   ~NBitcoin() noexcept override = default;
 };
 } // namespace module


### PR DESCRIPTION
Add `NBitcoin` module to `bip32_derive_from_path` target.
Fuzzing this target identified another difference in path parsing rules. `NBitcoin` [disregards](https://github.com/MetacoSA/NBitcoin/blob/587b124760a70018fb302573db40652f03ea42df/NBitcoin/BIP32/KeyPath.cs#L72) _all_ `m` segments in the path. 

e.g.: Path `m/1/m/1` is interpreted as `1/1`, but rejected in other modules.

Planning on pointing out all identified path parsing differences in the Bitcoin Core repository soon.