### PR TITLE
ci: run commit-by-commit build on push so it works on forks

### DIFF
--- a/.github/workflows/commit-by-commit-build.yml
+++ b/.github/workflows/commit-by-commit-build.yml
@@ -1,6 +1,9 @@
 name: Commit-by-Commit Build
 
 on:
+  push:
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:
@@ -21,12 +24,20 @@ jobs:
       - name: Get commits in PR
         id: get-commits
         run: |
-          # Get the base branch
-          git fetch origin ${{ github.base_ref }}
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Get the base branch
+            base_ref="${{ github.base_ref }}"
+            git fetch origin "$base_ref"
 
-          # Get all commits in the PR
-          git fetch origin pull/${{ github.event.number }}/head:pr-${{ github.event.number }}
-          commits=$(git rev-list --reverse origin/${{ github.base_ref }}..pr-${{ github.event.number }})
+            # Get all commits in the PR
+            git fetch origin pull/${{ github.event.number }}/head:pr-${{ github.event.number }}
+            commits=$(git rev-list --reverse "origin/$base_ref..pr-${{ github.event.number }}")
+          else
+            # push event (e.g. on a fork): diff against the default branch
+            base_ref="${{ github.event.repository.default_branch }}"
+            git fetch origin "$base_ref"
+            commits=$(git rev-list --reverse "origin/$base_ref..${{ github.sha }}")
+          fi
 
           # Count commits
           commit_count=$(echo "$commits" | wc -l)
@@ -64,7 +75,7 @@ jobs:
       - name: Checkout specific commit
         run: |
           # Ensure we have the full history including the base branch
-          git fetch origin ${{ github.base_ref }}
+          git fetch origin ${{ github.base_ref || github.event.repository.default_branch }}
           git checkout ${{ matrix.commit }}
           git submodule update --recursive
 


### PR DESCRIPTION
Fixes #448

The commit-by-commit workflow only triggered on pull_request, so it never ran on forks. Add a push trigger (matching the other workflows) and make the get-commits and build-commit steps fall back to the repo default branch when PR context is absent.