### PR TITLE
Fix: skip completely on 0-input/0-output PSBT match

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -232,14 +232,11 @@ void Driver::PSBTParseTarget(std::span<const uint8_t> buffer) const {
     if (!res.has_value())
       continue;
 
-#ifdef NBITCOIN
-    if (module.first == "NBitcoin" &&
-        ModuleRegistry::instance().isEnabled("NBITCOIN")) {
-      if (res->find("in=0") != std::string::npos ||
-          res->find("out=0") != std::string::npos)
-        continue;
-    }
-#endif
+    // Skip processing if the PSBT has 0 inputs or 0 outputs
+    // since different libraries handle this case differently
+    if (res->find("in=0") != std::string::npos ||
+        res->find("out=0") != std::string::npos)
+      return;
 
     LogResponse(module.first, *res);
 


### PR DESCRIPTION
# Title
Fix: skip completely on 0-input/0-output PSBT match

# Description
This PR resolves the test failures introduced after PR #533.

PR #533 changed an early `return` to a `continue` in `Driver::PSBTParseTarget` and scoped it to NBitcoin. However, the other libraries (like `rust-bitcoin`, `libwally`) also disagree on how to handle non-standard 0-input / 0-output PSBTs. 

Since these edge-case discrepancies are known and we do not want them blocking the fuzzing process (as discussed with  brunoerg), this PR:
1. Removes the `module.first == "NBitcoin"` restriction.
2. Reverts the logic to `return;` so that if *any* module encounters an `in=0` or `out=0` PSBT, the entire fuzz target gracefully exits. This guarantees no partial, mismatching comparisons are logged for this edge case.