### PR TITLE
doc: add trophies (BIP32 seed length validation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,3 +530,11 @@ LOG_OUTPUTS=1 FUZZ=address_parse ./bitcoinfuzz crash-xxxx
 - pycoin: https://github.com/richardkiss/pycoin/issues/437
 - embit: https://github.com/diybitcoinhardware/embit/issues/113
 - btcd: https://github.com/btcsuite/btcd/pull/2525
+- libwally-core: https://github.com/ElementsProject/libwally-core/issues/528
+- Bitcoin Core: https://github.com/bitcoin/bitcoin/issues/35308
+- embit: https://github.com/diybitcoinhardware/embit/issues/127
+- Bitcoin-S: https://github.com/bitcoin-s/bitcoin-s/issues/6350
+- NBitcoin: https://github.com/MetacoSA/NBitcoin/issues/1301
+- pycoin: https://github.com/richardkiss/pycoin/issues/438
+- rust-bitcoin: https://github.com/rust-bitcoin/rust-bitcoin/issues/6199
+- bitcoinj: https://github.com/bitcoinj/bitcoinj/pull/4210


### PR DESCRIPTION
I decided to open issues regarding the missing validation of seed bit-length [defined in BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki?plain=1#L148)  found in multiple modules. I first stumbled upon this back in [PR318](https://github.com/bitcoinfuzz/bitcoinfuzz/pull/318#issue-3604070571) and thought it might be nice to mention.

> Generate a seed byte sequence S of a chosen length (between 128 and 512 bits; 256 bits is advised) from a (P)RNG.

[BitcoinJ issue](https://github.com/bitcoinj/bitcoinj/issues/4209) turned into a [PR4210](https://github.com/bitcoinj/bitcoinj/pull/4210/) already.

