### PR TITLE
fix: prefix module symbols to avoid ODR link collisions

### DIFF
--- a/modules/bitcoin/Makefile
+++ b/modules/bitcoin/Makefile
@@ -266,12 +266,21 @@ $(LEVELDB_LIB): $(LEVELDB_OBJS)
 	@mkdir -p $(dir $@)
 	$(AR) rcs $@ $(LEVELDB_OBJS)
 
-# Generate symbol redefine map for ONLY secp256k1 symbols (exclude ASAN/sanitizer symbols)
+# Generate symbol redefine map: prefix every global symbol defined in
+# libsecp256k1.a (not just secp256k1_*) so they don't collide with the
+# standalone secp256k1 module when both are linked together. This catches the
+# `__odr_asan_gen_*` ODR-detection symbols that ASAN auto-generates, which
+# would otherwise produce multiple-definition errors at the final link.
+# Same pattern as modules/libbitcoinsystem/Makefile.
 secp256k1_symbols.map: $(SECP256K1_LIB)
 	@echo "Generating comprehensive symbol map..."
-	@nm -g $(SECP256K1_LIB) | awk '{print $$3}' | grep '^secp256k1' | sort -u | while read sym; do \
+	@{ \
+		nm -g --defined-only $(SECP256K1_LIB) | awk '{print $$3}'; \
+		nm --defined-only $(SECP256K1_LIB) | awk '$$2 == "n" {print $$3}'; \
+	} | grep -Ev '^$$' | sort -u | while read sym; do \
 		echo "$$sym $(SYMBOL_PREFIX)_$$sym"; \
 	done > $@
+	@sort -u -o $@ $@
 	@echo "Generated $$(wc -l < $@) symbol mappings"
 
 .PHONY: compile_objects
@@ -299,19 +308,15 @@ module.a: $(SECP256K1_LIB) $(UNIVALUE_LIB) $(LEVELDB_LIB) secp256k1_symbols.map 
 	$(AR) rcs $@ module.o cleanse.o $(BITCOIN_OBJS)
 
 	mkdir -p tmp_obj
-	# Extract secp256k1 objects and rename ONLY secp256k1_* symbols
+	# Extract secp256k1 objects and rename symbols using the same
+	# comprehensive map applied to the Bitcoin objects above, so every
+	# defined symbol (including ASAN's __odr_asan_gen_* ODR-detection
+	# globals) is prefixed and can't collide with the standalone
+	# secp256k1 module.
 	cd tmp_obj && $(AR) x ../$(SECP256K1_LIB)
-	@echo "Renaming only secp256k1_* symbols (preserving ASAN/sanitizer symbols)..."
+	@echo "Renaming secp256k1 symbols (including ASAN ODR globals)..."
 	cd tmp_obj && for obj in *.o; do \
-		for sym in $$(nm $$obj | grep ' T secp256k1' | awk '{print $$3}'); do \
-			$(OBJCOPY) --redefine-sym $$sym=$(SYMBOL_PREFIX)_$$sym $$obj 2>/dev/null || true; \
-		done; \
-		for sym in $$(nm $$obj | grep ' D secp256k1' | awk '{print $$3}'); do \
-			$(OBJCOPY) --redefine-sym $$sym=$(SYMBOL_PREFIX)_$$sym $$obj 2>/dev/null || true; \
-		done; \
-		for sym in $$(nm $$obj | grep ' B secp256k1' | awk '{print $$3}'); do \
-			$(OBJCOPY) --redefine-sym $$sym=$(SYMBOL_PREFIX)_$$sym $$obj 2>/dev/null || true; \
-		done; \
+		$(OBJCOPY) --redefine-syms=../secp256k1_symbols.map $$obj; \
 	done
 	$(AR) rcs $@ tmp_obj/*.o
 	rm -rf tmp_obj/*

--- a/modules/bitcoinkernel/Makefile
+++ b/modules/bitcoinkernel/Makefile
@@ -7,6 +7,14 @@ BITCOIN_URL := https://github.com/bitcoin/bitcoin.git
 KERNEL_BUILD_DIR := $(BITCOIN_DIR)/build-kernel
 KERNEL_LIB := $(KERNEL_BUILD_DIR)/lib/libbitcoinkernel.a
 
+SYMBOL_PREFIX ?= bitcoinkernel
+
+# Detect objcopy command
+OBJCOPY := $(shell command -v objcopy 2> /dev/null)
+ifeq ($(OBJCOPY),)
+$(error objcopy not found. Install with: apt-get install binutils)
+endif
+
 # Resolve Version Reference
 DEFAULT_REF:= master
 BITCOINKERNEL_REF ?=
@@ -15,8 +23,28 @@ $(warning BITCOINKERNEL_REF not set. Defaulting to $(DEFAULT_REF).)
 BITCOINKERNEL_REF := $(DEFAULT_REF)
 endif
 
-module.a: $(KERNEL_LIB) module.o
-	bash ../../merge.sh module.a $(KERNEL_LIB) module.o
+# libbitcoinkernel bundles a full copy of Bitcoin Core's consensus/validation
+# code (validation.cpp, secp256k1, ...) as plain, non-weak symbols. Other
+# modules (e.g. modules/bitcoin) embed their own copy of the same code, so
+# linking both into one binary causes multiple-definition errors. Prefix
+# every symbol in the kernel library so it can't collide. Same pattern as
+# modules/bitcoinkernelvariant/Makefile.
+bitcoinkernel_symbols.map: $(KERNEL_LIB)
+	@echo "Generating symbol map for $(SYMBOL_PREFIX)..."
+	@{ \
+		nm -g --defined-only $(KERNEL_LIB) | awk '{print $$3}'; \
+		nm --defined-only $(KERNEL_LIB) | awk '$$2 == "n" {print $$3}'; \
+	} | grep -Ev '^$$' | sort -u | while read sym; do \
+		echo "$$sym $(SYMBOL_PREFIX)_$$sym"; \
+	done > $@
+	@sort -u -o $@ $@
+	@echo "Generated $$(wc -l < $@) symbol mappings"
+
+module.a: $(KERNEL_LIB) bitcoinkernel_symbols.map module.o
+	bash ../../merge.sh module_temp.a $(KERNEL_LIB) module.o
+	$(OBJCOPY) --redefine-syms=bitcoinkernel_symbols.map module_temp.a module.a
+	rm -f module_temp.a
+	ranlib module.a
 
 $(KERNEL_LIB): bitcoin-sync
 	cd $(BITCOIN_DIR) && \
@@ -71,6 +99,6 @@ check-format:
 	clang-format -Werror --fail-on-incomplete-format -n module.h module.cpp
 
 clean:
-	rm -rf *.o module.a bitcoin/build-kernel
+	rm -rf *.o module.a module_temp.a bitcoinkernel_symbols.map bitcoin/build-kernel
 
 .PHONY: all format check-format clean bitcoin-sync

--- a/modules/rustbitcoinkernel/Makefile
+++ b/modules/rustbitcoinkernel/Makefile
@@ -3,6 +3,19 @@ all: module.a
 CXXFLAGS += -Wall -Wextra -fsanitize=address,fuzzer-no-link -std=c++20 -I ../../include
 RUST_LIB_PATH := ./rustbitcoinkernel_lib/target/release/librustbitcoinkernel_lib.a
 
+SYMBOL_PREFIX ?= rustbitcoinkernel
+
+# extern "C" functions module.cpp calls directly across the FFI boundary
+# (declared in rustbitcoinkernel_lib.h); these must keep their original
+# names, everything else in the archive gets prefixed.
+FFI_EXPORTS := rustbitcoinkernel_block rustbitcoinkernel_transaction rustbitcoinkernel_block_check kernel_free_c_string
+
+# Detect objcopy command
+OBJCOPY := $(shell command -v objcopy 2> /dev/null)
+ifeq ($(OBJCOPY),)
+$(error objcopy not found. Install with: apt-get install binutils)
+endif
+
 $(RUST_LIB_PATH):
 	cd rustbitcoinkernel_lib && \
 	CFLAGS="-fsanitize=address,fuzzer-no-link -ftrivial-auto-var-init=pattern" \
@@ -20,8 +33,30 @@ $(RUST_LIB_PATH):
 
 cargo: $(RUST_LIB_PATH)
 
-module.a: module.o $(RUST_LIB_PATH)
-	bash ../../merge.sh module.a $(RUST_LIB_PATH) module.o
+# The Rust crate statically bundles a full copy of libbitcoinkernel (secp256k1
+# included), which defines plain, non-weak globals like G_TRANSLATION_FUN.
+# When this module is linked alongside other modules that embed their own
+# copy of the same Bitcoin Core code (bitcoin, secp256k1, bitcoinkernel, ...),
+# those definitions collide at link time. Prefix every symbol in the archive
+# except the FFI boundary module.cpp calls, same pattern as
+# modules/bitcoinkernelvariant/Makefile.
+rustbitcoinkernel_symbols.map: $(RUST_LIB_PATH)
+	@echo "Generating symbol map for $(SYMBOL_PREFIX)..."
+	@{ \
+		nm -g --defined-only $(RUST_LIB_PATH) | awk '{print $$3}'; \
+		nm --defined-only $(RUST_LIB_PATH) | awk '$$2 == "n" {print $$3}'; \
+	} | grep -Ev '^$$' | sort -u | while read sym; do \
+		skip=0; \
+		for f in $(FFI_EXPORTS); do [ "$$sym" = "$$f" ] && skip=1 && break; done; \
+		[ "$$skip" -eq 0 ] && echo "$$sym $(SYMBOL_PREFIX)_$$sym"; \
+	done > $@
+	@sort -u -o $@ $@
+	@echo "Generated $$(wc -l < $@) symbol mappings"
+
+module.a: module.o $(RUST_LIB_PATH) rustbitcoinkernel_symbols.map
+	bash ../../merge.sh module_temp.a $(RUST_LIB_PATH) module.o
+	$(OBJCOPY) --redefine-syms=rustbitcoinkernel_symbols.map module_temp.a module.a
+	rm -f module_temp.a
 	ranlib module.a
 
 module.o: module.cpp module.h
@@ -36,7 +71,7 @@ check-format:
 	cd rustbitcoinkernel_lib && cargo fmt --check
 
 clean:
-	rm -rf *.o module.a
+	rm -rf *.o module.a module_temp.a rustbitcoinkernel_symbols.map
 	cd rustbitcoinkernel_lib && cargo clean
 
 .PHONY: all cargo clean format check-format $(RUST_LIB_PATH)


### PR DESCRIPTION
## Summary
- `modules/bitcoin`, `modules/rustbitcoinkernel`, and `modules/bitcoinkernel` each vendor a full copy of overlapping Bitcoin Core code (secp256k1, libbitcoinkernel, validation.cpp, etc.) as ordinary strong symbols.
- When two or more of these modules are combined in the same build (e.g. by `.github/scripts/select-cxxflags.sh`, which unions CXXFLAGS for every `modules/*` directory touched in a PR diff), linking failed with `multiple definition of` errors — first on ASAN's `__odr_asan_gen_*` ODR-detection globals, then on `G_TRANSLATION_FUN`, then on plain Bitcoin Core functions like `CheckFinalTxAtTip` and `Chainstate::FlushStateToDisk`.
- Extends the existing `objcopy --redefine-syms` symbol-prefixing pattern (already used by `modules/libbitcoinsystem` and `modules/bitcoinkernelvariant`) to `modules/bitcoin`, `modules/rustbitcoinkernel`, and `modules/bitcoinkernel`, so every module's vendored copy of shared code gets a unique prefix and can no longer collide with another module's copy.

## Test plan
- [x] Rebuilt `modules/bitcoin/module.a` and confirmed zero strong-symbol collisions against `modules/secp256k1/module.a`.
- [x] Rebuilt `modules/rustbitcoinkernel/module.a` and confirmed the FFI boundary (`rustbitcoinkernel_block`, `rustbitcoinkernel_transaction`, `rustbitcoinkernel_block_check`, `kernel_free_c_string`) is untouched while `G_TRANSLATION_FUN` is now prefixed, with zero collisions against `modules/bitcoin/module.a`.
- [x] Validated the `modules/bitcoinkernel` symbol-map/rename logic against an already-compiled `libbitcoinkernel.a` (same underlying content), confirming `CheckFinalTxAtTip`, `Chainstate::FlushStateToDisk`, and all `btck_*` API symbols rename consistently with zero collisions against `modules/bitcoin/module.a`.
- [x] Original branch (`2026-07-kernel`) that surfaced these errors is now green in CI with these same fixes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)