### PR TITLE
feat: add kernel_block_check differential fuzz target

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -115,6 +115,7 @@ jobs:
           -DEMBIT \
           -DPYBITCOINKERNEL \
           -DBITCOINKERNEL \
+          -DBITCOINKERNEL_VARIANT \
           -DLND \
           -DLDK \
           -DNLIGHTNING \
@@ -198,6 +199,10 @@ jobs:
           - corpus: "kernel_transaction"
             target: "kernel_transaction"
             cxxflags: "-DPYBITCOINKERNEL -DRUSTBITCOINKERNEL -DBITCOINKERNEL"
+            asan_options: "detect_leaks=0:detect_container_overflow=0"
+          - corpus: "kernel_block_check"
+            target: "kernel_block_check"
+            cxxflags: "-DBITCOINKERNEL -DPYBITCOINKERNEL -DRUSTBITCOINKERNEL"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "cmpctblocks_parse"
             target: "cmpctblocks_parse"

--- a/auto_build.py
+++ b/auto_build.py
@@ -57,7 +57,13 @@ def get_module_dir(flag: str) -> str:
     return f"modules/{flag.lower().replace('_', '')}"
 
 def should_build_sequentially(flag: str) -> bool:
-    return flag in {"SECP256K1", "BITCOINJ", "LIGHTNING_KMP"} or flag.startswith(
+    return flag in {
+        "SECP256K1",
+        "BITCOINJ",
+        "LIGHTNING_KMP",
+        "BITCOINKERNEL",
+        "BITCOINKERNEL_VARIANT",
+    } or flag.startswith(
         "CUSTOM_MUTATOR_"
     )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,22 @@ services:
     volumes:
       - ./docker:/app/data
 
+  kernel_block_check:
+    build:
+      context: .
+      tags:
+        - bitcoinfuzz:kernel_block_check
+      args:
+        CXXFLAGS: "-DBITCOINKERNEL -DBITCOINKERNEL_VARIANT -DPYBITCOINKERNEL -DRUSTBITCOINKERNEL"
+        FUZZ: kernel_block_check
+    env_file: .env
+    environment:
+      MODULES: ${MODULES:-}
+      LIBFUZZ_DETECT_LEAKS: 0
+      ASAN_OPTIONS: detect_leaks=0
+    volumes:
+      - ./docker:/app/data
+
   cmpctblocks_parse:
     build:
       context: .

--- a/driver.cpp
+++ b/driver.cpp
@@ -439,6 +439,21 @@ void Driver::KernelTransactionTarget(std::span<const uint8_t> buffer) const {
   }
 }
 
+void Driver::KernelBlockCheckTarget(std::span<const uint8_t> buffer) const {
+  std::optional<std::string> last_response{std::nullopt};
+  std::string last_module_name;
+
+  for (auto &module : modules) {
+    std::optional<std::string> res{module.second->kernel_block_check(buffer)};
+    if (!res.has_value())
+      continue;
+
+    VerifyMatchingResponse(
+        last_response, last_module_name, module.first, *res,
+        "Block validation from libbitcoinkernel binding failed:");
+  }
+}
+
 void Driver::ParseLightningP2pMessageTarget(
     std::span<const uint8_t> buffer) const {
   std::optional<std::string> last_response{std::nullopt};
@@ -871,6 +886,8 @@ void Driver::Run(const uint8_t *data, const size_t size,
     this->KernelBlockTarget(buffer);
   } else if (target == "kernel_transaction") {
     this->KernelTransactionTarget(buffer);
+  } else if (target == "kernel_block_check") {
+    this->KernelBlockCheckTarget(buffer);
   } else if (target == "private_to_public_key") {
     this->PrivateToPublicKeyTarget(buffer);
   } else if (target == "sign_compact") {

--- a/driver.h
+++ b/driver.h
@@ -52,6 +52,7 @@ public:
   void Bip32MasterKeygenTarget(std::span<const uint8_t> buffer) const;
   void KernelBlockTarget(std::span<const uint8_t> buffer) const;
   void KernelTransactionTarget(std::span<const uint8_t> buffer) const;
+  void KernelBlockCheckTarget(std::span<const uint8_t> buffer) const;
   void PrivateToPublicKeyTarget(std::span<const uint8_t> buffer) const;
   void SignCompactTarget(std::span<const uint8_t> buffer) const;
   void SignDerTarget(std::span<const uint8_t> buffer) const;

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -49,6 +49,11 @@ BaseModule::kernel_transaction(std::span<const uint8_t> /*buffer*/) const {
 }
 
 std::optional<std::string>
+BaseModule::kernel_block_check(std::span<const uint8_t> /*buffer*/) const {
+  return std::nullopt;
+}
+
+std::optional<std::string>
 BaseModule::deserialize_invoice(std::string /*str*/) const {
   return std::nullopt;
 }

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -66,6 +66,8 @@ public:
   virtual std::optional<std::string>
   kernel_transaction(std::span<const uint8_t> buffer) const;
   virtual std::optional<std::string>
+  kernel_block_check(std::span<const uint8_t> buffer) const;
+  virtual std::optional<std::string>
   private_to_public_key(std::span<const uint8_t> buffer) const;
   virtual std::optional<std::string>
   sign_compact(std::span<const uint8_t> buffer,

--- a/modules/bitcoinkernel/module.cpp
+++ b/modules/bitcoinkernel/module.cpp
@@ -1,6 +1,9 @@
 #include "module.h"
 #include <kernel/bitcoinkernel_wrapper.h>
 
+#include <array>
+#include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <iomanip>
@@ -29,6 +32,40 @@ std::string hash_bytes_to_hex(const uint8_t *bytes, int length) {
   }
 
   return string_stream.str();
+}
+
+btck::ChainType decode_chain_type(uint8_t value) {
+  constexpr std::array chain_types{
+      btck::ChainType::MAINNET, btck::ChainType::TESTNET,
+      btck::ChainType::TESTNET_4, btck::ChainType::SIGNET,
+      btck::ChainType::REGTEST};
+  return chain_types[value % chain_types.size()];
+}
+
+std::string chain_type_to_string(btck::ChainType chain_type) {
+  switch (chain_type) {
+  case btck::ChainType::MAINNET:
+    return "mainnet";
+  case btck::ChainType::TESTNET:
+    return "testnet";
+  case btck::ChainType::TESTNET_4:
+    return "testnet4";
+  case btck::ChainType::SIGNET:
+    return "signet";
+  case btck::ChainType::REGTEST:
+    return "regtest";
+  }
+
+  assert(false);
+}
+
+btck::BlockCheckFlags decode_block_check_flags(uint8_t value) {
+  auto flags = btck::BlockCheckFlags::BASE;
+  if ((value & 0x01) != 0)
+    flags |= btck::BlockCheckFlags::POW;
+  if ((value & 0x02) != 0)
+    flags |= btck::BlockCheckFlags::MERKLE;
+  return flags;
 }
 
 char *libbitcoinkernel_transaction(std::span<const uint8_t> buffer) {
@@ -99,6 +136,50 @@ char *libbitcoinkernel_block(std::span<const uint8_t> buffer) {
     return strdup("0");
   }
 }
+
+char *libbitcoinkernel_block_check(std::span<const uint8_t> buffer) {
+  const uint8_t chain_selector = buffer.size() > 0 ? buffer[0] : 0;
+  const uint8_t flag_selector = buffer.size() > 1 ? buffer[1] : 0;
+  const auto chain_type = decode_chain_type(chain_selector);
+  const auto flags = decode_block_check_flags(flag_selector);
+  const auto raw_block = buffer.subspan(
+      buffer.size() > 2 ? static_cast<size_t>(2) : buffer.size());
+
+  std::string result = "chain=";
+  result.append(chain_type_to_string(chain_type));
+  result.append(";flags=");
+  result.append(std::to_string(flag_selector & 0x03));
+  result.push_back(';');
+
+  try {
+    btck::ChainParams chain_params{chain_type};
+    std::span<const std::byte> raw_span{(const std::byte *)raw_block.data(),
+                                        raw_block.size()};
+    btck::Block block{raw_span};
+    btck::BlockValidationState state{};
+    const bool ok =
+        block.Check(chain_params.GetConsensusParams(), flags, state);
+
+    result.append("ok=");
+    result.append(ok ? "1" : "0");
+    result.append(";mode=");
+    result.append(std::to_string(static_cast<int>(state.GetValidationMode())));
+    result.append(";result=");
+    result.append(
+        std::to_string(static_cast<int>(state.GetBlockValidationResult())));
+    result.append(";hash=");
+    const auto block_hash_bytes = block.GetHash().ToBytes();
+    result.append(hash_bytes_to_hex((const uint8_t *)block_hash_bytes.data(),
+                                    static_cast<int>(block_hash_bytes.size())));
+    result.append(";txs=");
+    result.append(std::to_string(block.CountTransactions()));
+    result.push_back(';');
+    return strdup(result.c_str());
+  } catch (...) {
+    result.append("err=exception;");
+    return strdup(result.c_str());
+  }
+}
 } // namespace
 
 namespace bitcoinfuzz {
@@ -119,6 +200,17 @@ BitcoinKernel::kernel_transaction(std::span<const uint8_t> buffer) const {
 std::optional<std::string>
 BitcoinKernel::kernel_block(std::span<const uint8_t> buffer) const {
   auto result_ptr = libbitcoinkernel_block(buffer);
+  if (result_ptr == nullptr)
+    return std::nullopt;
+
+  std::string result(result_ptr);
+  free(result_ptr);
+  return result;
+}
+
+std::optional<std::string>
+BitcoinKernel::kernel_block_check(std::span<const uint8_t> buffer) const {
+  auto result_ptr = libbitcoinkernel_block_check(buffer);
   if (result_ptr == nullptr)
     return std::nullopt;
 

--- a/modules/bitcoinkernel/module.h
+++ b/modules/bitcoinkernel/module.h
@@ -10,6 +10,8 @@ public:
   kernel_block(std::span<const uint8_t> buffer) const override;
   std::optional<std::string>
   kernel_transaction(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  kernel_block_check(std::span<const uint8_t> buffer) const override;
   ~BitcoinKernel() noexcept override = default;
 };
 

--- a/modules/bitcoinkernelvariant/module.cpp
+++ b/modules/bitcoinkernelvariant/module.cpp
@@ -2,6 +2,9 @@
 #include "bitcoinkernel_variant_symbol_prefix.h"
 #include <kernel/bitcoinkernel_wrapper.h>
 
+#include <array>
+#include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <iomanip>
@@ -30,6 +33,40 @@ std::string hash_bytes_to_hex(const uint8_t *bytes, int length) {
   }
 
   return string_stream.str();
+}
+
+btck::ChainType decode_chain_type(uint8_t value) {
+  constexpr std::array chain_types{
+      btck::ChainType::MAINNET, btck::ChainType::TESTNET,
+      btck::ChainType::TESTNET_4, btck::ChainType::SIGNET,
+      btck::ChainType::REGTEST};
+  return chain_types[value % chain_types.size()];
+}
+
+std::string chain_type_to_string(btck::ChainType chain_type) {
+  switch (chain_type) {
+  case btck::ChainType::MAINNET:
+    return "mainnet";
+  case btck::ChainType::TESTNET:
+    return "testnet";
+  case btck::ChainType::TESTNET_4:
+    return "testnet4";
+  case btck::ChainType::SIGNET:
+    return "signet";
+  case btck::ChainType::REGTEST:
+    return "regtest";
+  }
+
+  assert(false);
+}
+
+btck::BlockCheckFlags decode_block_check_flags(uint8_t value) {
+  auto flags = btck::BlockCheckFlags::BASE;
+  if ((value & 0x01) != 0)
+    flags |= btck::BlockCheckFlags::POW;
+  if ((value & 0x02) != 0)
+    flags |= btck::BlockCheckFlags::MERKLE;
+  return flags;
 }
 
 char *libbitcoinkernel_transaction(std::span<const uint8_t> buffer) {
@@ -100,6 +137,50 @@ char *libbitcoinkernel_block(std::span<const uint8_t> buffer) {
     return strdup("0");
   }
 }
+
+char *libbitcoinkernel_block_check(std::span<const uint8_t> buffer) {
+  const uint8_t chain_selector = buffer.size() > 0 ? buffer[0] : 0;
+  const uint8_t flag_selector = buffer.size() > 1 ? buffer[1] : 0;
+  const auto chain_type = decode_chain_type(chain_selector);
+  const auto flags = decode_block_check_flags(flag_selector);
+  const auto raw_block = buffer.subspan(
+      buffer.size() > 2 ? static_cast<size_t>(2) : buffer.size());
+
+  std::string result = "chain=";
+  result.append(chain_type_to_string(chain_type));
+  result.append(";flags=");
+  result.append(std::to_string(flag_selector & 0x03));
+  result.push_back(';');
+
+  try {
+    btck::ChainParams chain_params{chain_type};
+    std::span<const std::byte> raw_span{(const std::byte *)raw_block.data(),
+                                        raw_block.size()};
+    btck::Block block{raw_span};
+    btck::BlockValidationState state{};
+    const bool ok =
+        block.Check(chain_params.GetConsensusParams(), flags, state);
+
+    result.append("ok=");
+    result.append(ok ? "1" : "0");
+    result.append(";mode=");
+    result.append(std::to_string(static_cast<int>(state.GetValidationMode())));
+    result.append(";result=");
+    result.append(
+        std::to_string(static_cast<int>(state.GetBlockValidationResult())));
+    result.append(";hash=");
+    const auto block_hash_bytes = block.GetHash().ToBytes();
+    result.append(hash_bytes_to_hex((const uint8_t *)block_hash_bytes.data(),
+                                    static_cast<int>(block_hash_bytes.size())));
+    result.append(";txs=");
+    result.append(std::to_string(block.CountTransactions()));
+    result.push_back(';');
+    return strdup(result.c_str());
+  } catch (...) {
+    result.append("err=exception;");
+    return strdup(result.c_str());
+  }
+}
 } // namespace
 
 namespace bitcoinfuzz {
@@ -121,6 +202,17 @@ std::optional<std::string> BitcoinKernelVariant::kernel_transaction(
 std::optional<std::string>
 BitcoinKernelVariant::kernel_block(std::span<const uint8_t> buffer) const {
   auto result_ptr = libbitcoinkernel_block(buffer);
+  if (result_ptr == nullptr)
+    return std::nullopt;
+
+  std::string result(result_ptr);
+  free(result_ptr);
+  return result;
+}
+
+std::optional<std::string> BitcoinKernelVariant::kernel_block_check(
+    std::span<const uint8_t> buffer) const {
+  auto result_ptr = libbitcoinkernel_block_check(buffer);
   if (result_ptr == nullptr)
     return std::nullopt;
 

--- a/modules/bitcoinkernelvariant/module.h
+++ b/modules/bitcoinkernelvariant/module.h
@@ -10,6 +10,8 @@ public:
   kernel_block(std::span<const uint8_t> buffer) const override;
   std::optional<std::string>
   kernel_transaction(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  kernel_block_check(std::span<const uint8_t> buffer) const override;
   ~BitcoinKernelVariant() noexcept override = default;
 };
 

--- a/modules/pybitcoinkernel/module.cpp
+++ b/modules/pybitcoinkernel/module.cpp
@@ -122,6 +122,11 @@ char *transaction_parse(const uint8_t *data, size_t len) {
       data, len, "transaction_parse", create_bytes_object, convert_to_string);
 }
 
+char *block_check(const uint8_t *data, size_t len) {
+  return call_python_function<const uint8_t *, char *>(
+      data, len, "block_check", create_bytes_object, convert_to_string);
+}
+
 namespace bitcoinfuzz {
 namespace module {
 Pybitcoinkernel::Pybitcoinkernel(void) : BaseModule("Pybitcoinkernel") {}
@@ -140,6 +145,17 @@ Pybitcoinkernel::kernel_transaction(std::span<const uint8_t> buffer) const {
 std::optional<std::string>
 Pybitcoinkernel::kernel_block(std::span<const uint8_t> buffer) const {
   auto result_ptr = block_parse(buffer.data(), buffer.size());
+  if (result_ptr == nullptr)
+    return std::nullopt;
+
+  std::string result(result_ptr);
+  free(result_ptr);
+  return result;
+}
+
+std::optional<std::string>
+Pybitcoinkernel::kernel_block_check(std::span<const uint8_t> buffer) const {
+  auto result_ptr = block_check(buffer.data(), buffer.size());
   if (result_ptr == nullptr)
     return std::nullopt;
 

--- a/modules/pybitcoinkernel/module.h
+++ b/modules/pybitcoinkernel/module.h
@@ -14,6 +14,8 @@ public:
   kernel_block(std::span<const uint8_t> buffer) const override;
   std::optional<std::string>
   kernel_transaction(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  kernel_block_check(std::span<const uint8_t> buffer) const override;
   ~Pybitcoinkernel() noexcept override = default;
 };
 

--- a/modules/pybitcoinkernel/pybitcoinkernel_lib.py
+++ b/modules/pybitcoinkernel/pybitcoinkernel_lib.py
@@ -1,5 +1,21 @@
 import pbk
 
+_CHAIN_TYPES = [
+    pbk.ChainType.MAINNET,
+    pbk.ChainType.TESTNET,
+    pbk.ChainType.TESTNET_4,
+    pbk.ChainType.SIGNET,
+    pbk.ChainType.REGTEST,
+]
+
+_CHAIN_TYPE_NAMES = {
+    pbk.ChainType.MAINNET: "mainnet",
+    pbk.ChainType.TESTNET: "testnet",
+    pbk.ChainType.TESTNET_4: "testnet4",
+    pbk.ChainType.SIGNET: "signet",
+    pbk.ChainType.REGTEST: "regtest",
+}
+
 
 def transaction_parse(data: bytes):
     try:
@@ -25,3 +41,35 @@ def block_parse(data: bytes):
         return res
     except Exception as _:
         return "0"
+
+
+def block_check(data: bytes):
+    chain_selector = data[0] if len(data) > 0 else 0
+    flag_selector = data[1] if len(data) > 1 else 0
+    raw_block = data[2:] if len(data) > 2 else b""
+
+    chain_type = _CHAIN_TYPES[chain_selector % len(_CHAIN_TYPES)]
+
+    flags = pbk.BlockCheckFlags.BASE
+    if flag_selector & 0x01:
+        flags |= pbk.BlockCheckFlags.POW
+    if flag_selector & 0x02:
+        flags |= pbk.BlockCheckFlags.MERKLE
+
+    res = f"chain={_CHAIN_TYPE_NAMES[chain_type]};flags={flag_selector & 0x03};"
+
+    try:
+        block = pbk.Block(raw_block)
+        consensus_params = pbk.ChainParameters(chain_type).consensus_params
+        state = block.check(consensus_params, flags)
+        ok = state.validation_mode == pbk.ValidationMode.VALID
+        res += f"ok={1 if ok else 0}"
+        res += f";mode={int(state.validation_mode)}"
+        res += f";result={int(state.block_validation_result)}"
+        res += f";hash={str(block.block_hash)}"
+        res += f";txs={len(block.transactions)}"
+        res += ";"
+        return res
+    except Exception as _:
+        res += "err=exception;"
+        return res

--- a/modules/rustbitcoinkernel/module.cpp
+++ b/modules/rustbitcoinkernel/module.cpp
@@ -28,5 +28,16 @@ Rustbitcoinkernel::kernel_block(std::span<const uint8_t> buffer) const {
   kernel_free_c_string(result_ptr);
   return result;
 }
+
+std::optional<std::string>
+Rustbitcoinkernel::kernel_block_check(std::span<const uint8_t> buffer) const {
+  auto result_ptr = rustbitcoinkernel_block_check(buffer.data(), buffer.size());
+  if (result_ptr == nullptr)
+    return std::nullopt;
+
+  std::string result(result_ptr);
+  kernel_free_c_string(result_ptr);
+  return result;
+}
 } // namespace module
 } // namespace bitcoinfuzz

--- a/modules/rustbitcoinkernel/module.h
+++ b/modules/rustbitcoinkernel/module.h
@@ -15,6 +15,8 @@ public:
   kernel_block(std::span<const uint8_t> buffer) const override;
   std::optional<std::string>
   kernel_transaction(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
+  kernel_block_check(std::span<const uint8_t> buffer) const override;
   ~Rustbitcoinkernel() noexcept override = default;
 };
 

--- a/modules/rustbitcoinkernel/rustbitcoinkernel_lib/rustbitcoinkernel_lib.h
+++ b/modules/rustbitcoinkernel/rustbitcoinkernel_lib/rustbitcoinkernel_lib.h
@@ -2,4 +2,5 @@
 
 extern "C" char *rustbitcoinkernel_block(const uint8_t *data, size_t len);
 extern "C" char *rustbitcoinkernel_transaction(const uint8_t *data, size_t len);
+extern "C" char *rustbitcoinkernel_block_check(const uint8_t *data, size_t len);
 extern "C" void kernel_free_c_string(char *ptr);

--- a/modules/rustbitcoinkernel/rustbitcoinkernel_lib/src/lib.rs
+++ b/modules/rustbitcoinkernel/rustbitcoinkernel_lib/src/lib.rs
@@ -1,10 +1,46 @@
 use bitcoinkernel::core::{ScriptPubkeyExt, TransactionExt, TxInExt, TxOutExt, TxOutPointExt};
-use bitcoinkernel::{Block, Transaction};
+use bitcoinkernel::prelude::BlockValidationStateExt;
+use bitcoinkernel::{
+    Block, BlockCheckFlags, BlockCheckResult, ChainParams, ChainType, Transaction,
+    BLOCK_CHECK_BASE, BLOCK_CHECK_MERKLE, BLOCK_CHECK_POW,
+};
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::slice;
 
 extern crate bitcoinkernel;
+
+fn decode_chain_type(value: u8) -> ChainType {
+    const CHAIN_TYPES: [ChainType; 5] = [
+        ChainType::Mainnet,
+        ChainType::Testnet,
+        ChainType::Testnet4,
+        ChainType::Signet,
+        ChainType::Regtest,
+    ];
+    CHAIN_TYPES[(value as usize) % CHAIN_TYPES.len()]
+}
+
+fn chain_type_to_str(chain_type: ChainType) -> &'static str {
+    match chain_type {
+        ChainType::Mainnet => "mainnet",
+        ChainType::Testnet => "testnet",
+        ChainType::Testnet4 => "testnet4",
+        ChainType::Signet => "signet",
+        ChainType::Regtest => "regtest",
+    }
+}
+
+fn decode_block_check_flags(value: u8) -> BlockCheckFlags {
+    let mut flags = BLOCK_CHECK_BASE;
+    if value & 0x01 != 0 {
+        flags |= BLOCK_CHECK_POW;
+    }
+    if value & 0x02 != 0 {
+        flags |= BLOCK_CHECK_MERKLE;
+    }
+    flags
+}
 
 unsafe fn str_to_c_string(input: &str) -> *mut c_char {
     CString::new(input).unwrap().into_raw()
@@ -68,6 +104,54 @@ pub unsafe extern "C" fn rustbitcoinkernel_block(data: *const u8, len: usize) ->
     for tx in block.transactions() {
         result.push_str(&format!("txid={};", tx.txid().to_string()));
     }
+
+    str_to_c_string(&result)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rustbitcoinkernel_block_check(data: *const u8, len: usize) -> *mut c_char {
+    // Safety: Ensure that the data pointer is valid for the given length
+    let data_slice = slice::from_raw_parts(data, len);
+    let chain_selector = data_slice.first().copied().unwrap_or(0);
+    let flag_selector = data_slice.get(1).copied().unwrap_or(0);
+    let chain_type = decode_chain_type(chain_selector);
+    let flags = decode_block_check_flags(flag_selector);
+    let raw_block = if data_slice.len() > 2 {
+        &data_slice[2..]
+    } else {
+        &[]
+    };
+
+    let mut result = String::new();
+    result.push_str("chain=");
+    result.push_str(chain_type_to_str(chain_type));
+    result.push_str(";flags=");
+    result.push_str(&(flag_selector & 0x03).to_string());
+    result.push(';');
+
+    let Ok(block) = Block::new(raw_block) else {
+        result.push_str("err=exception;");
+        return str_to_c_string(&result);
+    };
+
+    let chain_params = ChainParams::new(chain_type);
+    match block.check(&chain_params, flags) {
+        BlockCheckResult::Valid => {
+            result.push_str("ok=1;mode=0;result=0;");
+        }
+        BlockCheckResult::Invalid(state) => {
+            result.push_str("ok=0;mode=");
+            result.push_str(&(state.mode() as u8).to_string());
+            result.push_str(";result=");
+            result.push_str(&(state.result() as u32).to_string());
+            result.push(';');
+        }
+    }
+    result.push_str("hash=");
+    result.push_str(&block.hash().to_string());
+    result.push_str(";txs=");
+    result.push_str(&block.transaction_count().to_string());
+    result.push(';');
 
     str_to_c_string(&result)
 }


### PR DESCRIPTION
Runs btck::Block::Check (context-free block validation: size limits, coinbase structure, sigops, and optional PoW/merkle-root checks) across bitcoinkernel, bitcoinkernelvariant, rustbitcoinkernel, and pybitcoinkernel, comparing validation mode and result codes to catch consensus-logic divergence between bindings, not just parsing bugs.