### PR TITLE
Fix broken ci build after libbitcoin integration

### DIFF
--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -36,14 +36,16 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install -y lowdown libsodium-dev
-
+        # libbitcoin-system requires CMake >= 3.30; Ubuntu 24.04 ships 3.28.3.
+        # pip provides a binary cmake that takes precedence on PATH.
+        python3 -m pip install --upgrade --break-system-packages 'cmake>=3.30'
+  
     - name: Install Boost 1.86 (required for libbitcoin-system targets)
       shell: bash
       run: |
         # Cache hit short-circuits this; Boost is installed to /opt/boost-1.86
         # so the bitcoinfuzz link step can resolve libbitcoin-system's Boost refs.
         if [ ! -f /opt/boost-1.86/lib/cmake/Boost-1.86.0/BoostConfig.cmake ]; then
-          python3 -m pip install --upgrade --break-system-packages 'cmake>=3.30'
           curl -sSL -o /tmp/boost.tar.gz \
             https://github.com/boostorg/boost/releases/download/boost-1.86.0/boost-1.86.0-cmake.tar.gz
           tar -xzf /tmp/boost.tar.gz -C /tmp
@@ -54,7 +56,7 @@ runs:
             -DCMAKE_INSTALL_PREFIX=/opt/boost-1.86 \
             -DBUILD_SHARED_LIBS=OFF \
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-            -DBOOST_INCLUDE_LIBRARIES="iostreams;locale;program_options;thread;url;test;regex;filesystem;system;date_time;chrono;atomic;random;container;charconv"
+            -DBOOST_INCLUDE_LIBRARIES="iostreams;locale;program_options;thread;url;test;regex;filesystem;system;date_time;chrono;atomic;random;container;charconv;json"
           cmake --build build --parallel "$(nproc)"
           sudo cmake --install build
         fi

--- a/.github/workflows/commit-by-commit-build.yml
+++ b/.github/workflows/commit-by-commit-build.yml
@@ -116,13 +116,20 @@ jobs:
           python-version: "3.11"
       - run: python -m pip install --upgrade pip
 
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lowdown libsodium-dev libboost-all-dev npm nodejs quickjs libquickjs
+          # libbitcoin-system requires CMake >= 3.30; Ubuntu 24.04 ships 3.28.3.
+          # pip provides a binary cmake that takes precedence on PATH.
+          python3 -m pip install --upgrade --break-system-packages 'cmake>=3.30'
+
       - name: Install Boost 1.86 (required for libbitcoin-system targets)
         shell: bash
         run: |
           # Cache hit short-circuits this; Boost is installed to /opt/boost-1.86
           # so the bitcoinfuzz link step can resolve libbitcoin-system's Boost refs.
           if [ ! -f /opt/boost-1.86/lib/cmake/Boost-1.86.0/BoostConfig.cmake ]; then
-            python3 -m pip install --upgrade --break-system-packages 'cmake>=3.30'
             curl -sSL -o /tmp/boost.tar.gz \
               https://github.com/boostorg/boost/releases/download/boost-1.86.0/boost-1.86.0-cmake.tar.gz
             tar -xzf /tmp/boost.tar.gz -C /tmp
@@ -133,16 +140,11 @@ jobs:
               -DCMAKE_INSTALL_PREFIX=/opt/boost-1.86 \
               -DBUILD_SHARED_LIBS=OFF \
               -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-              -DBOOST_INCLUDE_LIBRARIES="iostreams;locale;program_options;thread;url;test;regex;filesystem;system;date_time;chrono;atomic;random;container;charconv"
+              -DBOOST_INCLUDE_LIBRARIES="iostreams;locale;program_options;thread;url;test;regex;filesystem;system;date_time;chrono;atomic;random;container;charconv;json"
             cmake --build build --parallel "$(nproc)"
             sudo cmake --install build
           fi
           echo "BOOST_ROOT=/opt/boost-1.86" >> $GITHUB_ENV
-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y lowdown libsodium-dev libboost-all-dev npm nodejs quickjs libquickjs
 
       - name: Setup common environment
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -50,26 +50,30 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y lowdown libsodium-dev libboost-all-dev npm nodejs quickjs libquickjs cmake
+          sudo apt-get install -y lowdown libsodium-dev libboost-all-dev npm nodejs quickjs libquickjs
           # libbitcoin-system requires CMake >= 3.30; Ubuntu 24.04 ships 3.28.3.
           # pip provides a binary cmake that takes precedence on PATH.
           python3 -m pip install --upgrade --break-system-packages 'cmake>=3.30'
 
       - name: Install Boost 1.86 (libbitcoin-system requires >= 1.86)
         run: |
-          curl -sSL -o /tmp/boost.tar.gz \
-            https://github.com/boostorg/boost/releases/download/boost-1.86.0/boost-1.86.0-cmake.tar.gz
-          tar -xzf /tmp/boost.tar.gz -C /tmp
-          cd /tmp/boost-1.86.0
-          cmake -B build \
-            -DCMAKE_C_COMPILER=/usr/bin/clang \
-            -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
-            -DCMAKE_INSTALL_PREFIX=/opt/boost-1.86 \
-            -DBUILD_SHARED_LIBS=OFF \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-            -DBOOST_INCLUDE_LIBRARIES="iostreams;locale;program_options;thread;url;test;regex;filesystem;system;date_time;chrono;atomic;random;container;charconv"
-          cmake --build build --parallel "$(nproc)"
-          sudo cmake --install build
+          # Cache hit short-circuits this; Boost is installed to /opt/boost-1.86
+          # so the bitcoinfuzz link step can resolve libbitcoin-system's Boost refs.
+          if [ ! -f /opt/boost-1.86/lib/cmake/Boost-1.86.0/BoostConfig.cmake ]; then
+            curl -sSL -o /tmp/boost.tar.gz \
+              https://github.com/boostorg/boost/releases/download/boost-1.86.0/boost-1.86.0-cmake.tar.gz
+            tar -xzf /tmp/boost.tar.gz -C /tmp
+            cd /tmp/boost-1.86.0
+            cmake -B build \
+              -DCMAKE_C_COMPILER=/usr/bin/clang \
+              -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+              -DCMAKE_INSTALL_PREFIX=/opt/boost-1.86 \
+              -DBUILD_SHARED_LIBS=OFF \
+              -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+              -DBOOST_INCLUDE_LIBRARIES="iostreams;locale;program_options;thread;url;test;regex;filesystem;system;date_time;chrono;atomic;random;container;charconv;json"
+            cmake --build build --parallel "$(nproc)"
+            sudo cmake --install build
+          fi
           echo "BOOST_ROOT=/opt/boost-1.86" >> $GITHUB_ENV
 
       - name: Setup common environment


### PR DESCRIPTION
[Libbitcoin integration ](https://github.com/bitcoinfuzz/bitcoinfuzz/pull/575)introduced some problems during ci build that weren't caught due to `commit-by-commit` workflow not being run on PRs with a single commit. This PR aims to standardize `cmake` and `boost` installations across different workflows. Those changes include:

- Add 'json' to the BOOST_INCLUDE_LIBRARIES variable.
- move cmake installation to the 'Setup environment' step, instead of inside boost installation.
- move boost installation to always be executed after dependencies install.